### PR TITLE
fix(ui): update keyboard shortcuts modal with current bindings (PUNT-71)

### DIFF
--- a/src/components/keyboard-shortcuts.tsx
+++ b/src/components/keyboard-shortcuts.tsx
@@ -2725,6 +2725,19 @@ export function KeyboardShortcuts() {
             </DialogDescription>
           </DialogHeader>
           <div className="mt-4 space-y-6">
+            {/* Navigation */}
+            <div>
+              <h3 className="text-sm font-semibold text-zinc-200 mb-2">Navigation</h3>
+              <div className="space-y-2 text-sm text-zinc-400">
+                <div className="flex items-center justify-between">
+                  <span>Search tickets</span>
+                  <kbd className="px-2 py-1 text-xs font-semibold text-zinc-300 bg-zinc-800 border border-zinc-700 rounded">
+                    Ctrl / Cmd + K
+                  </kbd>
+                </div>
+              </div>
+            </div>
+
             {/* Selection */}
             <div>
               <h3 className="text-sm font-semibold text-zinc-200 mb-2">Selection</h3>
@@ -2770,6 +2783,25 @@ export function KeyboardShortcuts() {
                   <span>Delete selected tickets</span>
                   <kbd className="px-2 py-1 text-xs font-semibold text-zinc-300 bg-zinc-800 border border-zinc-700 rounded">
                     Delete
+                  </kbd>
+                </div>
+              </div>
+            </div>
+
+            {/* Move Tickets */}
+            <div>
+              <h3 className="text-sm font-semibold text-zinc-200 mb-2">Move Tickets</h3>
+              <div className="space-y-2 text-sm text-zinc-400">
+                <div className="flex items-center justify-between">
+                  <span>Reorder selected tickets up/down</span>
+                  <kbd className="px-2 py-1 text-xs font-semibold text-zinc-300 bg-zinc-800 border border-zinc-700 rounded">
+                    Arrow Up / Down
+                  </kbd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Move selected tickets between columns</span>
+                  <kbd className="px-2 py-1 text-xs font-semibold text-zinc-300 bg-zinc-800 border border-zinc-700 rounded">
+                    Arrow Left / Right
                   </kbd>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Added **Navigation** section with `Ctrl/Cmd + K` shortcut for ticket search (command palette)
- Added **Move Tickets** section with `Arrow Up/Down` for reordering selected tickets within a column and `Arrow Left/Right` for moving selected tickets between columns
- All existing shortcuts (Selection, Actions, Undo/Redo, Help) verified to be accurate and kept unchanged

## Test plan
- [x] Press `?` to open the keyboard shortcuts modal
- [x] Verify the new **Navigation** section appears at the top with `Ctrl/Cmd + K`
- [x] Verify the new **Move Tickets** section appears between **Actions** and **Undo/Redo**
- [x] Verify `Ctrl/Cmd + K` opens ticket search
- [x] Select a ticket, verify arrow keys reorder (up/down) and move between columns (left/right)

🤖 Generated with [Claude Code](https://claude.com/claude-code)