### PR TITLE
fix(board): correct spacing in configure columns drawer (PUNT-65)

### DIFF
--- a/src/components/backlog/column-config.tsx
+++ b/src/components/backlog/column-config.tsx
@@ -127,15 +127,15 @@ export function ColumnConfig() {
 
   return (
     <Sheet open={columnConfigOpen} onOpenChange={setColumnConfigOpen}>
-      <SheetContent className="w-[400px] border-zinc-800 bg-zinc-950 sm:max-w-[400px]">
-        <SheetHeader>
+      <SheetContent className="w-[400px] border-zinc-800 bg-zinc-950 p-0 sm:max-w-[400px]">
+        <SheetHeader className="border-b border-zinc-800 px-4 pr-14 py-4">
           <SheetTitle>Configure Columns</SheetTitle>
           <SheetDescription>
             Drag to reorder columns. Toggle visibility with checkboxes.
           </SheetDescription>
         </SheetHeader>
 
-        <div className="mt-6 flex flex-col gap-4">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 px-4 pb-4">
           {/* Stats */}
           <div className="flex items-center justify-between text-sm text-zinc-400">
             <span>
@@ -160,7 +160,7 @@ export function ColumnConfig() {
             onDragEnd={handleDragEnd}
           >
             <SortableContext items={columnIds} strategy={verticalListSortingStrategy}>
-              <div className="flex flex-col gap-2">
+              <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
                 {columns.map((column) => (
                   <SortableColumnItem
                     key={column.id}


### PR DESCRIPTION
## Summary
- Reset SheetContent padding to `p-0` and manage padding per-section for consistent alignment with other drawers
- Added `border-b` separator and `pr-14` to SheetHeader to visually separate the header and prevent title/close-button overlap
- Removed excessive `mt-6` top margin on body content, replaced with proper `px-4 pb-4` padding aligned with the header
- Added `overflow-y-auto`, `min-h-0`, and `flex-1` to the column list container so it scrolls when many columns are present

## Test plan
- [x] Open a project's backlog view
- [x] Click the "Configure Columns" button to open the drawer
- [x] Verify the header has a visible bottom border separating it from the body
- [x] Verify horizontal padding is consistent between header text and body content
- [x] Verify the column list scrolls properly if the drawer is short or many columns exist
- [x] Verify the "Show All" / "Minimal" buttons at the bottom have proper bottom padding
- [x] Verify the close button does not overlap the title text

🤖 Generated with [Claude Code](https://claude.com/claude-code)