### PR TITLE
feat(tickets): inline ticket reference linking with PUNT-123 syntax (#PUNT-38)

### DIFF
--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,4 +1,5 @@
 export { EmptyState } from './empty-state'
 export { InlineCodeText } from './inline-code'
+export { LinkedText } from './linked-text'
 export { PriorityBadge } from './priority-badge'
 export { TypeBadge } from './type-badge'

--- a/src/components/common/linked-text.tsx
+++ b/src/components/common/linked-text.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import Link from 'next/link'
+import { getTicketReferencePath, parseTicketReferences } from '@/lib/ticket-references'
+
+interface LinkedTextProps {
+  text: string
+  className?: string
+}
+
+/**
+ * Renders text with ticket key references (e.g., PUNT-123) as clickable links.
+ * Non-ticket text is rendered as plain text.
+ *
+ * Links navigate to the canonical ticket URL which will open the ticket drawer.
+ */
+export function LinkedText({ text, className }: LinkedTextProps) {
+  const parts = parseTicketReferences(text)
+
+  // No ticket references found, return plain text
+  if (parts.length === 1 && !parts[0].ticketKey) {
+    return <span className={className}>{text}</span>
+  }
+
+  return (
+    <span className={className}>
+      {parts.map((part, index) =>
+        part.ticketKey ? (
+          <Link
+            key={index}
+            href={getTicketReferencePath(part.ticketKey)}
+            className="font-mono text-amber-500 hover:text-amber-400 hover:underline"
+            onClick={(e) => {
+              e.stopPropagation()
+            }}
+          >
+            {part.text}
+          </Link>
+        ) : (
+          <span key={index}>{part.text}</span>
+        ),
+      )}
+    </span>
+  )
+}

--- a/src/components/tickets/markdown-viewer.tsx
+++ b/src/components/tickets/markdown-viewer.tsx
@@ -15,6 +15,7 @@ import {
 import React, { useEffect, useMemo, useState } from 'react'
 import '@mdxeditor/editor/style.css'
 import { oneDark } from '@codemirror/theme-one-dark'
+import { linkifyTicketReferences } from '@/lib/ticket-references'
 
 interface MarkdownViewerProps {
   markdown: string
@@ -85,6 +86,9 @@ export const MarkdownViewer = React.memo(function MarkdownViewer({
     [],
   )
 
+  // Preprocess markdown to convert ticket references into clickable links
+  const processedMarkdown = useMemo(() => linkifyTicketReferences(markdown), [markdown])
+
   // Show loading placeholder during SSR to prevent hydration mismatch
   if (!isMounted) {
     return <div className={`text-sm text-zinc-300 ${className}`}>{markdown}</div>
@@ -93,7 +97,7 @@ export const MarkdownViewer = React.memo(function MarkdownViewer({
   return (
     <div className={`markdown-viewer ${className}`}>
       <MDXEditor
-        markdown={markdown}
+        markdown={processedMarkdown}
         readOnly
         plugins={plugins}
         contentEditableClassName="prose prose-invert max-w-none text-sm text-zinc-300 [&_strong]:text-zinc-100 [&_strong]:font-semibold [&_em]:italic [&_code]:text-amber-400 [&_code]:bg-zinc-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-xs [&_pre]:bg-zinc-950 [&_pre]:border [&_pre]:border-zinc-800 [&_pre]:p-3 [&_pre]:rounded-md [&_pre_code]:bg-transparent [&_pre_code]:text-amber-400 [&_pre_code]:px-0 [&_a]:text-amber-500 [&_a:hover]:text-amber-400 [&_a]:underline [&_h1]:text-zinc-100 [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-zinc-100 [&_h2]:text-xl [&_h2]:font-bold [&_h2]:mt-4 [&_h2]:mb-2 [&_h3]:text-zinc-100 [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-2 [&_h4]:text-zinc-100 [&_h4]:text-base [&_h4]:font-semibold [&_h4]:mt-3 [&_h4]:mb-2 [&_h5]:text-zinc-100 [&_h5]:font-semibold [&_h5]:mt-2 [&_h5]:mb-2 [&_h6]:text-zinc-100 [&_h6]:font-semibold [&_h6]:mt-2 [&_h6]:mb-2 [&_blockquote]:border-l-4 [&_blockquote]:border-l-amber-500 [&_blockquote]:pl-4 [&_blockquote]:text-zinc-300 [&_blockquote]:italic [&_ul]:list-disc [&_ul]:ml-6 [&_ul]:space-y-1 [&_ol]:list-decimal [&_ol]:ml-6 [&_ol]:space-y-1 [&_li]:text-zinc-300 [&_p]:text-zinc-300 [&_p]:mb-2 [&_hr]:border-zinc-600 [&_hr]:border-t-2 [&_hr]:my-4"

--- a/src/lib/__tests__/ticket-references.test.ts
+++ b/src/lib/__tests__/ticket-references.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getProjectKeyFromTicketKey,
+  getTicketReferencePath,
+  linkifyTicketReferences,
+  parseTicketReferences,
+} from '../ticket-references'
+
+describe('parseTicketReferences', () => {
+  it('should return plain text when no ticket references', () => {
+    const result = parseTicketReferences('No ticket references here')
+    expect(result).toEqual([{ text: 'No ticket references here', ticketKey: null }])
+  })
+
+  it('should parse a single ticket reference', () => {
+    const result = parseTicketReferences('See PUNT-123')
+    expect(result).toEqual([
+      { text: 'See ', ticketKey: null },
+      { text: 'PUNT-123', ticketKey: 'PUNT-123' },
+    ])
+  })
+
+  it('should parse multiple ticket references', () => {
+    const result = parseTicketReferences('See PUNT-123 and ABC-1 for details')
+    expect(result).toEqual([
+      { text: 'See ', ticketKey: null },
+      { text: 'PUNT-123', ticketKey: 'PUNT-123' },
+      { text: ' and ', ticketKey: null },
+      { text: 'ABC-1', ticketKey: 'ABC-1' },
+      { text: ' for details', ticketKey: null },
+    ])
+  })
+
+  it('should parse ticket reference at start of text', () => {
+    const result = parseTicketReferences('PUNT-1 is done')
+    expect(result).toEqual([
+      { text: 'PUNT-1', ticketKey: 'PUNT-1' },
+      { text: ' is done', ticketKey: null },
+    ])
+  })
+
+  it('should parse ticket reference at end of text', () => {
+    const result = parseTicketReferences('Related to PUNT-42')
+    expect(result).toEqual([
+      { text: 'Related to ', ticketKey: null },
+      { text: 'PUNT-42', ticketKey: 'PUNT-42' },
+    ])
+  })
+
+  it('should handle ticket reference that is the entire text', () => {
+    const result = parseTicketReferences('PUNT-123')
+    expect(result).toEqual([{ text: 'PUNT-123', ticketKey: 'PUNT-123' }])
+  })
+
+  it('should handle empty string', () => {
+    const result = parseTicketReferences('')
+    expect(result).toEqual([{ text: '', ticketKey: null }])
+  })
+
+  it('should handle project keys with numbers', () => {
+    const result = parseTicketReferences('See PROJ2-42')
+    expect(result).toEqual([
+      { text: 'See ', ticketKey: null },
+      { text: 'PROJ2-42', ticketKey: 'PROJ2-42' },
+    ])
+  })
+
+  it('should not match lowercase project keys', () => {
+    const result = parseTicketReferences('See punt-123')
+    expect(result).toEqual([{ text: 'See punt-123', ticketKey: null }])
+  })
+
+  it('should not match single-letter project keys', () => {
+    // Single letter followed by digit and dash doesn't match because
+    // the pattern requires at least 2 characters before the dash
+    const result = parseTicketReferences('See A-123')
+    expect(result).toEqual([{ text: 'See A-123', ticketKey: null }])
+  })
+})
+
+describe('getProjectKeyFromTicketKey', () => {
+  it('should extract project key from ticket key', () => {
+    expect(getProjectKeyFromTicketKey('PUNT-123')).toBe('PUNT')
+  })
+
+  it('should handle project keys with numbers', () => {
+    expect(getProjectKeyFromTicketKey('PROJ2-42')).toBe('PROJ2')
+  })
+
+  it('should handle single digit ticket numbers', () => {
+    expect(getProjectKeyFromTicketKey('ABC-1')).toBe('ABC')
+  })
+})
+
+describe('getTicketReferencePath', () => {
+  it('should build correct URL path', () => {
+    expect(getTicketReferencePath('PUNT-123')).toBe('/projects/PUNT/PUNT-123')
+  })
+
+  it('should handle different project keys', () => {
+    expect(getTicketReferencePath('ABC-1')).toBe('/projects/ABC/ABC-1')
+  })
+})
+
+describe('linkifyTicketReferences', () => {
+  it('should convert ticket references to markdown links', () => {
+    const result = linkifyTicketReferences('See PUNT-123 for details')
+    expect(result).toBe('See [PUNT-123](/projects/PUNT/PUNT-123) for details')
+  })
+
+  it('should handle multiple references', () => {
+    const result = linkifyTicketReferences('PUNT-1 blocks ABC-2')
+    expect(result).toBe('[PUNT-1](/projects/PUNT/PUNT-1) blocks [ABC-2](/projects/ABC/ABC-2)')
+  })
+
+  it('should not linkify references inside inline code', () => {
+    const result = linkifyTicketReferences('See `PUNT-123` in code')
+    expect(result).toBe('See `PUNT-123` in code')
+  })
+
+  it('should not linkify references inside code blocks', () => {
+    const input = '```\nPUNT-123\n```'
+    const result = linkifyTicketReferences(input)
+    expect(result).toBe('```\nPUNT-123\n```')
+  })
+
+  it('should not linkify references inside existing markdown links', () => {
+    const result = linkifyTicketReferences('See [PUNT-123](http://example.com)')
+    expect(result).toBe('See [PUNT-123](http://example.com)')
+  })
+
+  it('should not linkify references inside URLs', () => {
+    const result = linkifyTicketReferences('See https://example.com/PUNT-123')
+    expect(result).toBe('See https://example.com/PUNT-123')
+  })
+
+  it('should handle empty string', () => {
+    expect(linkifyTicketReferences('')).toBe('')
+  })
+
+  it('should handle text with no references', () => {
+    expect(linkifyTicketReferences('Just plain text')).toBe('Just plain text')
+  })
+
+  it('should handle multiline markdown', () => {
+    const input = 'First line with PUNT-1\n\nSecond line with ABC-2'
+    const result = linkifyTicketReferences(input)
+    expect(result).toBe(
+      'First line with [PUNT-1](/projects/PUNT/PUNT-1)\n\nSecond line with [ABC-2](/projects/ABC/ABC-2)',
+    )
+  })
+
+  it('should handle mixed content: code blocks and regular text', () => {
+    const input = 'See PUNT-1\n```\nPUNT-2 in code\n```\nAlso PUNT-3'
+    const result = linkifyTicketReferences(input)
+    expect(result).toBe(
+      'See [PUNT-1](/projects/PUNT/PUNT-1)\n```\nPUNT-2 in code\n```\nAlso [PUNT-3](/projects/PUNT/PUNT-3)',
+    )
+  })
+
+  it('should not double-linkify already linked references', () => {
+    const input = 'See [PUNT-123](/projects/PUNT/PUNT-123) and PUNT-456'
+    const result = linkifyTicketReferences(input)
+    expect(result).toBe(
+      'See [PUNT-123](/projects/PUNT/PUNT-123) and [PUNT-456](/projects/PUNT/PUNT-456)',
+    )
+  })
+})

--- a/src/lib/ticket-references.ts
+++ b/src/lib/ticket-references.ts
@@ -1,0 +1,221 @@
+/**
+ * Utility functions for detecting and linking ticket key references in text.
+ *
+ * Ticket keys follow the pattern: PROJECT_KEY-NUMBER (e.g., PUNT-123, ABC-1)
+ * where PROJECT_KEY is 2+ uppercase letters/digits starting with a letter,
+ * and NUMBER is one or more digits.
+ */
+
+/**
+ * Regex pattern for matching ticket key references.
+ * Matches patterns like PUNT-123, ABC-1, PROJ2-42.
+ * Uses word boundary to avoid matching partial strings.
+ */
+export const TICKET_KEY_PATTERN = /\b([A-Z][A-Z0-9]+-\d+)\b/g
+
+export interface TicketReferencePart {
+  text: string
+  ticketKey: string | null
+}
+
+/**
+ * Parse a text string into segments of plain text and ticket references.
+ *
+ * @param text - The input text to parse
+ * @returns An array of parts, each with text content and an optional ticketKey
+ *
+ * @example
+ * parseTicketReferences("See PUNT-123 and ABC-1 for details")
+ * // Returns:
+ * // [
+ * //   { text: "See ", ticketKey: null },
+ * //   { text: "PUNT-123", ticketKey: "PUNT-123" },
+ * //   { text: " and ", ticketKey: null },
+ * //   { text: "ABC-1", ticketKey: "ABC-1" },
+ * //   { text: " for details", ticketKey: null },
+ * // ]
+ */
+export function parseTicketReferences(text: string): TicketReferencePart[] {
+  const parts: TicketReferencePart[] = []
+  const regex = new RegExp(TICKET_KEY_PATTERN.source, 'g')
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  match = regex.exec(text)
+  while (match !== null) {
+    // Add plain text before the match
+    if (match.index > lastIndex) {
+      parts.push({
+        text: text.slice(lastIndex, match.index),
+        ticketKey: null,
+      })
+    }
+
+    // Add the ticket reference
+    parts.push({
+      text: match[1],
+      ticketKey: match[1],
+    })
+
+    lastIndex = match.index + match[0].length
+    match = regex.exec(text)
+  }
+
+  // Add remaining plain text
+  if (lastIndex < text.length) {
+    parts.push({
+      text: text.slice(lastIndex),
+      ticketKey: null,
+    })
+  }
+
+  // If no parts were created, return the original text
+  if (parts.length === 0) {
+    return [{ text, ticketKey: null }]
+  }
+
+  return parts
+}
+
+/**
+ * Extract the project key from a ticket key string.
+ *
+ * @param ticketKey - e.g., "PUNT-123"
+ * @returns The project key, e.g., "PUNT"
+ */
+export function getProjectKeyFromTicketKey(ticketKey: string): string {
+  const dashIndex = ticketKey.lastIndexOf('-')
+  return dashIndex > 0 ? ticketKey.substring(0, dashIndex) : ticketKey
+}
+
+/**
+ * Build a URL path for a ticket reference.
+ * Uses the canonical URL format: /projects/PROJECT_KEY/TICKET_KEY
+ * which will redirect to the appropriate view with the ticket drawer open.
+ *
+ * @param ticketKey - e.g., "PUNT-123"
+ * @returns The URL path, e.g., "/projects/PUNT/PUNT-123"
+ */
+export function getTicketReferencePath(ticketKey: string): string {
+  const projectKey = getProjectKeyFromTicketKey(ticketKey)
+  return `/projects/${projectKey}/${ticketKey}`
+}
+
+/**
+ * Process markdown text and convert ticket key references into markdown links.
+ *
+ * This preserves existing markdown syntax by only replacing ticket keys
+ * that appear outside of:
+ * - Existing markdown links [text](url) or [text][ref]
+ * - Inline code `code`
+ * - Code blocks ```code```
+ * - URLs (http://... or https://...)
+ *
+ * @param markdown - The raw markdown string
+ * @returns The markdown with ticket references converted to links
+ *
+ * @example
+ * linkifyTicketReferences("See PUNT-123 for details")
+ * // Returns: "See [PUNT-123](/projects/PUNT/PUNT-123) for details"
+ */
+export function linkifyTicketReferences(markdown: string): string {
+  if (!markdown) return markdown
+
+  // We process line-by-line to handle code blocks properly
+  const lines = markdown.split('\n')
+  let inCodeBlock = false
+  const result: string[] = []
+
+  for (const line of lines) {
+    // Check for code block fences
+    if (line.trimStart().startsWith('```')) {
+      inCodeBlock = !inCodeBlock
+      result.push(line)
+      continue
+    }
+
+    // Don't process lines inside code blocks
+    if (inCodeBlock) {
+      result.push(line)
+      continue
+    }
+
+    result.push(linkifyLine(line))
+  }
+
+  return result.join('\n')
+}
+
+/**
+ * Process a single line of markdown, converting ticket references to links.
+ * Skips ticket keys inside inline code, existing links, and URLs.
+ */
+function linkifyLine(line: string): string {
+  // Build a map of "protected" ranges that should not be linkified
+  const protectedRanges: Array<{ start: number; end: number }> = []
+
+  // Protect existing markdown links: [text](url) and [text][ref]
+  const linkRegex = /\[([^\]]*)\]\(([^)]*)\)|\[([^\]]*)\]\[([^\]]*)\]/g
+  let linkMatch: RegExpExecArray | null
+  linkMatch = linkRegex.exec(line)
+  while (linkMatch !== null) {
+    protectedRanges.push({ start: linkMatch.index, end: linkMatch.index + linkMatch[0].length })
+    linkMatch = linkRegex.exec(line)
+  }
+
+  // Protect inline code: `code`
+  const codeRegex = /`[^`]+`/g
+  let codeMatch: RegExpExecArray | null
+  codeMatch = codeRegex.exec(line)
+  while (codeMatch !== null) {
+    protectedRanges.push({ start: codeMatch.index, end: codeMatch.index + codeMatch[0].length })
+    codeMatch = codeRegex.exec(line)
+  }
+
+  // Protect URLs
+  const urlRegex = /https?:\/\/[^\s)]+/g
+  let urlMatch: RegExpExecArray | null
+  urlMatch = urlRegex.exec(line)
+  while (urlMatch !== null) {
+    protectedRanges.push({ start: urlMatch.index, end: urlMatch.index + urlMatch[0].length })
+    urlMatch = urlRegex.exec(line)
+  }
+
+  // Now find and replace ticket keys that are NOT in protected ranges
+  const ticketRegex = new RegExp(TICKET_KEY_PATTERN.source, 'g')
+  let resultLine = ''
+  let lastIndex = 0
+  let ticketMatch: RegExpExecArray | null
+
+  ticketMatch = ticketRegex.exec(line)
+  while (ticketMatch !== null) {
+    const matchStart = ticketMatch.index
+    const matchEnd = matchStart + ticketMatch[0].length
+
+    // Check if this match is inside a protected range
+    const isProtected = protectedRanges.some(
+      (range) => matchStart >= range.start && matchEnd <= range.end,
+    )
+
+    // Add text before match
+    resultLine += line.slice(lastIndex, matchStart)
+
+    if (isProtected) {
+      // Keep as-is
+      resultLine += ticketMatch[0]
+    } else {
+      // Convert to markdown link
+      const ticketKey = ticketMatch[1]
+      const path = getTicketReferencePath(ticketKey)
+      resultLine += `[${ticketKey}](${path})`
+    }
+
+    lastIndex = matchEnd
+    ticketMatch = ticketRegex.exec(line)
+  }
+
+  // Add remaining text
+  resultLine += line.slice(lastIndex)
+
+  return resultLine
+}


### PR DESCRIPTION
## Summary
- Ticket keys (e.g., \`PUNT-123\`) in markdown descriptions now render as clickable amber links
- New \`linkifyTicketReferences()\` preprocessor intelligently skips code blocks, inline code, existing links, and URLs
- New \`LinkedText\` component exported from \`src/components/common/\` for plain text contexts
- Links navigate to \`/projects/PROJECT_KEY/TICKET_KEY\` using existing server-side route
- 26 unit tests covering edge cases

## Test plan
- [x] Create a ticket with description containing \`PUNT-1\` — should render as clickable link
- [x] Verify links inside \`\`backticks\`\` and code blocks are NOT linkified
- [x] Verify existing markdown links are not double-linked
- [x] Click a ticket reference — should open the referenced ticket
- [x] Run \`pnpm test -- src/lib/__tests__/ticket-references.test.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)