### PR TITLE
fix(ci): fix CLA Assistant bot configuration (PUNT-57)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,14 +15,9 @@ permissions:
 jobs:
   cla:
     runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'pull_request_target') ||
-      (github.event_name == 'issue_comment' && (
-        github.event.comment.body == 'recheck' ||
-        contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')
-      ))
     steps:
       - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +25,7 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/${{ github.repository }}/blob/main/CLA.md'
           branch: 'cla-signatures'
-          allowlist: 'bot*,dependabot*,renovate*'
+          allowlist: 'bot*,dependabot*,renovate*,github-actions*'
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, you need to sign our [Contributor License Agreement](https://github.com/${{ github.repository }}/blob/main/CLA.md).
 


### PR DESCRIPTION
## Summary

Fixes the CLA Assistant bot so it properly processes contributor signatures.

### What was wrong
The `if` condition was on the **job level** instead of the **step level**, which differs from the [recommended configuration](https://github.com/contributor-assistant/github-action#readme). This can cause issues with event context handling, particularly when contributors sign via comment and the status check needs to update.

### Changes
- Moved `if` condition from job level to step level (matches upstream docs)
- Switched from `contains()` to exact `==` for the sign comment check
- Added `github-actions*` to the bot allowlist

### Kept as-is
- CLA.md with relicensing rights (preserves dual-licensing option)
- `cla-signatures` branch for storing signatures
- v2.6.1 (already the latest version)

## Test plan
- [x] Open a test PR from a non-signed account and verify the bot comments
- [x] Reply with the sign comment and verify the status check updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)