### PR TITLE
feat(roles): allow renaming default roles (PUNT-28)

### DIFF
--- a/src/components/projects/permissions/roles-tab.tsx
+++ b/src/components/projects/permissions/roles-tab.tsx
@@ -63,7 +63,7 @@ import { useCurrentUser } from '@/hooks/use-current-user'
 import { useHasPermission, useIsSystemAdmin } from '@/hooks/use-permissions'
 import { getTabId } from '@/hooks/use-realtime'
 import { ALL_PERMISSIONS, PERMISSIONS } from '@/lib/permissions'
-import { type DefaultRoleName, isDefaultRoleName, ROLE_PRESETS } from '@/lib/permissions/presets'
+import { type DefaultRoleName, ROLE_POSITIONS, ROLE_PRESETS } from '@/lib/permissions/presets'
 import { cn, getAvatarColor, getInitials } from '@/lib/utils'
 import {
   type BulkMemberRoleSnapshot,
@@ -159,15 +159,28 @@ export function RolesTab({ projectId }: RolesTabProps) {
     [editPermissions],
   )
 
+  // Map a default role's position to its preset name for permission lookup
+  const getPresetNameByPosition = useCallback((position: number): DefaultRoleName | null => {
+    const entry = Object.entries(ROLE_POSITIONS).find(([, pos]) => pos === position)
+    return entry ? (entry[0] as DefaultRoleName) : null
+  }, [])
+
   // Check if the selected role's permissions match the preset defaults
   const isAtDefaults = useMemo(() => {
-    const roleName = isCreating ? null : selectedRole?.name
-    if (!roleName || !isDefaultRoleName(roleName)) return true
-    const preset = ROLE_PRESETS[roleName as DefaultRoleName]
+    if (isCreating || !selectedRole?.isDefault) return true
+    const presetName = getPresetNameByPosition(selectedRole.position)
+    if (!presetName) return true
+    const preset = ROLE_PRESETS[presetName]
     return (
       editPermissions.length === preset.length && preset.every((p) => editPermissions.includes(p))
     )
-  }, [editPermissions, selectedRole?.name, isCreating])
+  }, [
+    editPermissions,
+    selectedRole?.isDefault,
+    selectedRole?.position,
+    isCreating,
+    getPresetNameByPosition,
+  ])
 
   // Get members for the selected role
   const roleMembers = useMemo(() => {
@@ -643,7 +656,7 @@ export function RolesTab({ projectId }: RolesTabProps) {
       } else if (selectedRole) {
         await updateRole.mutateAsync({
           roleId: selectedRole.id,
-          name: selectedRole.isDefault ? undefined : editName.trim(),
+          name: editName.trim(),
           color: editColor,
           description: editDescription.trim() || null,
           permissions: editPermissions,
@@ -857,7 +870,7 @@ export function RolesTab({ projectId }: RolesTabProps) {
               <CardHeader className="flex-shrink-0 pb-4">
                 <div className="flex items-center gap-3">
                   <div className="w-4 h-4 rounded-full" style={{ backgroundColor: editColor }} />
-                  {canManageRoles && !selectedRole?.isDefault ? (
+                  {canManageRoles ? (
                     <div className="group/title relative flex items-center gap-2 flex-1 min-w-0">
                       <div className="relative">
                         <Input
@@ -948,23 +961,24 @@ export function RolesTab({ projectId }: RolesTabProps) {
                           )}
                           {canManageRoles &&
                             !isCreating &&
-                            selectedRole &&
-                            isDefaultRoleName(selectedRole.name) &&
-                            !isAtDefaults && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() =>
-                                  handleFieldChange('permissions', [
-                                    ...ROLE_PRESETS[selectedRole.name as DefaultRoleName],
-                                  ])
-                                }
-                                className="h-6 px-2 text-xs text-zinc-400 hover:text-zinc-200"
-                              >
-                                <RotateCcw className="mr-1 h-3 w-3" />
-                                Reset to Defaults
-                              </Button>
-                            )}
+                            selectedRole?.isDefault &&
+                            !isAtDefaults &&
+                            (() => {
+                              const presetName = getPresetNameByPosition(selectedRole.position)
+                              return presetName ? (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() =>
+                                    handleFieldChange('permissions', [...ROLE_PRESETS[presetName]])
+                                  }
+                                  className="h-6 px-2 text-xs text-zinc-400 hover:text-zinc-200"
+                                >
+                                  <RotateCcw className="mr-1 h-3 w-3" />
+                                  Reset to Defaults
+                                </Button>
+                              ) : null
+                            })()}
                           {canManageRoles && (
                             <Button
                               variant="ghost"

--- a/src/lib/permissions/create-default-roles.ts
+++ b/src/lib/permissions/create-default-roles.ts
@@ -6,7 +6,7 @@
 
 import { db } from '@/lib/db'
 import { isValidPermission, type Permission } from './constants'
-import { type DefaultRoleName, getDefaultRoleConfigs, ROLE_PRESETS } from './presets'
+import { type DefaultRoleName, getDefaultRoleConfigs, ROLE_POSITIONS } from './presets'
 
 type CustomRolePermissions = {
   [K in DefaultRoleName]?: Permission[]
@@ -73,13 +73,14 @@ export async function createDefaultRolesForProject(
 /**
  * Get the Owner role for a project.
  * Creates default roles if they don't exist.
+ * Uses position instead of name to support renamed default roles.
  */
 export async function getOwnerRoleForProject(projectId: string): Promise<string> {
-  // Try to find existing Owner role
+  // Try to find existing Owner role by position (supports renamed defaults)
   const ownerRole = await db.role.findFirst({
     where: {
       projectId,
-      name: 'Owner',
+      position: ROLE_POSITIONS.Owner,
       isDefault: true,
     },
     select: { id: true },
@@ -117,12 +118,13 @@ export async function getRoleByName(
 /**
  * Get the Member role for a project.
  * This is the default role for invited users.
+ * Uses position instead of name to support renamed default roles.
  */
 export async function getMemberRoleForProject(projectId: string): Promise<string> {
   const memberRole = await db.role.findFirst({
     where: {
       projectId,
-      name: 'Member',
+      position: ROLE_POSITIONS.Member,
       isDefault: true,
     },
     select: { id: true },


### PR DESCRIPTION
## Summary
- Allow project owners to rename default roles (Owner, Admin, Member) in project settings
- Permissions remain tied to the `isDefault` flag and `position`, not the role name
- Update all `isDefaultRoleName()` call sites in the roles UI to use `role.isDefault` boolean instead
- Fix `getOwnerRoleForProject` / `getMemberRoleForProject` to use position-based lookup so they work after renaming

## Changes
- **`src/components/projects/permissions/roles-tab.tsx`**: Remove UI restriction preventing name editing for default roles; always send name in update calls; use position-based preset lookup for "Reset to Defaults" button; replace `isDefaultRoleName()` checks with `role.isDefault`
- **`src/lib/permissions/create-default-roles.ts`**: Use `ROLE_POSITIONS.Owner` / `ROLE_POSITIONS.Member` instead of hardcoded name strings in `getOwnerRoleForProject` / `getMemberRoleForProject`

## Test plan
- [x] All 886 existing tests pass
- [x] Verify default roles can be renamed in project settings UI
- [x] Verify permissions are preserved after renaming
- [x] Verify "Reset to Defaults" button still works for renamed default roles
- [x] Verify default roles still cannot be deleted (only renamed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)