### PR TITLE
feat(roles): add select/deselect all button for permissions

### DIFF
--- a/src/components/projects/permissions/roles-tab.tsx
+++ b/src/components/projects/permissions/roles-tab.tsx
@@ -60,7 +60,7 @@ import {
 import { useCurrentUser } from '@/hooks/use-current-user'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { getTabId } from '@/hooks/use-realtime'
-import { PERMISSIONS } from '@/lib/permissions'
+import { ALL_PERMISSIONS, PERMISSIONS } from '@/lib/permissions'
 import { cn, getAvatarColor, getInitials } from '@/lib/utils'
 import {
   type BulkMemberRoleSnapshot,
@@ -146,6 +146,14 @@ export function RolesTab({ projectId }: RolesTabProps) {
     if (!selectedRoleId || !roles) return null
     return roles.find((r) => r.id === selectedRoleId) || null
   }, [selectedRoleId, roles])
+
+  // Check if all permissions are currently enabled
+  const allPermissionsEnabled = useMemo(
+    () =>
+      editPermissions.length === ALL_PERMISSIONS.length &&
+      ALL_PERMISSIONS.every((p) => editPermissions.includes(p)),
+    [editPermissions],
+  )
 
   // Get members for the selected role
   const roleMembers = useMemo(() => {
@@ -907,20 +915,37 @@ export function RolesTab({ projectId }: RolesTabProps) {
                     <div className="space-y-2">
                       <div className="flex items-center justify-between">
                         <Label>Permissions</Label>
-                        {!isCreating && hasChanges && (
-                          <label
-                            htmlFor="show-diff"
-                            className="flex items-center gap-2 cursor-pointer select-none"
-                          >
-                            <span className="text-xs text-zinc-500">Show changes</span>
-                            <Checkbox
-                              id="show-diff"
-                              checked={showDiff}
-                              onCheckedChange={(checked) => setShowDiff(checked === true)}
-                              className="border-zinc-600 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
-                            />
-                          </label>
-                        )}
+                        <div className="flex items-center gap-3">
+                          {!isCreating && hasChanges && (
+                            <label
+                              htmlFor="show-diff"
+                              className="flex items-center gap-2 cursor-pointer select-none"
+                            >
+                              <span className="text-xs text-zinc-500">Show changes</span>
+                              <Checkbox
+                                id="show-diff"
+                                checked={showDiff}
+                                onCheckedChange={(checked) => setShowDiff(checked === true)}
+                                className="border-zinc-600 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                              />
+                            </label>
+                          )}
+                          {canManageRoles && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() =>
+                                handleFieldChange(
+                                  'permissions',
+                                  allPermissionsEnabled ? [] : [...ALL_PERMISSIONS],
+                                )
+                              }
+                              className="h-6 px-2 text-xs text-zinc-400 hover:text-zinc-200"
+                            >
+                              {allPermissionsEnabled ? 'Disable All' : 'Enable All'}
+                            </Button>
+                          )}
+                        </div>
                       </div>
                       <p className="text-xs text-zinc-500 mb-3">
                         Select the actions members with this role can perform.


### PR DESCRIPTION
## Summary
- Adds an "Enable All" / "Disable All" button in the permissions section of the project roles tab
- When not all permissions are enabled, the button shows "Enable All" and enables every permission for the selected role
- When all permissions are already enabled, the button shows "Disable All" and clears all permissions
- The button is only visible to users with the `MEMBERS_ADMIN` permission (same check as other role management controls)
- Uses the existing `handleFieldChange` mechanism so changes are tracked, can be saved/cancelled, and trigger the unsaved changes flow

## Test plan
- [x] Navigate to a project's Settings > Roles tab
- [x] Select a role that has some (but not all) permissions enabled
- [x] Verify the "Enable All" button appears in the permissions section header
- [x] Click "Enable All" and verify all permission checkboxes become checked
- [x] Verify the button text changes to "Disable All"
- [x] Click "Disable All" and verify all permissions are unchecked
- [x] Verify the button text changes back to "Enable All"
- [x] Verify the "unsaved changes" footer appears after toggling
- [x] Save the changes and verify they persist
- [x] Verify the button is not shown for users without role management permissions
- [x] Verify the button works correctly when creating a new role

🤖 Generated with [Claude Code](https://claude.com/claude-code)