### PR TITLE
fix(admin): fix vertical scrolling on user profile page (PUNT-96)

### DIFF
--- a/src/app/(app)/admin/users/[userId]/page.tsx
+++ b/src/app/(app)/admin/users/[userId]/page.tsx
@@ -422,7 +422,7 @@ export default function AdminUserProfilePage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-zinc-950">
+      <div className="h-full overflow-auto bg-zinc-950">
         <div className="max-w-3xl mx-auto px-6 py-12">
           <div className="animate-pulse space-y-8">
             <div className="h-8 w-48 bg-zinc-800 rounded" />
@@ -436,7 +436,7 @@ export default function AdminUserProfilePage() {
 
   if (error || !user) {
     return (
-      <div className="min-h-screen bg-zinc-950">
+      <div className="h-full overflow-auto bg-zinc-950">
         <div className="max-w-3xl mx-auto px-6 py-12">
           <Button variant="ghost" asChild className="mb-6">
             <Link href="/admin/users">
@@ -469,7 +469,7 @@ export default function AdminUserProfilePage() {
   })
 
   return (
-    <div className="min-h-screen bg-zinc-950">
+    <div className="h-full overflow-auto bg-zinc-950">
       {/* Header with gradient accent */}
       <div className="relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-amber-500/10 via-orange-500/5 to-transparent" />


### PR DESCRIPTION
## Summary
- Fix broken vertical scrolling on the admin user profile page (`/admin/users/[userId]`)
- Replace `min-h-screen` with `h-full overflow-auto` on the page's root container (loading, error, and main render states)
- `min-h-screen` (100vh) conflicted with the parent app layout's flex constraints (`h-full`, `overflow-hidden`), preventing content from scrolling when it overflowed the viewport
- This matches the pattern used by other admin pages (dashboard uses `h-full overflow-auto`, settings/user list use `h-full flex flex-col overflow-hidden`)

## Test plan
- [x] Navigate to `/admin/users/{userId}` for a user with multiple project memberships
- [x] Verify the page scrolls vertically when content overflows the viewport
- [x] Verify the "Back to Users" button, header, and all cards are visible by scrolling
- [x] Verify no regression on the admin dashboard, user list, or settings pages
- [x] Verify loading and error states also scroll correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)