### PR TITLE
fix(ci): add DATABASE_URL env var for Prisma generate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
 
+    env:
+      DATABASE_URL: file:./test.db
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds DATABASE_URL environment variable for CI workflow
- Fixes Prisma generate failing due to missing env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)