### PR TITLE
feat(undo): wire up undo/redo for ticket creation

### DIFF
--- a/src/components/tickets/create-ticket-dialog.tsx
+++ b/src/components/tickets/create-ticket-dialog.tsx
@@ -256,34 +256,43 @@ export function CreateTicketDialog() {
       showUndoButtons: true,
       onUndo: async (id) => {
         // Undo: delete the created ticket
-        const entry = useUndoStore.getState().undoByToastId(id)
+        const store = useUndoStore.getState()
+        if (store.isProcessing) return
+        const entry = store.undoByToastId(id)
         if (entry) {
           useBoardStore.getState().removeTicket(projectId, serverTicket.id)
-          // Delete from server
-          deleteTicketAPI(projectId, serverTicket.id).catch((err) => {
-            console.error('Failed to delete ticket on undo:', err)
-          })
+          // Delete from server (block next undo/redo until done)
+          store.setProcessing(true)
+          deleteTicketAPI(projectId, serverTicket.id)
+            .catch((err) => {
+              console.error('Failed to delete ticket on undo:', err)
+            })
+            .finally(() => {
+              useUndoStore.getState().setProcessing(false)
+            })
         }
       },
       onRedo: async (id) => {
         // Redo: re-create the ticket
-        const entry = useUndoStore.getState().redoByToastId(id)
+        const store = useUndoStore.getState()
+        if (store.isProcessing) return
+        const entry = store.redoByToastId(id)
         if (entry) {
           useBoardStore.getState().addTicket(projectId, columnId, serverTicket)
-          // Re-create on server
-          createTicketAPI(projectId, columnId, serverTicket)
-            .then((newServerTicket) => {
-              // Replace the old ticket with the new server ticket
-              const boardStore = useBoardStore.getState()
-              boardStore.removeTicket(projectId, serverTicket.id)
-              boardStore.addTicket(projectId, columnId, newServerTicket)
-              // Update undo/redo store entries so next cycle uses the new server ticket ID
-              useUndoStore.getState().updateTicketCreateEntry(serverTicket.id, newServerTicket)
-              serverTicket = newServerTicket
-            })
-            .catch((err) => {
-              console.error('Failed to recreate ticket on redo:', err)
-            })
+          // Re-create on server (await to block next undo/redo)
+          store.setProcessing(true)
+          try {
+            const newServerTicket = await createTicketAPI(projectId, columnId, serverTicket)
+            const boardStore = useBoardStore.getState()
+            boardStore.removeTicket(projectId, serverTicket.id)
+            boardStore.addTicket(projectId, columnId, newServerTicket)
+            useUndoStore.getState().updateTicketCreateEntry(serverTicket.id, newServerTicket)
+            serverTicket = newServerTicket
+          } catch (err) {
+            console.error('Failed to recreate ticket on redo:', err)
+          } finally {
+            useUndoStore.getState().setProcessing(false)
+          }
         }
       },
       onUndoneToast: (newId) => {

--- a/src/stores/undo-store.ts
+++ b/src/stores/undo-store.ts
@@ -63,6 +63,9 @@ interface UndoState {
   undoStack: UndoEntry[]
   // Stack of redo entries
   redoStack: UndoEntry[]
+  // Whether an async undo/redo operation (e.g. API call) is in flight
+  isProcessing: boolean
+  setProcessing: (v: boolean) => void
 
   // Add a delete action to the undo stack
   pushDeleted: (
@@ -171,6 +174,8 @@ interface UndoState {
 export const useUndoStore = create<UndoState>((set, get) => ({
   undoStack: [],
   redoStack: [],
+  isProcessing: false,
+  setProcessing: (v) => set({ isProcessing: v }),
 
   pushDeleted: (projectId, ticket, columnId, toastId, isRedo = false) => {
     console.debug(`[SessionLog] Action: Delete ${isRedo ? '(Redo)' : ''}`, {


### PR DESCRIPTION
## Summary
- After creating a ticket via the Create Ticket dialog, a `ticketCreate` undo action is pushed to the undo store with a toast notification showing an "Undo" button
- Pressing Undo (via toast button or Ctrl+Z) deletes the created ticket from both the board store and the server
- Pressing Redo (via toast button or Ctrl+Y) re-creates the ticket on the server and restores it in the board store
- Adds missing API persistence to the existing `ticketCreate` undo/redo handlers in keyboard-shortcuts.tsx (previously only updated local state without server calls)

## Test plan
- [x] Create a ticket via the Create Ticket dialog -- verify a "Ticket created" toast appears with an "Undo" button
- [x] Click the "Undo" button on the toast -- verify the ticket is removed from the board and deleted on the server
- [x] Click the "Redo" button on the undo confirmation toast -- verify the ticket reappears and is re-created on the server
- [x] Create a ticket, then press Ctrl+Z -- verify the ticket is undone (deleted from board and server)
- [x] After Ctrl+Z, press Ctrl+Y -- verify the ticket is redone (re-created on board and server)
- [x] Verify no regression in existing undo/redo for delete, paste, move, and update actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)