### PR TITLE
fix: add missing avatarColor to UserDetails interface

### DIFF
--- a/src/app/(app)/admin/users/[userId]/page.tsx
+++ b/src/app/(app)/admin/users/[userId]/page.tsx
@@ -61,6 +61,7 @@ interface UserDetails {
   email: string | null
   name: string
   avatar: string | null
+  avatarColor: string | null
   isSystemAdmin: boolean
   isActive: boolean
   createdAt: string


### PR DESCRIPTION
## Summary
- Add missing `avatarColor` field to `UserDetails` interface in admin user detail page
- Fixes build failure introduced by avatar color feature (#28) that missed this type

## Test plan
- [x] `pnpm build` passes without type errors