### PR TITLE
fix(test): add missing avatarColor field to useCurrentUser test

### DIFF
--- a/src/hooks/__tests__/use-current-user.test.ts
+++ b/src/hooks/__tests__/use-current-user.test.ts
@@ -66,6 +66,7 @@ describe('useCurrentUser', () => {
       name: 'Test User',
       email: 'test@example.com',
       avatar: '/avatar.jpg',
+      avatarColor: null,
       isSystemAdmin: false,
     })
   })


### PR DESCRIPTION
## Summary
- Add missing `avatarColor: null` to the expected output in the `useCurrentUser` test, fixing CI failure introduced by the avatar color feature

## Test plan
- [x] `pnpm test` passes (850/850)

🤖 Generated with [Claude Code](https://claude.com/claude-code)