### PR TITLE
chore(repo): add branch cleanup convention after PR merge (PUNT-87)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,6 +484,11 @@ The `.mcp.json` file lives in the project root but is **gitignored** because it 
 
 **Commit messages:** Same convention as PR titles when tied to a ticket.
 
+**Branch cleanup after merge:** GitHub is configured to auto-delete remote branches when a PR is merged (`delete_branch_on_merge` enabled). After merging, clean up the local branch:
+```bash
+git checkout main && git pull && git branch -d <branch-name>
+```
+
 ### Debugging
 
 - Logger: `logger.debug()`, `logger.info()`, `logger.warn()`, `logger.error()`, `logger.measure()`


### PR DESCRIPTION
## Summary
- Enabled GitHub's `delete_branch_on_merge` setting to auto-delete remote branches after PR merge
- Added "Branch cleanup after merge" documentation to the Branch & PR Naming Convention section in CLAUDE.md, documenting the auto-delete behavior and the local branch cleanup command

## Test plan
- [x] Verify `delete_branch_on_merge` is enabled: `gh api repos/{owner}/{repo} --jq '.delete_branch_on_merge'` returns `true`
- [x] Verify CLAUDE.md renders correctly with the new subsection
- [x] Merge a test PR and confirm the remote branch is auto-deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)