### PR TITLE
docs: add MCP workflow prerequisites and recommended tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,6 +442,11 @@ PUNT includes an MCP (Model Context Protocol) server for conversational ticket m
 - `MCP_API_KEY` - User's API key (from `/api/me/mcp-key`)
 - `MCP_BASE_URL` - PUNT server URL (default: `http://localhost:3000`)
 
+**Prerequisites for full workflow:**
+- `pnpm dev` running on port 3000 (MCP calls the PUNT API)
+- [GitHub CLI (`gh`)](https://cli.github.com/) authenticated — used for PR creation, merging, and issue management
+- Git configured for the repository
+
 **Running the MCP server:**
 ```bash
 cd mcp && pnpm install  # First time only

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ PUNT is a lightweight, local-first issue tracking system for teams who want the 
 - Node.js 20.9+
 - pnpm 9+
 
+**Recommended for MCP / Claude Code workflow:**
+- [GitHub CLI (`gh`)](https://cli.github.com/) — for PR creation, merging, and issue management from the terminal
+
 ## Quick Start
 
 ```bash

--- a/docs-site/docs/user-guide/mcp.md
+++ b/docs-site/docs/user-guide/mcp.md
@@ -44,9 +44,17 @@ AI:  Started sprint "Sprint 3" with 12 tickets
 
 ### Prerequisites
 
-- PUNT installed and running
+- PUNT installed and running (`pnpm dev` on port 3000)
 - Node.js 20.9+
+- pnpm 9+
 - An MCP-compatible client (Claude Desktop, Claude Code, etc.)
+
+### Recommended Tools
+
+These are not required for basic MCP usage, but enable the full development workflow with Claude Code:
+
+- **[GitHub CLI (`gh`)](https://cli.github.com/)** — Required for creating PRs, merging, and managing issues from the terminal. Claude Code uses `gh` for all GitHub operations.
+- **[Git](https://git-scm.com/)** — For branch management and committing changes via Claude Code.
 
 ### Install Dependencies
 


### PR DESCRIPTION
## Summary
- Add `gh` (GitHub CLI) as recommended tool in README, CLAUDE.md, and docs-site MCP guide
- Document `pnpm dev` and Git as prerequisites for the full MCP + Claude Code workflow
- Add "Recommended Tools" section to docs-site MCP prerequisites

## Test plan
- [x] Documentation-only changes across 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)