### PR TITLE
feat(profile): add customizable fallback avatar color

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   email       String?   @unique
   name        String
   avatar      String?
+  avatarColor String?   // Custom background color for fallback avatar
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
   lastLoginAt DateTime?

--- a/src/app/(app)/admin/users/[userId]/page.tsx
+++ b/src/app/(app)/admin/users/[userId]/page.tsx
@@ -488,7 +488,7 @@ export default function AdminUserProfilePage() {
               <AvatarImage src={user.avatar || undefined} alt={user.name} />
               <AvatarFallback
                 className="text-2xl font-semibold text-white"
-                style={{ backgroundColor: getAvatarColor(user.id) }}
+                style={{ backgroundColor: user.avatarColor || getAvatarColor(user.id) }}
               >
                 {getInitials(user.name)}
               </AvatarFallback>

--- a/src/components/admin/user-list.tsx
+++ b/src/components/admin/user-list.tsx
@@ -79,6 +79,7 @@ interface User {
   name: string
   email: string
   avatar: string | null
+  avatarColor: string | null
   isSystemAdmin: boolean
   isActive: boolean
   createdAt: string
@@ -827,7 +828,10 @@ export function UserList() {
             />
             <Avatar>
               <AvatarImage src={user.avatar || undefined} />
-              <AvatarFallback className="bg-zinc-700 text-zinc-300">
+              <AvatarFallback
+                className="text-white"
+                style={user.avatarColor ? { backgroundColor: user.avatarColor } : undefined}
+              >
                 {user.name.charAt(0).toUpperCase()}
               </AvatarFallback>
             </Avatar>

--- a/src/components/backlog/backlog-filters.tsx
+++ b/src/components/backlog/backlog-filters.tsx
@@ -774,7 +774,10 @@ export function BacklogFilters({ statusColumns: _statusColumns, projectId }: Bac
                         <AvatarImage src={user.avatar || undefined} />
                         <AvatarFallback
                           className="text-[10px] text-white font-medium"
-                          style={{ backgroundColor: getAvatarColor(user.id || user.name) }}
+                          style={{
+                            backgroundColor:
+                              user.avatarColor || getAvatarColor(user.id || user.name),
+                          }}
                         >
                           {getInitials(user.name)}
                         </AvatarFallback>

--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -211,7 +211,9 @@ export function KanbanCard({
                 <AvatarFallback
                   className="text-white text-[10px] font-medium"
                   style={{
-                    backgroundColor: getAvatarColor(ticket.assignee.id || ticket.assignee.name),
+                    backgroundColor:
+                      ticket.assignee.avatarColor ||
+                      getAvatarColor(ticket.assignee.id || ticket.assignee.name),
                   }}
                 >
                   {getInitials(ticket.assignee.name)}

--- a/src/components/board/ticket-context-menu.tsx
+++ b/src/components/board/ticket-context-menu.tsx
@@ -961,7 +961,10 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                           <Avatar className="h-5 w-5">
                             <AvatarFallback
                               className="text-[10px] text-white font-medium"
-                              style={{ backgroundColor: getAvatarColor(currentUser.id) }}
+                              style={{
+                                backgroundColor:
+                                  currentUser.avatarColor || getAvatarColor(currentUser.id),
+                              }}
                             >
                               {getInitials(currentUser.name)}
                             </AvatarFallback>
@@ -982,7 +985,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                           {m.avatar && <AvatarImage src={m.avatar} />}
                           <AvatarFallback
                             className="text-[10px] text-white font-medium"
-                            style={{ backgroundColor: getAvatarColor(m.id) }}
+                            style={{ backgroundColor: m.avatarColor || getAvatarColor(m.id) }}
                           >
                             {getInitials(m.name)}
                           </AvatarFallback>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -96,7 +96,11 @@ export function Header() {
                   <AvatarImage src={currentUser.avatar || undefined} alt={currentUser.name} />
                   <AvatarFallback
                     className="text-xs text-white font-medium"
-                    style={{ backgroundColor: getAvatarColor(currentUser.id || currentUser.name) }}
+                    style={{
+                      backgroundColor:
+                        currentUser.avatarColor ||
+                        getAvatarColor(currentUser.id || currentUser.name),
+                    }}
                   >
                     {getInitials(currentUser.name)}
                   </AvatarFallback>

--- a/src/components/projects/permissions/add-member-dialog.tsx
+++ b/src/components/projects/permissions/add-member-dialog.tsx
@@ -245,7 +245,8 @@ export function AddMemberDialog({ projectId, trigger }: AddMemberDialogProps) {
                                   <AvatarFallback
                                     className="text-[10px] text-white font-medium"
                                     style={{
-                                      backgroundColor: getAvatarColor(user.id || user.name),
+                                      backgroundColor:
+                                        user.avatarColor || getAvatarColor(user.id || user.name),
                                     }}
                                   >
                                     {user.name.slice(0, 2).toUpperCase()}
@@ -287,7 +288,9 @@ export function AddMemberDialog({ projectId, trigger }: AddMemberDialogProps) {
                         <AvatarFallback
                           className="text-xs text-white font-medium"
                           style={{
-                            backgroundColor: getAvatarColor(member.user.id || member.user.name),
+                            backgroundColor:
+                              member.user.avatarColor ||
+                              getAvatarColor(member.user.id || member.user.name),
                           }}
                         >
                           {member.user.name.slice(0, 2).toUpperCase()}

--- a/src/components/projects/permissions/members-tab.tsx
+++ b/src/components/projects/permissions/members-tab.tsx
@@ -814,7 +814,10 @@ function MemberCard({
             <AvatarImage src={member.user.avatar || undefined} alt={member.user.name} />
             <AvatarFallback
               className="text-white font-medium"
-              style={{ backgroundColor: getAvatarColor(member.user.id || member.user.name) }}
+              style={{
+                backgroundColor:
+                  member.user.avatarColor || getAvatarColor(member.user.id || member.user.name),
+              }}
             >
               {initials}
             </AvatarFallback>

--- a/src/components/projects/permissions/roles-tab.tsx
+++ b/src/components/projects/permissions/roles-tab.tsx
@@ -980,8 +980,11 @@ export function RolesTab({ projectId }: RolesTabProps) {
                                   <Avatar className="h-6 w-6">
                                     <AvatarImage src={user.avatar || undefined} alt={user.name} />
                                     <AvatarFallback
-                                      className="text-xs"
-                                      style={{ backgroundColor: getAvatarColor(user.id) }}
+                                      className="text-xs text-white"
+                                      style={{
+                                        backgroundColor:
+                                          user.avatarColor || getAvatarColor(user.id),
+                                      }}
                                     >
                                       {getInitials(user.name)}
                                     </AvatarFallback>
@@ -1055,11 +1058,11 @@ export function RolesTab({ projectId }: RolesTabProps) {
                                     alt={member.user.name}
                                   />
                                   <AvatarFallback
-                                    className="text-xs font-medium"
+                                    className="text-xs font-medium text-white"
                                     style={{
-                                      backgroundColor: getAvatarColor(
-                                        member.user.id || member.user.name,
-                                      ),
+                                      backgroundColor:
+                                        member.user.avatarColor ||
+                                        getAvatarColor(member.user.id || member.user.name),
                                     }}
                                   >
                                     {getInitials(member.user.name)}

--- a/src/components/sprints/sprint-ticket-row.tsx
+++ b/src/components/sprints/sprint-ticket-row.tsx
@@ -203,7 +203,12 @@ export function SprintTicketRow({
               <AvatarImage src={ticket.assignee.avatar} alt={ticket.assignee.name} />
             ) : null}
             <AvatarFallback
-              className={cn('text-[10px] font-medium', getAvatarColor(ticket.assignee.name))}
+              className="text-[10px] font-medium text-white"
+              style={{
+                backgroundColor:
+                  ticket.assignee.avatarColor ||
+                  getAvatarColor(ticket.assignee.id || ticket.assignee.name),
+              }}
             >
               {getInitials(ticket.assignee.name)}
             </AvatarFallback>

--- a/src/components/table/ticket-cell.tsx
+++ b/src/components/table/ticket-cell.tsx
@@ -60,7 +60,9 @@ export function TicketCell({ column, ticket, projectKey, getStatusName }: Ticket
             <AvatarFallback
               className="text-[10px] text-white font-medium"
               style={{
-                backgroundColor: getAvatarColor(ticket.assignee.id || ticket.assignee.name),
+                backgroundColor:
+                  ticket.assignee.avatarColor ||
+                  getAvatarColor(ticket.assignee.id || ticket.assignee.name),
               }}
             >
               {getInitials(ticket.assignee.name)}
@@ -87,7 +89,9 @@ export function TicketCell({ column, ticket, projectKey, getStatusName }: Ticket
             <AvatarFallback
               className="text-[10px] text-white font-medium"
               style={{
-                backgroundColor: getAvatarColor(ticket.creator.id || ticket.creator.name),
+                backgroundColor:
+                  ticket.creator?.avatarColor ||
+                  getAvatarColor(ticket.creator.id || ticket.creator.name),
               }}
             >
               {getInitials(ticket.creator.name)}

--- a/src/components/tickets/ticket-detail-drawer.tsx
+++ b/src/components/tickets/ticket-detail-drawer.tsx
@@ -1283,7 +1283,10 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
                         <AvatarImage src={watcher.avatar || undefined} />
                         <AvatarFallback
                           className="text-xs text-white font-medium"
-                          style={{ backgroundColor: getAvatarColor(watcher.id || watcher.name) }}
+                          style={{
+                            backgroundColor:
+                              watcher.avatarColor || getAvatarColor(watcher.id || watcher.name),
+                          }}
                         >
                           {getInitials(watcher.name)}
                         </AvatarFallback>

--- a/src/components/tickets/user-select.tsx
+++ b/src/components/tickets/user-select.tsx
@@ -69,7 +69,9 @@ export function UserSelect({
                   <AvatarFallback
                     className="text-xs text-white font-medium"
                     style={{
-                      backgroundColor: getAvatarColor(selectedUser.id || selectedUser.name),
+                      backgroundColor:
+                        selectedUser.avatarColor ||
+                        getAvatarColor(selectedUser.id || selectedUser.name),
                     }}
                   >
                     {getInitials(selectedUser.name)}
@@ -132,7 +134,9 @@ export function UserSelect({
                       <AvatarImage src={user.avatar || undefined} />
                       <AvatarFallback
                         className="text-xs text-white font-medium"
-                        style={{ backgroundColor: getAvatarColor(user.id || user.name) }}
+                        style={{
+                          backgroundColor: user.avatarColor || getAvatarColor(user.id || user.name),
+                        }}
                       >
                         {getInitials(user.name)}
                       </AvatarFallback>

--- a/src/hooks/use-current-user.ts
+++ b/src/hooks/use-current-user.ts
@@ -29,6 +29,7 @@ export function useCurrentUser(): UserSummary | null {
     name: session.user.name || 'Unknown',
     email: session.user.email || '',
     avatar: session.user.avatar || null,
+    avatarColor: session.user.avatarColor || null,
     isSystemAdmin: session.user.isSystemAdmin ?? false,
   }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -82,6 +82,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             email: true,
             name: true,
             avatar: true,
+            avatarColor: true,
             isSystemAdmin: true,
             isActive: true,
             passwordChangedAt: true,
@@ -113,6 +114,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         token.username = dbUser.username
         token.isSystemAdmin = dbUser.isSystemAdmin
         token.avatar = dbUser.avatar
+        token.avatarColor = dbUser.avatarColor
       }
 
       return token
@@ -130,6 +132,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         session.user.username = token.username as string
         session.user.isSystemAdmin = token.isSystemAdmin as boolean
         session.user.avatar = token.avatar as string | null
+        session.user.avatarColor = token.avatarColor as string | null
       }
 
       return session
@@ -148,6 +151,7 @@ declare module 'next-auth' {
       image?: string | null
       isSystemAdmin: boolean
       avatar: string | null
+      avatarColor: string | null
     }
   }
 
@@ -155,5 +159,6 @@ declare module 'next-auth' {
     username?: string
     isSystemAdmin?: boolean
     avatar?: string | null
+    avatarColor?: string | null
   }
 }

--- a/src/lib/prisma-selects.ts
+++ b/src/lib/prisma-selects.ts
@@ -11,6 +11,7 @@ export const USER_SELECT_SUMMARY = {
   name: true,
   email: true,
   avatar: true,
+  avatarColor: true,
 } as const
 
 /**
@@ -145,7 +146,13 @@ export const TICKET_SELECT_FULL = {
  * Type for the watcher relation as returned from Prisma.
  */
 export type TicketWatcher = {
-  user: { id: string; name: string; email: string | null; avatar: string | null }
+  user: {
+    id: string
+    name: string
+    email: string | null
+    avatar: string | null
+    avatarColor: string | null
+  }
 }
 
 /**
@@ -179,6 +186,7 @@ export const USER_SELECT_ADMIN_LIST = {
   email: true,
   name: true,
   avatar: true,
+  avatarColor: true,
   isSystemAdmin: true,
   isActive: true,
   createdAt: true,
@@ -196,6 +204,7 @@ export const USER_SELECT_CREATED = {
   email: true,
   name: true,
   avatar: true,
+  avatarColor: true,
   isSystemAdmin: true,
   isActive: true,
   createdAt: true,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,7 +6,7 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 // Avatar colors that work well with white text
-const AVATAR_COLORS = [
+export const AVATAR_COLORS = [
   '#dc2626', // red-600
   '#ea580c', // orange-600
   '#d97706', // amber-600

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -110,6 +110,7 @@ export interface UserSummary {
   name: string
   email: string
   avatar: string | null
+  avatarColor?: string | null
   isSystemAdmin?: boolean
 }
 


### PR DESCRIPTION
## Summary
- Allow users to customize fallback avatar background color
- Added avatarColor field to User model (with migration)
- Added color picker to profile settings
- Color applied consistently across all avatar instances

## Test plan
- [x] Go to profile settings (without uploaded avatar)
- [x] Verify color picker appears
- [x] Select a color from palette
- [x] Verify avatar color updates in header, sidebar, and other locations
- [x] Verify color persists after page refresh

PUNT-32

🤖 Generated with [Claude Code](https://claude.ai/code)