### PR TITLE
fix(sse): emit ticket.sprint_changed event for sprint assignment changes

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -12,6 +12,7 @@ export type TicketEventType =
   | 'ticket.updated'
   | 'ticket.deleted'
   | 'ticket.moved'
+  | 'ticket.sprint_changed'
 
 /**
  * Event types for project operations


### PR DESCRIPTION
## Summary
- Adds `ticket.sprint_changed` event type to SSE system
- Detects when ticket's sprintId changes in PATCH handler
- Emits specific `ticket.sprint_changed` event instead of generic `ticket.updated`

Fixes PUNT-13: Other clients now properly update when tickets are added/removed from sprints via context menu.

## Test plan
- [x] Open app in two browser tabs
- [x] Use context menu to add a ticket to a sprint
- [x] Verify the other tab updates in real-time
- [x] Use context menu to remove ticket from sprint
- [x] Verify the other tab updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)