### PR TITLE
fix(mcp): show dash instead of 1 for null story points (PUNT-75)

### DIFF
--- a/mcp/src/tools/sprints.ts
+++ b/mcp/src/tools/sprints.ts
@@ -51,7 +51,7 @@ function formatSprint(sprint: SprintData, projectKey?: string): string {
       const key = projectKey ? `${projectKey}-${t.number}` : `#${t.number}`
       const title = t.title.length > 35 ? `${t.title.slice(0, 35)}...` : t.title
       const assignee = t.assignee?.name || '-'
-      const points = t.storyPoints ?? 1
+      const points = t.storyPoints ?? '-'
 
       lines.push(
         `| ${key} | ${title} | ${t.type} | ${t.priority} | ${t.column.name} | ${assignee} | ${points} |`,

--- a/mcp/src/tools/tickets.ts
+++ b/mcp/src/tools/tickets.ts
@@ -95,7 +95,7 @@ function formatTicketList(tickets: TicketData[], projectKey?: string): string {
     const title = t.title.length > 45 ? `${t.title.slice(0, 45)}...` : t.title
     const sprint = t.sprint?.name || '-'
     const assignee = t.assignee?.name || '-'
-    const points = t.storyPoints ?? 1
+    const points = t.storyPoints ?? '-'
 
     lines.push(
       `| ${key} | ${title} | ${t.type} | ${t.priority} | ${t.column.name} | ${sprint} | ${assignee} | ${points} |`,


### PR DESCRIPTION
## Summary
- Fixed `formatTicketList` in `mcp/src/tools/tickets.ts` and `mcp/src/tools/sprints.ts` defaulting null story points to `1` instead of `'-'`
- This aligns with the existing pattern in `mcp/src/utils.ts` which already correctly uses `?? '-'`

## Test plan
- [x] Run `list_tickets` via MCP for a project with tickets that have no story points assigned and verify they show `-` instead of `1`
- [x] Run `get_sprint` via MCP for a sprint containing tickets without story points and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)