### PR TITLE
fix(mcp): gitignore .mcp.json and update MCP setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ next-env.d.ts
 
 /src/generated/prisma
 .playwright-mcp/
+.mcp.json
 tmp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "punt": {
-      "type": "stdio",
-      "command": "pnpm",
-      "args": ["--dir", "mcp", "exec", "tsx", "src/index.ts"]
-    }
-  }
-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,7 +442,10 @@ cd mcp && pnpm install  # First time only
 MCP_API_KEY=your-key pnpm --dir mcp exec tsx src/index.ts
 ```
 
-**Configuration** (`.mcp.json`):
+**Configuration** (`.mcp.json` — gitignored, contains secrets):
+
+The `.mcp.json` file lives in the project root but is **gitignored** because it contains the API key. Claude Code reads it automatically per-project. The MCP server requires the dev server (`pnpm dev`) to be running on port 3000, since it calls the PUNT API. If MCP tools return HTML instead of JSON, the dev server is not running.
+
 ```json
 {
   "mcpServers": {
@@ -451,7 +454,7 @@ MCP_API_KEY=your-key pnpm --dir mcp exec tsx src/index.ts
       "command": "pnpm",
       "args": ["--dir", "mcp", "exec", "tsx", "src/index.ts"],
       "env": {
-        "MCP_API_KEY": "your-api-key-here"
+        "MCP_API_KEY": "<user's key from POST /api/me/mcp-key>"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ AI:  Created PUNT-42: Login page not loading
    # Save the returned apiKey - it won't be shown again
    ```
 
-3. Add to your MCP client config (e.g., Claude Desktop):
+3. Add to your MCP client config (e.g., Claude Desktop `claude_desktop_config.json`):
    ```json
    {
      "mcpServers": {
@@ -146,6 +146,24 @@ AI:  Created PUNT-42: Login page not loading
      }
    }
    ```
+
+   For **Claude Code**, add a `.mcp.json` in the project root (it's gitignored — do not commit API keys):
+   ```json
+   {
+     "mcpServers": {
+       "punt": {
+         "type": "stdio",
+         "command": "pnpm",
+         "args": ["--dir", "mcp", "exec", "tsx", "src/index.ts"],
+         "env": {
+           "MCP_API_KEY": "your-api-key-here"
+         }
+       }
+     }
+   }
+   ```
+
+   > **Note:** The MCP server requires the PUNT dev server (`pnpm dev`) to be running on port 3000.
 
 ### Available Operations
 

--- a/docs-site/docs/user-guide/mcp.md
+++ b/docs-site/docs/user-guide/mcp.md
@@ -92,7 +92,7 @@ Add PUNT to your MCP client's configuration. The exact location depends on your 
 }
 ```
 
-**Claude Code** (`.mcp.json` in your project):
+**Claude Code** (`.mcp.json` in the project root — gitignored, do not commit):
 
 ```json
 {
@@ -108,6 +108,10 @@ Add PUNT to your MCP client's configuration. The exact location depends on your 
   }
 }
 ```
+
+:::caution
+The `.mcp.json` file contains your API key and is gitignored. Do not commit it to version control. The MCP server also requires the PUNT dev server (`pnpm dev`) to be running on port 3000.
+:::
 
 ### Verify Connection
 

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1148,7 +1148,8 @@ export default function ProfilePage() {
                 <p className="font-medium text-zinc-300">How to configure MCP</p>
                 <p>
                   Add the following to your <code className="text-amber-400">.mcp.json</code> file
-                  to connect an AI assistant to PUNT:
+                  in the project root to connect an AI assistant to PUNT. This file is gitignored
+                  and should not be committed:
                 </p>
                 <pre className="bg-zinc-900 rounded p-2 overflow-x-auto text-zinc-300">
                   {`{
@@ -1166,8 +1167,7 @@ export default function ProfilePage() {
                 </pre>
                 <p>
                   Replace <code className="text-amber-400">your-api-key-here</code> with the
-                  generated key. The MCP server enables AI assistants to create, update, and manage
-                  tickets conversationally.
+                  generated key. The PUNT dev server must be running for the MCP server to work.
                 </p>
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary
- Gitignored `.mcp.json` and removed it from git tracking (contains API keys)
- Updated MCP setup instructions in CLAUDE.md, README, docs-site guide, and profile page UI to note the file is gitignored and the dev server must be running
- The missing `env.MCP_API_KEY` was why MCP tools consistently failed across sessions

## Test plan
- [x] `.mcp.json` no longer appears in `git status`
- [x] New Claude Code sessions can use MCP tools when `.mcp.json` has the API key and dev server is running
- [x] Profile page MCP instructions mention gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)