### PR TITLE
feat(labels): redesign labels settings with side-by-side editor layout (PUNT-81)

### DIFF
--- a/src/components/projects/settings/labels-tab.tsx
+++ b/src/components/projects/settings/labels-tab.tsx
@@ -95,34 +95,25 @@ export function LabelsTab({ projectId }: LabelsTabProps) {
     setTimeout(() => nameInputRef.current?.focus(), 50)
   }, [labels?.length])
 
-  // Check if the editor form has changes
-  const checkForChanges = useCallback(
-    (name: string, color: string) => {
-      if (isCreating) {
-        return name.trim() !== ''
-      }
-      if (!selectedLabel) return false
-      return name !== selectedLabel.name || color !== selectedLabel.color
-    },
-    [isCreating, selectedLabel],
-  )
+  // Derive hasChanges reactively from current state
+  useEffect(() => {
+    if (isCreating) {
+      setHasChanges(editName.trim() !== '')
+    } else if (selectedLabel) {
+      setHasChanges(editName !== selectedLabel.name || editColor !== selectedLabel.color)
+    } else {
+      setHasChanges(false)
+    }
+  }, [editName, editColor, isCreating, selectedLabel])
 
   // Handle field changes
-  const handleNameChange = useCallback(
-    (value: string) => {
-      setEditName(value)
-      setHasChanges(checkForChanges(value, editColor))
-    },
-    [editColor, checkForChanges],
-  )
+  const handleNameChange = useCallback((value: string) => {
+    setEditName(value)
+  }, [])
 
-  const handleColorChange = useCallback(
-    (value: string) => {
-      setEditColor(value)
-      setHasChanges(checkForChanges(editName, value))
-    },
-    [editName, checkForChanges],
-  )
+  const handleColorChange = useCallback((value: string) => {
+    setEditColor(value)
+  }, [])
 
   // Save changes (create or update)
   const handleSave = useCallback(async () => {


### PR DESCRIPTION
## Summary
- Redesigned the labels settings page from a flat list with inline editing to a side-by-side layout (left panel: scrollable label list, right panel: label editor), mirroring the roles tab pattern
- Added a full color picker with preset palette swatches, hex color spectrum picker, custom hex input, and saved colors support via the shared `ColorPickerBody` component
- Added a large live preview badge showing how the label will appear on tickets
- Added inline name editing in the editor header with the same underline + pencil icon pattern used by the roles tab
- Added "Create new label" flow with a + button in the list header and a highlighted placeholder in the label list
- Added "Danger Zone" section with contextual ticket count warning and delete confirmation dialog
- Added sticky save/cancel footer bar that appears when changes are detected

## Test plan
- [x] Navigate to Project Settings > Labels tab
- [x] Verify the side-by-side layout displays correctly (label list on left, editor on right)
- [x] Click different labels in the left panel and verify the editor updates
- [x] Edit a label name using the inline input in the editor header
- [x] Change a label color using the preset palette swatches
- [x] Change a label color using the hex spectrum picker
- [x] Enter a custom hex color value and verify live preview updates
- [x] Save custom colors and verify they appear in the "Saved" section
- [x] Verify the live preview badge updates in real-time as name/color change
- [x] Click the + button to create a new label and verify the create flow
- [x] Delete a label and verify confirmation dialog shows ticket count warning
- [x] Verify the save/cancel footer bar appears only when there are unsaved changes
- [x] Verify Enter key saves changes and Escape key cancels
- [x] Verify the component works correctly without "Manage labels" permission (read-only mode)
- [x] Verify empty state displays correctly when no labels exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)