### PR TITLE
Fix button spacing in import/export database modals

### DIFF
--- a/src/components/admin/database-export-dialog.tsx
+++ b/src/components/admin/database-export-dialog.tsx
@@ -94,7 +94,7 @@ export function DatabaseExportDialog({
           </div>
         </div>
 
-        <DialogFooter className="gap-2 sm:gap-0">
+        <DialogFooter>
           <Button variant="outline" onClick={handleClose} disabled={exportMutation.isPending}>
             Cancel
           </Button>

--- a/src/components/admin/database-import-dialog.tsx
+++ b/src/components/admin/database-import-dialog.tsx
@@ -217,7 +217,7 @@ export function DatabaseImportDialog({
               )}
             </div>
 
-            <DialogFooter className="gap-2 sm:gap-0">
+            <DialogFooter>
               <Button variant="outline" onClick={handleClose}>
                 Cancel
               </Button>
@@ -289,7 +289,7 @@ export function DatabaseImportDialog({
               </div>
             </div>
 
-            <DialogFooter className="gap-2 sm:gap-0">
+            <DialogFooter>
               <Button variant="outline" onClick={handleBack}>
                 Back
               </Button>
@@ -335,7 +335,7 @@ export function DatabaseImportDialog({
               </div>
             </div>
 
-            <DialogFooter className="gap-2 sm:gap-0">
+            <DialogFooter>
               <Button variant="outline" onClick={handleBack}>
                 Back
               </Button>
@@ -516,7 +516,7 @@ export function DatabaseImportDialog({
               </div>
             </div>
 
-            <DialogFooter className="gap-2 sm:gap-0">
+            <DialogFooter>
               <Button variant="outline" onClick={handleClose}>
                 Close
               </Button>


### PR DESCRIPTION
## Summary
- Removes `sm:gap-0` override from `DialogFooter` in the database import and export modals
- `DialogFooter` already provides `gap-2` by default — the override was collapsing the gap between Cancel and action buttons on desktop
- Matches the correct spacing seen in the wipe-all-projects modal

## Test plan
- [x] Open export database modal — verify gap between Cancel and Export buttons
- [x] Open import database modal — verify gap between Cancel and action buttons on all steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)