### PR TITLE
fix(ci): update biome schema to 2.3.13 and fix all lint errors

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/mcp/src/tools/labels.ts
+++ b/mcp/src/tools/labels.ts
@@ -65,7 +65,10 @@ export function registerLabelTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
-      const label = result.data!
+      const label = result.data
+      if (!label) {
+        return errorResponse('Failed to create label: no data returned')
+      }
       return textResponse(
         `Created label "${label.name}" (${label.color}) in ${projectKey.toUpperCase()}`,
       )

--- a/mcp/src/tools/members.ts
+++ b/mcp/src/tools/members.ts
@@ -2,9 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import {
   addMember as apiAddMember,
-  listMembers as apiListMembers,
-  listRoles as apiListRoles,
-  listUsers as apiListUsers,
   removeMember as apiRemoveMember,
   updateMemberRole as apiUpdateMemberRole,
 } from '../api-client.js'

--- a/mcp/src/tools/projects.ts
+++ b/mcp/src/tools/projects.ts
@@ -108,6 +108,7 @@ export function registerProjectTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       return textResponse(formatProject(result.data!))
     },
   )
@@ -134,6 +135,7 @@ export function registerProjectTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       const project = result.data!
       return textResponse(`Created project ${project.key}\n\n${formatProject(project)}`)
     },
@@ -164,6 +166,7 @@ export function registerProjectTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       const project = result.data!
       return textResponse(`Updated project ${project.key}\n\n${formatProject(project)}`)
     },
@@ -188,6 +191,7 @@ export function registerProjectTools(server: McpServer) {
         return errorResponse(projectResult.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       const project = projectResult.data!
       const result = await deleteProject(key)
       if (result.error) {

--- a/mcp/src/tools/sprints.ts
+++ b/mcp/src/tools/sprints.ts
@@ -145,6 +145,7 @@ export function registerSprintTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       return textResponse(formatSprint(result.data!, projectKey.toUpperCase()))
     },
   )
@@ -174,6 +175,7 @@ export function registerSprintTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       const sprint = result.data!
       return textResponse(`Created sprint "${sprint.name}"\n\n${formatSprint(sprint)}`)
     },
@@ -223,6 +225,7 @@ export function registerSprintTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       const updated = result.data!
       return textResponse(`Updated sprint "${updated.name}"\n\n${formatSprint(updated)}`)
     },
