### PR TITLE
fix(tests): resolve type errors in test and fuzz files (PUNT-103)

### DIFF
--- a/src/__tests__/fuzz/arbitraries/file-upload.ts
+++ b/src/__tests__/fuzz/arbitraries/file-upload.ts
@@ -142,8 +142,18 @@ export const uploadSettings = fc.record({
   maxVideoSizeMB: fc.integer({ min: 1, max: 500 }),
   maxDocumentSizeMB: fc.integer({ min: 1, max: 100 }),
   maxAttachmentsPerTicket: fc.integer({ min: 1, max: 50 }),
-  allowedImageTypes: fc.constant(['image/jpeg', 'image/png', 'image/gif', 'image/webp']),
-  allowedVideoTypes: fc.constant(['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime']),
+  allowedImageTypes: fc.constant([
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+  ] as string[]),
+  allowedVideoTypes: fc.constant([
+    'video/mp4',
+    'video/webm',
+    'video/ogg',
+    'video/quicktime',
+  ] as string[]),
   allowedDocumentTypes: fc.constant([
     'application/pdf',
     'application/msword',
@@ -152,5 +162,5 @@ export const uploadSettings = fc.record({
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     'text/plain',
     'text/csv',
-  ]),
+  ] as string[]),
 })

--- a/src/__tests__/fuzz/stores/hydration.fuzz.test.ts
+++ b/src/__tests__/fuzz/stores/hydration.fuzz.test.ts
@@ -349,10 +349,13 @@ describe('Hydration Validation Fuzz Tests', () => {
 
   describe('Edge cases in validation', () => {
     it('should handle objects with prototype pollution attempts', () => {
-      const malicious = [
-        { id: 'col-1', tickets: [], __proto__: { evil: true } },
-        { id: 'col-2', tickets: [], constructor: { prototype: { pwned: true } } },
-      ]
+      const col1 = { id: 'col-1', tickets: [] as unknown[], __proto__: { evil: true } }
+      const col2 = {
+        id: 'col-2',
+        tickets: [] as unknown[],
+        constructor: { prototype: { pwned: true } },
+      }
+      const malicious = [col1, col2]
 
       // Should still work correctly
       expect(isValidColumns(malicious)).toBe(true)

--- a/src/__tests__/utils/mocks.ts
+++ b/src/__tests__/utils/mocks.ts
@@ -57,6 +57,7 @@ export const createMockTicket = (overrides?: Partial<TicketWithRelations>): Tick
     environment: null,
     affectedVersion: null,
     fixVersion: null,
+    resolution: null,
     createdAt: new Date('2024-01-01'),
     updatedAt: new Date('2024-01-01'),
     projectId: 'project-1',

--- a/src/app/api/auth/__tests__/register.test.ts
+++ b/src/app/api/auth/__tests__/register.test.ts
@@ -18,7 +18,8 @@ vi.mock('@/lib/rate-limit', () => ({
 
 import { db } from '@/lib/db'
 
-const mockDb = vi.mocked(db)
+// biome-ignore lint/suspicious/noExplicitAny: partial mock for testing
+const mockDb = vi.mocked(db) as any
 
 function createRequest(body: unknown): Request {
   return new Request('http://localhost:3000/api/auth/register', {
@@ -32,7 +33,8 @@ describe('Registration API - Username Validation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockDb.user.findUnique.mockResolvedValue(null)
-    mockDb.user.create.mockImplementation(({ data }) =>
+    // biome-ignore lint/suspicious/noExplicitAny: partial mock for testing
+    mockDb.user.create.mockImplementation(({ data }: any) =>
       Promise.resolve({
         id: 'test-id',
         username: data.username,
@@ -177,7 +179,8 @@ describe('Registration API - Password Validation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockDb.user.findUnique.mockResolvedValue(null)
-    mockDb.user.create.mockImplementation(({ data }) =>
+    // biome-ignore lint/suspicious/noExplicitAny: partial mock for testing
+    mockDb.user.create.mockImplementation(({ data }: any) =>
       Promise.resolve({
         id: 'test-id',
         username: data.username,
@@ -334,7 +337,8 @@ describe('Registration API - Input Sanitization', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockDb.user.findUnique.mockResolvedValue(null)
-    mockDb.user.create.mockImplementation(({ data }) =>
+    // biome-ignore lint/suspicious/noExplicitAny: partial mock for testing
+    mockDb.user.create.mockImplementation(({ data }: any) =>
       Promise.resolve({
         id: 'test-id',
         username: data.username,

--- a/src/app/api/projects/[projectId]/__tests__/permissions.test.ts
+++ b/src/app/api/projects/[projectId]/__tests__/permissions.test.ts
@@ -55,7 +55,8 @@ import { hasPermission, isMember } from '@/lib/permissions'
 // Import routes after mocks
 import { DELETE, GET, PATCH } from '../route'
 
-const mockDb = vi.mocked(db)
+// biome-ignore lint/suspicious/noExplicitAny: partial mock for testing
+const mockDb = vi.mocked(db) as any
 const mockRequireAuth = vi.mocked(requireAuth)
 const mockHasPermission = vi.mocked(hasPermission)
 const mockIsMember = vi.mocked(isMember)

--- a/src/app/api/projects/[projectId]/tickets/__tests__/permissions.test.ts
+++ b/src/app/api/projects/[projectId]/tickets/__tests__/permissions.test.ts
@@ -59,7 +59,8 @@ import { getEffectivePermissions, hasPermission, isMember } from '@/lib/permissi
 // Import routes after mocks
 import { GET, POST } from '../route'
 
-const mockDb = vi.mocked(db)
+// biome-ignore lint/suspicious/noExplicitAny: partial mock for testing
+const mockDb = vi.mocked(db) as any
 const mockRequireAuth = vi.mocked(requireAuth)
 const mockHasPermission = vi.mocked(hasPermission)
 const mockIsMember = vi.mocked(isMember)

--- a/src/components/board/__tests__/kanban-board.test.tsx
+++ b/src/components/board/__tests__/kanban-board.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockColumns } from '@/__tests__/utils/mocks'
 import { render } from '@/__tests__/utils/test-utils'
 import { useBoardStore } from '@/stores/board-store'
+import type { ColumnWithTickets } from '@/types'
 import { KanbanBoard } from '../kanban-board'
 
 // Use vi.hoisted to define mocks before vi.mock runs (vi.mock is hoisted)
@@ -24,7 +25,7 @@ const { mockBoardState, mockSelectionState, mockUiState, mockUndoState, createMo
     }
 
     const mockBoardState = {
-      getColumns: vi.fn(() => []),
+      getColumns: vi.fn(() => [] as ColumnWithTickets[]),
       moveTicket: vi.fn(),
       moveTickets: vi.fn(),
       reorderTicket: vi.fn(),
@@ -105,8 +106,10 @@ describe('KanbanBoard', () => {
     // Update the mock to return columns
     mockBoardState.getColumns = vi.fn(() => mockColumns)
     // Update both the hook return and getState return
-    vi.mocked(useBoardStore).mockReturnValue(mockBoardState)
-    vi.mocked(useBoardStore.getState).mockReturnValue(mockBoardState)
+    // biome-ignore lint/suspicious/noExplicitAny: partial mock for testing
+    vi.mocked(useBoardStore).mockReturnValue(mockBoardState as any)
+    // biome-ignore lint/suspicious/noExplicitAny: partial mock for testing
+    vi.mocked(useBoardStore.getState).mockReturnValue(mockBoardState as any)
   })
 
   it('should render board with columns', () => {

--- a/src/components/table/__tests__/ticket-cell.test.tsx
+++ b/src/components/table/__tests__/ticket-cell.test.tsx
@@ -15,6 +15,7 @@ const createColumn = (id: string): BacklogColumn => ({
   visible: true,
   width: 100,
   minWidth: 50,
+  sortable: true,
 })
 
 const mockGetStatusName = (columnId: string) => {

--- a/src/components/table/__tests__/ticket-table-row.test.tsx
+++ b/src/components/table/__tests__/ticket-table-row.test.tsx
@@ -82,9 +82,9 @@ vi.mock('@/stores/undo-store', () => {
 })
 
 const mockColumns: BacklogColumn[] = [
-  { id: 'key', label: 'Key', visible: true, width: 100, minWidth: 80 },
-  { id: 'title', label: 'Title', visible: true, width: 300, minWidth: 150 },
-  { id: 'status', label: 'Status', visible: true, width: 120, minWidth: 100 },
+  { id: 'key', label: 'Key', visible: true, width: 100, minWidth: 80, sortable: true },
+  { id: 'title', label: 'Title', visible: true, width: 300, minWidth: 150, sortable: true },
+  { id: 'status', label: 'Status', visible: true, width: 120, minWidth: 100, sortable: true },
 ]
 
 const mockContext: TableContext = {

--- a/src/components/table/__tests__/ticket-table.test.tsx
+++ b/src/components/table/__tests__/ticket-table.test.tsx
@@ -73,10 +73,10 @@ vi.mock('@/stores/undo-store', () => {
 })
 
 const mockColumns: BacklogColumn[] = [
-  { id: 'key', label: 'Key', visible: true, width: 100, minWidth: 80 },
-  { id: 'title', label: 'Title', visible: true, width: 300, minWidth: 150 },
-  { id: 'status', label: 'Status', visible: true, width: 120, minWidth: 100 },
-  { id: 'priority', label: 'Priority', visible: true, width: 100, minWidth: 80 },
+  { id: 'key', label: 'Key', visible: true, width: 100, minWidth: 80, sortable: true },
+  { id: 'title', label: 'Title', visible: true, width: 300, minWidth: 150, sortable: true },
+  { id: 'status', label: 'Status', visible: true, width: 120, minWidth: 100, sortable: true },
+  { id: 'priority', label: 'Priority', visible: true, width: 100, minWidth: 80, sortable: true },
 ]
 
 const mockContext: TableContext = {
@@ -178,10 +178,17 @@ describe('TicketTable', () => {
 
   it('should only render visible columns', () => {
     const columnsWithHidden: BacklogColumn[] = [
-      { id: 'key', label: 'Key', visible: true, width: 100, minWidth: 80 },
-      { id: 'title', label: 'Title', visible: true, width: 300, minWidth: 150 },
-      { id: 'status', label: 'Status', visible: false, width: 120, minWidth: 100 },
-      { id: 'priority', label: 'Priority', visible: true, width: 100, minWidth: 80 },
+      { id: 'key', label: 'Key', visible: true, width: 100, minWidth: 80, sortable: true },
+      { id: 'title', label: 'Title', visible: true, width: 300, minWidth: 150, sortable: true },
+      { id: 'status', label: 'Status', visible: false, width: 120, minWidth: 100, sortable: true },
+      {
+        id: 'priority',
+        label: 'Priority',
+        visible: true,
+        width: 100,
+        minWidth: 80,
+        sortable: true,
+      },
     ]
 
     const tickets = [createMockTicket({ id: 'ticket-1', columnId: 'col-2' })]

--- a/src/lib/permissions/__tests__/check.test.ts
+++ b/src/lib/permissions/__tests__/check.test.ts
@@ -29,10 +29,13 @@ vi.mock('@/lib/db', () => ({
 // Import mocked db after vi.mock
 import { db } from '@/lib/db'
 
-// Type-safe mock accessors
-const mockUserFindUnique = vi.mocked(db.user.findUnique)
-const mockProjectMemberFindUnique = vi.mocked(db.projectMember.findUnique)
-const mockRoleFindUnique = vi.mocked(db.role.findUnique)
+// Mock accessors - cast to any since we pass partial mock data
+// biome-ignore lint/suspicious/noExplicitAny: partial mock data for unit tests
+const mockUserFindUnique = vi.mocked(db.user.findUnique) as any
+// biome-ignore lint/suspicious/noExplicitAny: partial mock data for unit tests
+const mockProjectMemberFindUnique = vi.mocked(db.projectMember.findUnique) as any
+// biome-ignore lint/suspicious/noExplicitAny: partial mock data for unit tests
+const mockRoleFindUnique = vi.mocked(db.role.findUnique) as any
 
 // Test data helpers
 const TEST_USER_ID = 'user-1'

--- a/src/stores/__tests__/undo-store.test.ts
+++ b/src/stores/__tests__/undo-store.test.ts
@@ -20,8 +20,10 @@ describe('Undo Store', () => {
       const entry = useUndoStore.getState().undoStack[0]
       expect(entry).toBeDefined()
       expect(entry?.action.type).toBe('delete')
-      expect(entry?.action.tickets).toHaveLength(1)
-      expect(entry?.action.tickets[0].ticket.id).toBe('ticket-1')
+      if (entry?.action.type === 'delete') {
+        expect(entry.action.tickets).toHaveLength(1)
+        expect(entry.action.tickets[0].ticket.id).toBe('ticket-1')
+      }
       expect(entry?.toastId).toBe('toast-1')
       expect(entry?.projectId).toBe(PROJECT_ID)
     })
@@ -56,7 +58,9 @@ describe('Undo Store', () => {
 
       const entry = useUndoStore.getState().undoStack[0]
       expect(entry?.action.type).toBe('delete')
-      expect(entry?.action.tickets).toHaveLength(2)
+      if (entry?.action.type === 'delete') {
+        expect(entry.action.tickets).toHaveLength(2)
+      }
     })
   })
 


### PR DESCRIPTION
## Summary
- Fix 131 TypeScript type errors across 13 test and fuzz files so `tsc --noEmit` produces zero errors
- Add missing `TicketWithRelations` properties (`resolution`, `creatorId`, `creator`, `sprint`, `carriedFromSprint`) to ticket arbitraries and mock helpers
- Fix type mismatches in fuzz arbitraries (`estimate` field type, `UserSummary.email` nullability, `readonly` array incompatibility, discriminated union access)
- Add missing `sortable` property to `BacklogColumn` mocks in table component tests
- Cast partial Prisma mock data with `as any` in permission and API route tests for type compatibility

## Test plan
- [x] `pnpm exec tsc --noEmit` produces zero errors
- [x] `pnpm test` passes all 886 tests across 41 test files
- [x] `pnpm lint` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)