### PR TITLE
fix(board): correct column icon default color mapping

### DIFF
--- a/src/components/board/column-menu.tsx
+++ b/src/components/board/column-menu.tsx
@@ -36,12 +36,7 @@ import { columnKeys, ticketKeys } from '@/hooks/queries/use-tickets'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { getTabId } from '@/hooks/use-realtime'
 import { PERMISSIONS } from '@/lib/permissions'
-import {
-  COLUMN_ICON_OPTIONS,
-  getColumnIcon,
-  resolveColumnColor,
-  resolveColumnIconName,
-} from '@/lib/status-icons'
+import { COLUMN_ICON_OPTIONS, getColumnIcon, resolveColumnIconName } from '@/lib/status-icons'
 import { showUndoRedoToast } from '@/lib/undo-toast'
 import { cn } from '@/lib/utils'
 import { useBoardStore } from '@/stores/board-store'
@@ -88,7 +83,7 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
   const handleRenameOpen = useCallback(() => {
     setRenameValue(column.name)
     setIconValue(resolveColumnIconName(column.icon, column.name))
-    setColorValue(resolveColumnColor(column.color, column.icon, column.name))
+    setColorValue(column.color ?? null)
     setRenameOpen(true)
     // Focus the input after the dialog renders
     setTimeout(() => renameInputRef.current?.focus(), 50)

--- a/src/lib/status-icons.ts
+++ b/src/lib/status-icons.ts
@@ -104,25 +104,24 @@ export function resolveColumnIconName(
   return null
 }
 
-// Map Tailwind text color classes to hex values for the color picker.
-// Uses LABEL_COLORS preset values where possible so the swatch gets highlighted.
+// Map Tailwind text color classes to their actual hex values for the color picker.
 export const TAILWIND_TO_HEX: Record<string, string> = {
-  'text-zinc-400': '#64748b', // slate preset
-  'text-zinc-500': '#78716c', // stone preset
-  'text-blue-300': '#3b82f6', // blue preset
-  'text-blue-400': '#3b82f6', // blue preset
-  'text-cyan-300': '#06b6d4', // cyan preset
-  'text-amber-300': '#f59e0b', // amber preset
-  'text-amber-400': '#f59e0b', // amber preset
-  'text-purple-300': '#8b5cf6', // purple preset
-  'text-emerald-400': '#22c55e', // green preset
-  'text-red-300': '#ef4444', // red preset
-  'text-red-400': '#ef4444', // red preset
-  'text-green-400': '#22c55e', // green preset
-  'text-yellow-300': '#eab308', // yellow preset
-  'text-yellow-400': '#eab308', // yellow preset
-  'text-orange-400': '#f97316', // orange preset
-  'text-indigo-400': '#a855f7', // purple-500 preset
+  'text-zinc-400': '#a1a1aa',
+  'text-zinc-500': '#71717a',
+  'text-blue-300': '#93c5fd',
+  'text-blue-400': '#60a5fa',
+  'text-cyan-300': '#67e8f9',
+  'text-amber-300': '#fcd34d',
+  'text-amber-400': '#fbbf24',
+  'text-purple-300': '#d8b4fe',
+  'text-emerald-400': '#34d399',
+  'text-red-300': '#fca5a5',
+  'text-red-400': '#f87171',
+  'text-green-400': '#4ade80',
+  'text-yellow-300': '#fde047',
+  'text-yellow-400': '#facc15',
+  'text-orange-400': '#fb923c',
+  'text-indigo-400': '#818cf8',
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed all 16 entries in `TAILWIND_TO_HEX` — they were mapped to `LABEL_COLORS` presets (e.g. `-500` shades) instead of the actual Tailwind hex values for their class (e.g. `-300`/`-400` shades)
- Fixed `handleRenameOpen` to use `column.color ?? null` instead of resolving through the wrong mapping, so columns without a custom color correctly show "auto-detected" in the edit dialog

## Test plan
- [x] Open column edit dialog for a column with no custom color → should show "Using auto-detected color from icon"
- [x] Pick a custom color → save → reopen → shows that custom color with "Reset to default color" button
- [x] Click "Reset to default color" → shows "Using auto-detected color from icon" again
- [x] Preview icon color matches the actual column header icon color throughout

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)