@@ -262,6 +265,7 @@ export function registerSprintTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       const started = result.data!
       const ticketCount = started.tickets?.length ?? 0
       return textResponse(

--- a/mcp/src/tools/tickets.ts
+++ b/mcp/src/tools/tickets.ts
@@ -369,6 +369,7 @@ export function registerTicketTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       const ticket = result.data!
       const upperKey = projectKey.toUpperCase()
       return textResponse(
@@ -535,6 +536,7 @@ export function registerTicketTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       const ticket = result.data!
       return textResponse(
         `Updated ticket ${key}\n\n${formatTicket(ticket, parsed.projectKey.toUpperCase())}`,
@@ -621,6 +623,7 @@ export function registerTicketTools(server: McpServer) {
         return errorResponse(result.error)
       }
 
+      // biome-ignore lint/style/noNonNullAssertion: data is guaranteed present when no error
       const ticket = result.data!
       return textResponse(
         `Moved ${key}: ${changes.join(', ')}\n\n${formatTicket(ticket, parsed.projectKey.toUpperCase())}`,

--- a/mcp/src/utils.ts
+++ b/mcp/src/utils.ts
@@ -95,7 +95,7 @@ export function formatTicketList(
 
   for (const ticket of tickets) {
     const key = `${projectKey ?? ticket.project?.key ?? 'UNKNOWN'}-${ticket.number}`
-    const title = ticket.title.length > 50 ? ticket.title.substring(0, 47) + '...' : ticket.title
+    const title = ticket.title.length > 50 ? `${ticket.title.substring(0, 47)}...` : ticket.title
     const status = ticket.column?.name ?? '-'
     const sprint = ticket.sprint?.name ?? '-'
     const assignee = ticket.assignee?.name ?? '-'
@@ -173,7 +173,7 @@ export function formatProjectList(
   for (const project of projects) {
     const desc = project.description
       ? project.description.length > 40
-        ? project.description.substring(0, 37) + '...'
+        ? `${project.description.substring(0, 37)}...`
         : project.description
       : '-'
     const tickets = project._count?.tickets ?? '-'
@@ -252,7 +252,7 @@ export function formatSprintList(
   for (const sprint of sprints) {
     const goal = sprint.goal
       ? sprint.goal.length > 30
-        ? sprint.goal.substring(0, 27) + '...'
+        ? `${sprint.goal.substring(0, 27)}...`
         : sprint.goal
       : '-'
     const start = sprint.startDate ? formatDate(sprint.startDate) : '-'

--- a/prisma/seed-sprint-test.ts
+++ b/prisma/seed-sprint-test.ts
@@ -116,8 +116,11 @@ async function main() {
     roleMap.set(roleConfig.name, role.id)
   }
 
+  // biome-ignore lint/style/noNonNullAssertion: roles are guaranteed to exist from upsert above
   const ownerRoleId = roleMap.get('Owner')!
+  // biome-ignore lint/style/noNonNullAssertion: roles are guaranteed to exist from upsert above
   const adminRoleId = roleMap.get('Admin')!
+  // biome-ignore lint/style/noNonNullAssertion: roles are guaranteed to exist from upsert above
   const memberRoleId = roleMap.get('Member')!
 
   // Add users as project members
@@ -186,9 +189,13 @@ async function main() {
     console.log('\nUsing existing columns')
   }
 
+  // biome-ignore lint/style/noNonNullAssertion: columns are guaranteed to exist from creation above
   const todoCol = columns.find((c) => c.name === 'To Do')!
+  // biome-ignore lint/style/noNonNullAssertion: columns are guaranteed to exist from creation above
   const inProgressCol = columns.find((c) => c.name === 'In Progress')!
+  // biome-ignore lint/style/noNonNullAssertion: columns are guaranteed to exist from creation above
   const reviewCol = columns.find((c) => c.name === 'Review')!
+  // biome-ignore lint/style/noNonNullAssertion: columns are guaranteed to exist from creation above
   const doneCol = columns.find((c) => c.name === 'Done')!
 
   // Create labels

--- a/scripts/test-permissions-direct.ts
+++ b/scripts/test-permissions-direct.ts
@@ -81,7 +81,7 @@ async function main() {
   test('Non-member is not member', false, await isMember('non-existent-user-id', projectId))
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('2. PROJECT SETTINGS PERMISSION')
   console.log('='.repeat(60))
   // ================================
@@ -103,7 +103,7 @@ async function main() {
   )
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('3. PROJECT DELETE PERMISSION')
   console.log('='.repeat(60))
   // ================================
@@ -125,7 +125,7 @@ async function main() {
   )
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('4. TICKET PERMISSIONS')
   console.log('='.repeat(60))
   // ================================
@@ -163,7 +163,7 @@ async function main() {
   )
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('5. SPRINT PERMISSIONS')
   console.log('='.repeat(60))
   // ================================
@@ -185,7 +185,7 @@ async function main() {
   )
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('6. LABEL PERMISSIONS')
   console.log('='.repeat(60))
   // ================================
@@ -207,7 +207,7 @@ async function main() {
   )
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('7. BOARD PERMISSIONS')
   console.log('='.repeat(60))
   // ================================
@@ -229,7 +229,7 @@ async function main() {
   )
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('8. MEMBER PERMISSIONS')
   console.log('='.repeat(60))
   // ================================
@@ -278,7 +278,7 @@ async function main() {
   )
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('9. MODERATION PERMISSIONS')
   console.log('='.repeat(60))
   // ================================
@@ -316,7 +316,7 @@ async function main() {
   )
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('10. SYSTEM ADMIN BYPASS')
   console.log('='.repeat(60))
   // ================================
@@ -335,7 +335,7 @@ async function main() {
 
   // System admin on a project they're NOT a member of
   const tempProject = await db.project.create({
-    data: { name: 'Temp Test Project', key: 'TMP' + Date.now() },
+    data: { name: 'Temp Test Project', key: `TMP${Date.now()}` },
   })
 
   test(
@@ -353,7 +353,7 @@ async function main() {
   await db.project.delete({ where: { id: tempProject.id } })
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('11. EFFECTIVE PERMISSIONS COUNT')
   console.log('='.repeat(60))
   // ================================
@@ -375,7 +375,7 @@ async function main() {
   test('Owner has 13 permissions (all)', true, ownerPerms.size === 13)
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('12. MEMBER MANAGEMENT HIERARCHY')
   console.log('='.repeat(60))
   // ================================
@@ -434,7 +434,7 @@ async function main() {
   }
 
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('13. OWNERSHIP-BASED PERMISSIONS')
   console.log('='.repeat(60))
   // ================================
@@ -535,7 +535,7 @@ async function main() {
   // ================================
   // SUMMARY
   // ================================
-  console.log('\n' + '='.repeat(60))
+  console.log(`\n${'='.repeat(60)}`)
   console.log('SUMMARY')
   console.log('='.repeat(60))
 

--- a/src/__tests__/fuzz/api/register.fuzz.test.ts
+++ b/src/__tests__/fuzz/api/register.fuzz.test.ts
@@ -6,7 +6,7 @@
 import * as fc from 'fast-check'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { invalidUsername, usernameArb, validUsername } from '../arbitraries'
+import { invalidUsername, validUsername } from '../arbitraries'
 import { emailLike, maliciousString, passwordString } from '../arbitraries/primitives'
 import { FUZZ_CONFIG } from '../setup'
 

--- a/src/__tests__/fuzz/api/validation.fuzz.test.ts
+++ b/src/__tests__/fuzz/api/validation.fuzz.test.ts
@@ -111,7 +111,7 @@ describe('Generic API Validation Fuzz Tests', () => {
 
   describe('String constraints', () => {
     const titleSchema = z.string().min(1).max(500)
-    const descriptionSchema = z.string().max(10000).optional()
+    const _descriptionSchema = z.string().max(10000).optional()
     const projectKeySchema = z
       .string()
       .min(1)

--- a/src/__tests__/fuzz/arbitraries/file-upload.ts
+++ b/src/__tests__/fuzz/arbitraries/file-upload.ts
@@ -122,7 +122,7 @@ export const fileName = fc.oneof(
     '文件名.txt',
   ),
   // Edge cases
-  fc.constantFrom('', '.', '..', '...', '.hidden', 'a' + 'a'.repeat(300)),
+  fc.constantFrom('', '.', '..', '...', '.hidden', `a${'a'.repeat(300)}`),
 )
 
 /**

--- a/src/__tests__/fuzz/stores/board-store.fuzz.test.ts
+++ b/src/__tests__/fuzz/stores/board-store.fuzz.test.ts
@@ -6,8 +6,8 @@
 import * as fc from 'fast-check'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { useBoardStore } from '@/stores/board-store'
-import type { ColumnWithTickets, TicketWithRelations } from '@/types'
-import { batchMoveOperation, columnsArray, moveOperation } from '../arbitraries'
+import type { TicketWithRelations } from '@/types'
+import { columnsArray } from '../arbitraries'
 import { ticketBase } from '../arbitraries/ticket'
 import { FUZZ_CONFIG } from '../setup'
 

--- a/src/__tests__/fuzz/stores/hydration.fuzz.test.ts
+++ b/src/__tests__/fuzz/stores/hydration.fuzz.test.ts
@@ -247,7 +247,7 @@ describe('Hydration Validation Fuzz Tests', () => {
           }
 
           // Check each project's columns
-          for (const [projectId, columns] of Object.entries(corrupted)) {
+          for (const [_projectId, columns] of Object.entries(corrupted)) {
             const isValid = isValidColumns(columns)
             expect(typeof isValid).toBe('boolean')
           }

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -4,7 +4,7 @@
 
 import '@testing-library/jest-dom'
 import { cleanup } from '@testing-library/react'
-import { afterEach, beforeAll, vi } from 'vitest'
+import { afterEach, vi } from 'vitest'
 
 // ============================================================================
 // CRITICAL SAFETY CHECK: Prevent tests from using production database

--- a/src/app/(app)/preferences/page.tsx
+++ b/src/app/(app)/preferences/page.tsx
@@ -251,7 +251,7 @@ export default function PreferencesPage() {
               </div>
               <Checkbox
                 id="sidebar-admin"
-                checked={sidebarExpandedSections['admin'] ?? false}
+                checked={sidebarExpandedSections.admin ?? false}
                 onCheckedChange={(checked) => setSidebarSectionExpanded('admin', checked === true)}
                 className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
               />

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -54,7 +54,6 @@ export default function ProfilePage() {
   const isDemo = isDemoMode()
 
   // In demo mode, we skip useSession entirely
-  // biome-ignore lint/correctness/useHookAtTopLevel: isDemoMode is build-time constant
   const {
     data: session,
     status,

--- a/src/app/api/projects/[projectId]/tickets/__tests__/permissions.test.ts
+++ b/src/app/api/projects/[projectId]/tickets/__tests__/permissions.test.ts
@@ -63,7 +63,7 @@ const mockDb = vi.mocked(db)
 const mockRequireAuth = vi.mocked(requireAuth)
 const mockHasPermission = vi.mocked(hasPermission)
 const mockIsMember = vi.mocked(isMember)
-const mockGetEffectivePermissions = vi.mocked(getEffectivePermissions)
+const _mockGetEffectivePermissions = vi.mocked(getEffectivePermissions)
 
 // Test data
 const TEST_USER = {
@@ -196,7 +196,8 @@ describe('Ticket API - Permission Tests', () => {
         creatorId: TEST_USER.id,
         watchers: [],
       }
-      ;(mockDb.$transaction as any).mockImplementation(async (fn: any) => {
+      // biome-ignore lint/suspicious/noExplicitAny: mock typing
+      ;(mockDb.$transaction as any).mockImplementation(async (_fn: any) => {
         // Return the ticket directly since the transaction returns it
         return createdTicket
       })
@@ -228,7 +229,8 @@ describe('Ticket API - Permission Tests', () => {
         creatorId: ADMIN_USER.id,
         watchers: [],
       }
-      ;(mockDb.$transaction as any).mockImplementation(async (fn: any) => {
+      // biome-ignore lint/suspicious/noExplicitAny: mock typing
+      ;(mockDb.$transaction as any).mockImplementation(async (_fn: any) => {
         return createdTicket
       })
 

--- a/src/components/board/ticket-context-menu.tsx
+++ b/src/components/board/ticket-context-menu.tsx
@@ -345,7 +345,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
         </div>
       )
 
-    const uiState = useUIStore.getState ? useUIStore.getState() : uiStore
+    const _uiState = useUIStore.getState ? useUIStore.getState() : uiStore
     const showUndo = useSettingsStore.getState().showUndoButtons ?? true
     const boardStateMove = useBoardStore.getState ? useBoardStore.getState() : board
     const toastId = showUndoRedoToast('success', {
@@ -676,7 +676,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
       toSprintId: null,
     }))
 
-    const uiState = useUIStore.getState ? useUIStore.getState() : uiStore
+    const _uiState = useUIStore.getState ? useUIStore.getState() : uiStore
     const showUndo = useSettingsStore.getState().showUndoButtons ?? true
 
     const toastId = showUndoRedoToast('success', {
@@ -818,7 +818,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
       toSprintId: targetSprint.id,
     }))
 
-    const uiState = useUIStore.getState ? useUIStore.getState() : uiStore
+    const _uiState = useUIStore.getState ? useUIStore.getState() : uiStore
     const showUndo = useSettingsStore.getState().showUndoButtons ?? true
 
     const toastId = showUndoRedoToast('success', {

--- a/src/components/layout/sidebar-content.tsx
+++ b/src/components/layout/sidebar-content.tsx
@@ -109,7 +109,7 @@ export function SidebarContent({
   const [adminExpanded, setAdminExpanded] = useState(true)
   const [projectsExpanded, setProjectsExpanded] = useState(true)
   const { sidebarExpandedSections, toggleSidebarSection } = useSettingsStore()
-  const adminSettingsExpanded = sidebarExpandedSections['admin'] ?? false
+  const adminSettingsExpanded = sidebarExpandedSections.admin ?? false
   const setAdminSettingsExpanded = useCallback(
     (v: boolean) => useSettingsStore.getState().setSidebarSectionExpanded('admin', v),
     [],

--- a/src/components/sprints/sprint-header.tsx
+++ b/src/components/sprints/sprint-header.tsx
@@ -128,7 +128,7 @@ export function SprintHeader({
   const sprintTickets = tickets.filter((t) => t.sprintId === activeSprint.id)
   const completedCount = sprintTickets.filter((t) => doneColumnIds.includes(t.columnId)).length
   const totalCount = sprintTickets.length
-  const progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0
+  const _progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0
 
   // Calculate story points
   const totalPoints = sprintTickets.reduce((sum, t) => sum + (t.storyPoints ?? 0), 0)
@@ -162,7 +162,7 @@ export function SprintHeader({
 
   // Calculate "velocity" (points per day if we had more data)
   // For now, show estimated remaining work indicator
-  const remainingPoints = totalPoints - completedPoints
+  const _remainingPoints = totalPoints - completedPoints
 
   // Color scheme: orange for expired, blue for planning, green for active
   const getColorScheme = () => {

--- a/src/components/table/__tests__/ticket-table-row.test.tsx
+++ b/src/components/table/__tests__/ticket-table-row.test.tsx
@@ -144,6 +144,7 @@ describe('TicketTableRow', () => {
       </DndWrapper>,
     )
 
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
     const row = container.querySelector('tr[data-ticket-row]')!
     fireEvent.click(row)
 
@@ -164,6 +165,7 @@ describe('TicketTableRow', () => {
       </DndWrapper>,
     )
 
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
     const row = container.querySelector('tr[data-ticket-row]')!
     fireEvent.click(row, { ctrlKey: true })
 
@@ -184,6 +186,7 @@ describe('TicketTableRow', () => {
       </DndWrapper>,
     )
 
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
     const row = container.querySelector('tr[data-ticket-row]')!
     fireEvent.click(row, { metaKey: true })
 
@@ -204,6 +207,7 @@ describe('TicketTableRow', () => {
       </DndWrapper>,
     )
 
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
     const row = container.querySelector('tr[data-ticket-row]')!
     fireEvent.click(row, { shiftKey: true })
 
@@ -262,6 +266,7 @@ describe('TicketTableRow', () => {
       </DndWrapper>,
     )
 
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
     const row = container.querySelector('tr[data-ticket-row]')!
     expect(row.className).toContain('ring-2')
   })
@@ -279,6 +284,7 @@ describe('TicketTableRow', () => {
       </DndWrapper>,
     )
 
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
     const row = container.querySelector('tr[data-ticket-row]')!
     fireEvent.keyDown(row, { key: 'Enter' })
 
@@ -299,6 +305,7 @@ describe('TicketTableRow', () => {
       </DndWrapper>,
     )
 
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
     const row = container.querySelector('tr[data-ticket-row]')!
     fireEvent.keyDown(row, { key: ' ' })
 

--- a/src/components/table/ticket-cell.tsx
+++ b/src/components/table/ticket-cell.tsx
@@ -199,11 +199,7 @@ export function TicketCell({ column, ticket, projectKey, getStatusName }: Ticket
 
     case 'startDate': {
       if (!ticket.startDate) return <span className="text-zinc-500">—</span>
-      return (
-        <span className="text-sm text-zinc-400">
-          {format(ticket.startDate, 'yyyy-MM-dd')}
-        </span>
-      )
+      return <span className="text-sm text-zinc-400">{format(ticket.startDate, 'yyyy-MM-dd')}</span>
     }
 
     case 'environment':

--- a/src/hooks/use-current-user.ts
+++ b/src/hooks/use-current-user.ts
@@ -77,7 +77,6 @@ export function useIsSystemAdmin(): { isSystemAdmin: boolean; isLoading: boolean
  */
 export function useProjectMembers(projectId?: string): UserSummary[] {
   // Demo mode: always return demo members (no API call needed)
-  // biome-ignore lint/correctness/useHookAtTopLevel: isDemoMode is build-time constant
   if (isDemoMode()) {
     return [DEMO_USER_SUMMARY, ...DEMO_TEAM_SUMMARIES]
   }

--- a/src/lib/__tests__/auth-helpers-permissions.test.ts
+++ b/src/lib/__tests__/auth-helpers-permissions.test.ts
@@ -162,6 +162,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should return true when user has "any" permission', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_ANY]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -180,6 +181,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should return true when user owns the resource and has "own" permission', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_OWN]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -198,6 +200,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should throw when user owns the resource but lacks "own" permission', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set(), // No permissions
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -216,6 +219,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should throw when user does not own resource and lacks "any" permission', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_OWN]), // Only has "own"
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -234,6 +238,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should handle null owner (legacy data)', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_ANY]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -254,6 +259,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should allow ticket creator with manage_own permission to edit', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_OWN]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -271,6 +277,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should allow ticket creator with manage_own permission to delete', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_OWN]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -288,6 +295,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should allow user with manage_any to edit any ticket', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_ANY]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -305,6 +313,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should deny non-creator with only manage_own permission', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_OWN]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -366,6 +375,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should allow moderating other comments with comments.manage_any', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.COMMENTS_MANAGE_ANY]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -400,6 +410,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should deny moderating other comments without permission', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_ANY]), // Wrong permission
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -426,6 +437,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should allow deleting other attachments with attachments.manage_any', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.ATTACHMENTS_MANAGE_ANY]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -460,6 +472,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should deny deleting other attachments without permission', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.TICKETS_MANAGE_ANY]), // Wrong permission
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -472,6 +485,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should handle null uploader (legacy data) with manage_any permission', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set([PERMISSIONS.ATTACHMENTS_MANAGE_ANY]),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })
@@ -489,6 +503,7 @@ describe('Auth Helpers - Permission Functions', () => {
     it('should deny deleting when uploader is null and no permission', async () => {
       mockGetEffectivePermissions.mockResolvedValue({
         permissions: new Set(),
+        // biome-ignore lint/suspicious/noExplicitAny: mock typing
         membership: {} as any,
         isSystemAdmin: false,
       })

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -37,7 +37,7 @@ async function getMcpUser() {
   })
 
   // Only return active users
-  if (user && user.isActive) {
+  if (user?.isActive) {
     return user
   }
 


### PR DESCRIPTION
## Summary
- Bump biome.json schema from 2.3.8 to 2.3.13 to match installed CLI version (fixes schema mismatch error)
- Fix all lint errors promoted from warnings by the schema update across 26 files
- Includes: useTemplate, noNonNullAssertion, noUnusedImports, noExplicitAny suppressions, stale biome-ignore removal

## Test plan
- [x] `pnpm lint` passes (0 errors, warnings only)
- [x] All 886 tests pass (41 test files)
- [x] CI check suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)