### PR TITLE
fix(board): improve edit column modal UX (PUNT-72, PUNT-73, PUNT-74)

### DIFF
--- a/src/app/api/projects/[projectId]/labels/route.ts
+++ b/src/app/api/projects/[projectId]/labels/route.ts
@@ -6,29 +6,11 @@ import {
   requirePermission,
   requireProjectByKey,
 } from '@/lib/auth-helpers'
+import { LABEL_COLORS } from '@/lib/constants'
 import { db } from '@/lib/db'
 import { projectEvents } from '@/lib/events'
 import { PERMISSIONS } from '@/lib/permissions'
 import { LABEL_SELECT } from '@/lib/prisma-selects'
-
-// Predefined colors for auto-assignment when creating labels
-const LABEL_COLORS = [
-  '#ec4899', // pink
-  '#06b6d4', // cyan
-  '#8b5cf6', // purple
-  '#f59e0b', // amber
-  '#ef4444', // red
-  '#14b8a6', // teal
-  '#64748b', // slate
-  '#22c55e', // green
-  '#eab308', // yellow
-  '#dc2626', // red-600
-  '#a855f7', // purple-500
-  '#78716c', // stone
-  '#3b82f6', // blue
-  '#16a34a', // green-600
-  '#f97316', // orange
-]
 
 const createLabelSchema = z.object({
   name: z.string().min(1).max(50).trim(),

--- a/src/components/board/column-menu.tsx
+++ b/src/components/board/column-menu.tsx
@@ -49,7 +49,6 @@ import {
   getColumnIcon,
   resolveColumnColor,
   resolveColumnIconName,
-  TAILWIND_TO_HEX,
 } from '@/lib/status-icons'
 import { showUndoRedoToast } from '@/lib/undo-toast'
 import { cn } from '@/lib/utils'
@@ -57,9 +56,6 @@ import { useBoardStore } from '@/stores/board-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useUndoStore } from '@/stores/undo-store'
 import type { ColumnWithTickets } from '@/types'
-
-// Column auto-detected colors to include as extra presets in the color picker
-const COLUMN_COLOR_PRESETS = [...new Set(Object.values(TAILWIND_TO_HEX))]
 
 interface ColumnMenuProps {
   column: ColumnWithTickets
@@ -646,7 +642,6 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
                     onColorChange={setColorValue}
                     onApply={setColorValue}
                     isDisabled={renameLoading}
-                    extraPresets={COLUMN_COLOR_PRESETS}
                   />
                   {/* PUNT-74: Ghost button style for reset */}
                   <button
@@ -670,7 +665,6 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
                     onColorChange={setColorValue}
                     onApply={setColorValue}
                     isDisabled={renameLoading}
-                    extraPresets={COLUMN_COLOR_PRESETS}
                   />
                 </>
               )}

--- a/src/components/projects/settings/labels-tab.tsx
+++ b/src/components/projects/settings/labels-tab.tsx
@@ -24,27 +24,9 @@ import {
   useUpdateLabel,
 } from '@/hooks/queries/use-labels'
 import { useHasPermission } from '@/hooks/use-permissions'
+import { LABEL_COLORS } from '@/lib/constants'
 import { PERMISSIONS } from '@/lib/permissions'
 import { cn } from '@/lib/utils'
-
-// Predefined color palette matching the backend LABEL_COLORS
-const LABEL_COLORS = [
-  '#ec4899', // pink
-  '#06b6d4', // cyan
-  '#8b5cf6', // purple
-  '#f59e0b', // amber
-  '#ef4444', // red
-  '#14b8a6', // teal
-  '#64748b', // slate
-  '#22c55e', // green
-  '#eab308', // yellow
-  '#dc2626', // red-600
-  '#a855f7', // purple-500
-  '#78716c', // stone
-  '#3b82f6', // blue
-  '#16a34a', // green-600
-  '#f97316', // orange
-]
 
 interface LabelsTabProps {
   projectId: string

--- a/src/components/tickets/label-select.tsx
+++ b/src/components/tickets/label-select.tsx
@@ -25,28 +25,10 @@ import {
 } from '@/components/ui/command'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { LABEL_COLORS } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { LabelSummary } from '@/types'
-
-// Predefined color palette matching the backend LABEL_COLORS
-const LABEL_COLORS = [
-  '#ec4899', // pink
-  '#06b6d4', // cyan
-  '#8b5cf6', // purple
-  '#f59e0b', // amber
-  '#ef4444', // red
-  '#14b8a6', // teal
-  '#64748b', // slate
-  '#22c55e', // green
-  '#eab308', // yellow
-  '#dc2626', // red-600
-  '#a855f7', // purple-500
-  '#78716c', // stone
-  '#3b82f6', // blue
-  '#16a34a', // green-600
-  '#f97316', // orange
-]
 
 interface LabelSelectProps {
   value: string[]

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,5 +2,29 @@
  * Shared constants used across the application.
  */
 
-// This file is intentionally minimal.
-// Add shared constants here as needed.
+/**
+ * Unified color palette for labels, column icons, and color pickers.
+ * Ordered by hue (red → pink → purple → blue → cyan → green → yellow → orange → grey).
+ * Includes all TAILWIND_TO_HEX values so column auto-detected colors always appear in presets.
+ */
+export const LABEL_COLORS = [
+  '#ef4444', // red
+  '#f87171', // coral
+  '#ec4899', // pink
+  '#e879f9', // fuchsia
+  '#d8b4fe', // lavender
+  '#a855f7', // purple
+  '#818cf8', // indigo
+  '#3b82f6', // blue
+  '#60a5fa', // sky blue
+  '#93c5fd', // light blue
+  '#67e8f9', // cyan
+  '#14b8a6', // teal
+  '#34d399', // emerald
+  '#4ade80', // green
+  '#a3e635', // lime
+  '#fde047', // yellow
+  '#fbbf24', // amber
+  '#fb923c', // orange
+  '#a1a1aa', // grey
+]

--- a/src/lib/status-icons.ts
+++ b/src/lib/status-icons.ts
@@ -105,21 +105,22 @@ export function resolveColumnIconName(
 }
 
 // Map Tailwind text color classes to their actual hex values for the color picker.
+// Near-duplicate shades are consolidated to the same hex so they share one swatch.
 export const TAILWIND_TO_HEX: Record<string, string> = {
   'text-zinc-400': '#a1a1aa',
-  'text-zinc-500': '#71717a',
+  'text-zinc-500': '#a1a1aa', // consolidated with zinc-400
   'text-blue-300': '#93c5fd',
   'text-blue-400': '#60a5fa',
   'text-cyan-300': '#67e8f9',
-  'text-amber-300': '#fcd34d',
+  'text-amber-300': '#fbbf24', // consolidated with amber-400
   'text-amber-400': '#fbbf24',
   'text-purple-300': '#d8b4fe',
   'text-emerald-400': '#34d399',
-  'text-red-300': '#fca5a5',
+  'text-red-300': '#f87171', // consolidated with red-400
   'text-red-400': '#f87171',
   'text-green-400': '#4ade80',
   'text-yellow-300': '#fde047',
-  'text-yellow-400': '#facc15',
+  'text-yellow-400': '#fde047', // consolidated with yellow-300
   'text-orange-400': '#fb923c',
   'text-indigo-400': '#818cf8',
 }


### PR DESCRIPTION
## Summary

- **PUNT-72**: Replace `AlertDialog` with `Dialog` for the edit column modal, which provides a built-in close button (X) in the top-right corner and click-outside-to-dismiss behavior
- **PUNT-73**: Fix the color preset swatch defaulting to `#3b82f6` (blue) when no custom color is set. Now uses `resolveColumnColor()` to resolve the column's actual auto-detected Tailwind color to hex, so the correct preset swatch is highlighted (or none if no match)
- **PUNT-74**: Upgrade the "Reset to default color" button from a plain text link to a subtle ghost button with a `RotateCcw` icon, border, and hover states that fit the dark theme

## Test plan

- [x] Open the edit column modal and verify the X close button appears in the top-right corner
- [x] Click outside the edit column modal and verify it dismisses
- [x] Open edit modal for a column named "In Progress" (amber auto-color) and verify the amber preset swatch is highlighted, not blue
- [x] Open edit modal for a column named "Done" (emerald auto-color) and verify the emerald preset is highlighted
- [x] Open edit modal for a column with a custom color set and verify the "Reset to default color" button has a ghost button style with the RotateCcw icon
- [x] Click "Reset to default color" and verify it clears the custom color correctly
- [x] Verify the delete column dialog still uses AlertDialog (no close button, no click-outside dismiss)
- [x] Verify saving changes (rename, icon change, color change) still works correctly with undo/redo

🤖 Generated with [Claude Code](https://claude.com/claude-code)