### PR TITLE
feat(tickets): support backtick code formatting in ticket titles

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -5,6 +5,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { format, isPast, isToday } from 'date-fns'
 import { Calendar, GripVertical, MessageSquare, Paperclip, User } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { InlineCodeText } from '@/components/common/inline-code'
 import { PriorityBadge } from '@/components/common/priority-badge'
 import { TypeBadge } from '@/components/common/type-badge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -126,7 +127,9 @@ export function KanbanCard({
           </div>
 
           {/* Title */}
-          <h4 className="text-sm font-medium text-zinc-200 mb-2 line-clamp-2">{ticket.title}</h4>
+          <h4 className="text-sm font-medium text-zinc-200 mb-2 line-clamp-2">
+            <InlineCodeText text={ticket.title} />
+          </h4>
 
           {/* Labels */}
           {ticket.labels.length > 0 && (

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export { EmptyState } from './empty-state'
+export { InlineCodeText } from './inline-code'
 export { PriorityBadge } from './priority-badge'
 export { TypeBadge } from './type-badge'

--- a/src/components/common/inline-code.tsx
+++ b/src/components/common/inline-code.tsx
@@ -1,0 +1,92 @@
+interface InlineCodeTextProps {
+  text: string
+  className?: string
+}
+
+/**
+ * Renders text with backtick-wrapped segments styled as inline code.
+ * Example: "Fix bug in `calculateTotal` function" renders with monospace styling for `calculateTotal`.
+ */
+export function InlineCodeText({ text, className }: InlineCodeTextProps) {
+  // Parse text to find backtick-wrapped segments
+  const parts = parseInlineCode(text)
+
+  if (parts.length === 1 && !parts[0].isCode) {
+    // No code segments, return plain text
+    return <span className={className}>{text}</span>
+  }
+
+  return (
+    <span className={className}>
+      {parts.map((part, index) =>
+        part.isCode ? (
+          <code
+            key={index}
+            className="rounded bg-zinc-800 px-1 py-0.5 font-mono text-[0.9em] text-amber-300"
+          >
+            {part.text}
+          </code>
+        ) : (
+          <span key={index}>{part.text}</span>
+        ),
+      )}
+    </span>
+  )
+}
+
+interface ParsedPart {
+  text: string
+  isCode: boolean
+}
+
+/**
+ * Parses text to identify backtick-wrapped code segments.
+ * Returns an array of parts, each marked as code or plain text.
+ */
+export function parseInlineCode(text: string): ParsedPart[] {
+  const parts: ParsedPart[] = []
+  let currentIndex = 0
+  let inCode = false
+  let segmentStart = 0
+
+  while (currentIndex < text.length) {
+    if (text[currentIndex] === '`') {
+      // Found a backtick
+      if (currentIndex > segmentStart) {
+        // Add the text before this backtick
+        parts.push({
+          text: text.slice(segmentStart, currentIndex),
+          isCode: inCode,
+        })
+      }
+      inCode = !inCode
+      segmentStart = currentIndex + 1
+    }
+    currentIndex++
+  }
+
+  // Add remaining text
+  if (segmentStart < text.length) {
+    parts.push({
+      text: text.slice(segmentStart),
+      isCode: inCode, // If still inCode, the backtick was never closed - treat as code anyway
+    })
+  }
+
+  // Handle edge case: if we end in code mode with no text after, we have an unclosed backtick
+  // In this case, the last segment should be treated as plain text with the backtick
+  if (inCode && parts.length > 0) {
+    const lastPart = parts[parts.length - 1]
+    if (lastPart.isCode) {
+      lastPart.isCode = false
+      lastPart.text = `\`${lastPart.text}`
+    }
+  }
+
+  // If no parts were created, return the original text
+  if (parts.length === 0) {
+    return [{ text, isCode: false }]
+  }
+
+  return parts
+}

--- a/src/components/sprints/sprint-ticket-row.tsx
+++ b/src/components/sprints/sprint-ticket-row.tsx
@@ -4,6 +4,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { format, isPast, isToday } from 'date-fns'
 import { Calendar, GripVertical, MessageSquare, Paperclip, Repeat } from 'lucide-react'
+import { InlineCodeText } from '@/components/common/inline-code'
 import { PriorityBadge } from '@/components/common/priority-badge'
 import { TypeBadge } from '@/components/common/type-badge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -115,7 +116,10 @@ export function SprintTicketRow({
       </span>
 
       {/* Title */}
-      <span className="flex-1 text-sm text-zinc-200 truncate min-w-0">{ticket.title}</span>
+      <InlineCodeText
+        text={ticket.title}
+        className="flex-1 text-sm text-zinc-200 truncate min-w-0"
+      />
 
       {/* Carryover indicator */}
       {ticket.isCarriedOver && (

--- a/src/components/table/ticket-cell.tsx
+++ b/src/components/table/ticket-cell.tsx
@@ -2,6 +2,7 @@
 
 import { format, isBefore, isToday } from 'date-fns'
 import { User } from 'lucide-react'
+import { InlineCodeText } from '@/components/common/inline-code'
 import { PriorityBadge } from '@/components/common/priority-badge'
 import { TypeBadge } from '@/components/common/type-badge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -29,7 +30,7 @@ export function TicketCell({ column, ticket, projectKey, getStatusName }: Ticket
     case 'title':
       return (
         <div className="flex items-center gap-2">
-          <span className="truncate font-medium">{ticket.title}</span>
+          <InlineCodeText text={ticket.title} className="truncate font-medium" />
           {ticket._count && ticket._count.subtasks > 0 && (
             <Badge variant="outline" className="shrink-0 text-xs">
               {ticket._count.subtasks} subtasks

--- a/src/components/tickets/ticket-detail-drawer.tsx
+++ b/src/components/tickets/ticket-detail-drawer.tsx
@@ -90,6 +90,7 @@ import type {
   UploadedFileInfo,
 } from '@/types'
 import { ISSUE_TYPES, PRIORITIES } from '@/types'
+import { InlineCodeText } from '../common/inline-code'
 import { PriorityBadge } from '../common/priority-badge'
 import { TypeBadge } from '../common/type-badge'
 import type { ParentTicketOption } from './create-ticket-dialog'
@@ -844,7 +845,7 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
                     className="text-xl font-semibold text-zinc-100 cursor-pointer hover:bg-amber-500/15 rounded px-2 py-1 -mx-2"
                     onClick={() => startEditing('title')}
                   >
-                    {ticket.title}
+                    <InlineCodeText text={ticket.title} />
                   </h2>
                 )}
               </div>
@@ -1238,7 +1239,10 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
                       <span className="font-mono text-zinc-500 shrink-0">
                         {projectKey}-{parentTicket.number}
                       </span>
-                      <span className="truncate text-zinc-300">{parentTicket.title}</span>
+                      <InlineCodeText
+                        text={parentTicket.title}
+                        className="truncate text-zinc-300"
+                      />
                       <Link2 className="h-3.5 w-3.5 text-zinc-500 ml-auto shrink-0" />
                     </div>
                   </Button>
@@ -1264,7 +1268,7 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
                           <span className="font-mono text-zinc-500 shrink-0">
                             {projectKey}-{child.number}
                           </span>
-                          <span className="truncate text-zinc-300">{child.title}</span>
+                          <InlineCodeText text={child.title} className="truncate text-zinc-300" />
                           <Link2 className="h-3.5 w-3.5 text-zinc-500 ml-auto shrink-0" />
                         </div>
                       </Button>


### PR DESCRIPTION
## Summary
- Support inline code formatting in ticket titles using backticks
- Text wrapped in backticks renders with monospace styling
- Works in Kanban cards, backlog table, and ticket drawer
- Created reusable FormattedTitle component

## Test plan
- [x] Create ticket with title containing \`backticks\`
- [x] Verify code styling appears in Kanban card
- [x] Verify code styling appears in backlog table
- [x] Verify code styling appears in ticket drawer
- [x] Backticks should not be visible in rendered output

PUNT-16

🤖 Generated with [Claude Code](https://claude.ai/code)