### PR TITLE
feat(admin): add (you) badge to current user in admin users list

### DIFF
--- a/src/components/admin/user-list.tsx
+++ b/src/components/admin/user-list.tsx
@@ -839,7 +839,10 @@ export function UserList() {
               <div className="flex items-center gap-2">
                 <span className="font-medium text-zinc-100">{user.name}</span>
                 {isCurrentUser && (
-                  <Badge variant="outline" className="border-zinc-500 text-zinc-400 text-xs">
+                  <Badge
+                    variant="outline"
+                    className="text-[10px] px-1.5 py-0 h-4 border-amber-600 text-amber-500"
+                  >
                     You
                   </Badge>
                 )}


### PR DESCRIPTION
## Summary
- Update the "(you)" badge in the admin users list (`/admin/users`) to use amber styling matching the project members tab
- Previously the badge used plain zinc/gray colors (`border-zinc-500 text-zinc-400`), now uses amber (`border-amber-600 text-amber-500`) consistent with the members tab badge

## Test plan
- [x] Navigate to `/admin/users`
- [x] Verify current user's row shows amber "(you)" badge
- [x] Badge style matches the one in project member settings (`/projects/KEY/settings?tab=members`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)