### PR TITLE
feat(board): add "Won't Fix" as a default column

### DIFF
--- a/src/__tests__/fuzz/stores/board-store.fuzz.test.ts
+++ b/src/__tests__/fuzz/stores/board-store.fuzz.test.ts
@@ -52,12 +52,13 @@ describe('Board Store Fuzz Tests', () => {
           const store = useBoardStore.getState()
           const columns = store.getColumns(projectId)
 
-          // Should return default columns (4 columns)
-          expect(columns.length).toBe(4)
+          // Should return default columns (5 columns)
+          expect(columns.length).toBe(5)
           expect(columns[0].name).toBe('To Do')
           expect(columns[1].name).toBe('In Progress')
           expect(columns[2].name).toBe('Review')
           expect(columns[3].name).toBe('Done')
+          expect(columns[4].name).toBe("Won't Fix")
         }),
         FUZZ_CONFIG.quick,
       )

--- a/src/app/api/projects/[projectId]/columns/route.ts
+++ b/src/app/api/projects/[projectId]/columns/route.ts
@@ -21,6 +21,7 @@ const DEFAULT_COLUMNS = [
   { name: 'In Progress', order: 1 },
   { name: 'Review', order: 2 },
   { name: 'Done', order: 3 },
+  { name: "Won't Fix", order: 4 },
 ]
 
 /**

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -130,6 +130,7 @@ export async function POST(request: Request) {
             { name: 'In Progress', order: 1 },
             { name: 'Review', order: 2 },
             { name: 'Done', order: 3 },
+            { name: "Won't Fix", order: 4 },
           ],
         },
       },

--- a/src/lib/demo/demo-data.ts
+++ b/src/lib/demo/demo-data.ts
@@ -87,11 +87,13 @@ export const DEMO_COLUMNS: DemoColumn[] = [
   { id: 'demo-col-1-2', name: 'In Progress', order: 1, projectId: 'demo-project-1' },
   { id: 'demo-col-1-3', name: 'Review', order: 2, projectId: 'demo-project-1' },
   { id: 'demo-col-1-4', name: 'Done', order: 3, projectId: 'demo-project-1' },
+  { id: 'demo-col-1-5', name: "Won't Fix", order: 4, projectId: 'demo-project-1' },
   // Project 2: Bug Tracker
   { id: 'demo-col-2-1', name: 'To Do', order: 0, projectId: 'demo-project-2' },
   { id: 'demo-col-2-2', name: 'In Progress', order: 1, projectId: 'demo-project-2' },
   { id: 'demo-col-2-3', name: 'Review', order: 2, projectId: 'demo-project-2' },
   { id: 'demo-col-2-4', name: 'Done', order: 3, projectId: 'demo-project-2' },
+  { id: 'demo-col-2-5', name: "Won't Fix", order: 4, projectId: 'demo-project-2' },
 ]
 
 // ============================================================================

--- a/src/lib/demo/demo-storage.ts
+++ b/src/lib/demo/demo-storage.ts
@@ -165,6 +165,7 @@ class DemoStorage {
       { id: `demo-col-${Date.now()}-2`, name: 'In Progress', order: 1, projectId: newProject.id },
       { id: `demo-col-${Date.now()}-3`, name: 'Review', order: 2, projectId: newProject.id },
       { id: `demo-col-${Date.now()}-4`, name: 'Done', order: 3, projectId: newProject.id },
+      { id: `demo-col-${Date.now()}-5`, name: "Won't Fix", order: 4, projectId: newProject.id },
     ]
     localStorage.setItem(KEYS.columns(newProject.id), JSON.stringify(defaultColumns))
     localStorage.setItem(KEYS.tickets(newProject.id), JSON.stringify([]))

--- a/src/lib/sprint-utils.ts
+++ b/src/lib/sprint-utils.ts
@@ -5,7 +5,16 @@ import type { ColumnWithTickets, SprintSummary, TicketWithRelations } from '@/ty
  * Used for auto-detecting completed tickets when completing sprints.
  */
 export function isCompletedColumn(columnName: string): boolean {
-  const patterns = ['done', 'complete', 'completed', 'closed', 'resolved', 'finished']
+  const patterns = [
+    'done',
+    'complete',
+    'completed',
+    'closed',
+    'resolved',
+    'finished',
+    "won't fix",
+    'wontfix',
+  ]
   return patterns.includes(columnName.trim().toLowerCase())
 }
 

--- a/src/stores/__tests__/board-store.test.ts
+++ b/src/stores/__tests__/board-store.test.ts
@@ -34,7 +34,7 @@ describe('Board Store', () => {
 
     it('should return default columns for unknown project', () => {
       const columns = useBoardStore.getState().getColumns('unknown-project')
-      expect(columns).toHaveLength(4) // Default columns
+      expect(columns).toHaveLength(5) // Default columns
       expect(columns[0].name).toBe('To Do')
     })
   })

--- a/src/stores/board-store.ts
+++ b/src/stores/board-store.ts
@@ -11,6 +11,7 @@ function createDefaultColumns(projectId: string): ColumnWithTickets[] {
     { id: `${projectId}-col-2`, name: 'In Progress', order: 1, projectId, tickets: [] },
     { id: `${projectId}-col-3`, name: 'Review', order: 2, projectId, tickets: [] },
     { id: `${projectId}-col-4`, name: 'Done', order: 3, projectId, tickets: [] },
+    { id: `${projectId}-col-5`, name: "Won't Fix", order: 4, projectId, tickets: [] },
   ]
 }
 


### PR DESCRIPTION
## Summary
- Adds **"Won't Fix"** as the fifth default board column (order 4, after "Done") for all newly created projects
- Updates the sprint completion heuristic (`isCompletedColumn`) to treat "Won't Fix" and "wontfix" as terminal statuses, so tickets in that column count as resolved when completing a sprint
- Applied consistently across all 5 locations where default columns are defined: API project creation, columns fallback route, board store defaults, demo data, and demo storage

Closes PUNT-20

## Test plan
- [ ] Create a new project and verify 5 default columns appear: To Do, In Progress, Review, Done, Won't Fix
- [ ] In demo mode, verify both demo projects show the Won't Fix column
- [ ] Move a ticket to the Won't Fix column and complete a sprint -- verify the ticket is counted as "completed" (not incomplete/carried over)
- [ ] Verify existing projects are unaffected (they keep their current columns)
- [ ] Board store tests pass (26 tests) and fuzz tests pass (15 tests) with updated expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)