### PR TITLE
docs(claude): add worktree and nullish coalescing conventions (PUNT-101)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,15 @@ The `.mcp.json` file lives in the project root but is **gitignored** because it 
 }
 ```
 
+**Parallel subagents must use git worktrees:** When launching multiple Claude Code subagents in parallel, each must work in its own git worktree to avoid branch-switching conflicts. Without this, agents overwrite each other's file changes and cause linter/commit failures.
+```bash
+git worktree add /tmp/worktree-<branch-name> -b <branch-name> main
+cd /tmp/worktree-<branch-name>
+# Do all work here, then commit, push, and create PR from this directory
+```
+
+**Use `??` (nullish coalescing), not `||`:** For values where `0`, `false`, or empty string are valid, always use `??`. Example: `storyPoints ?? null` not `storyPoints || null` (the latter silently discards `0`).
+
 ### Branch & PR Naming Convention
 
 **Branch names:** `type/punt-N-short-description`


### PR DESCRIPTION
## Summary
- Add **git worktree** convention for parallel subagents to the MCP Server section of CLAUDE.md, preventing branch-switching conflicts when multiple agents work simultaneously
- Add **nullish coalescing (`??`)** convention to avoid silently discarding valid falsy values like `0` or empty string

## Test plan
- [x] Verify CLAUDE.md renders correctly on GitHub
- [x] Confirm new sections appear at the end of the MCP Server section, before Branch & PR Naming Convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)