### PR TITLE
fix(profile): restore vertical scroll on profile page

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -12,7 +12,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
         <main className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex-1 min-h-0">{children}</div>
+          <div className="flex-1 min-h-0 overflow-auto">{children}</div>
           <Footer />
         </main>
       </div>


### PR DESCRIPTION
## Summary
- Fix vertical scroll not working on /profile page
- Added `overflow-auto` to the content wrapper in the app layout

## Test plan
- [x] Navigate to /profile page
- [x] Verify page scrolls vertically when content overflows
- [x] Verify no regression on other pages

PUNT-33

🤖 Generated with [Claude Code](https://claude.ai/code)