### PR TITLE
ci: add build verification step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,8 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_DEMO_MODE: 'true'


### PR DESCRIPTION
## Summary
- Adds `pnpm build` step to CI workflow
- Verifies Next.js build succeeds before PRs can be merged
- Uses demo mode env var for build

🤖 Generated with [Claude Code](https://claude.com/claude-code)