### PR TITLE
fix(tests): add username field to fuzz test arbitraries (PUNT-103)

### DIFF
--- a/src/__tests__/fuzz/arbitraries/ticket.ts
+++ b/src/__tests__/fuzz/arbitraries/ticket.ts
@@ -34,10 +34,20 @@ export const storyPoints = fc.option(fc.constantFrom(1, 2, 3, 5, 8, 13, 21), { n
  * Base ticket arbitrary with minimal required fields
  */
 /**
+ * Valid username characters for generating usernames
+ */
+const validUsernameChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-'
+
+const validUsername = fc
+  .array(fc.constantFrom(...validUsernameChars.split('')), { minLength: 3, maxLength: 30 })
+  .map((chars) => chars.join(''))
+
+/**
  * User summary arbitrary (for assignee, reporter, creator, watchers)
  */
 const userSummary = fc.record({
   id: fc.uuid(),
+  username: validUsername,
   name: fc.string({ minLength: 1, maxLength: 100 }),
   email: fc.emailAddress(),
   avatar: fc.option(fc.webUrl(), { nil: null }),
@@ -150,12 +160,14 @@ export const maliciousTicket = fc.record({
   assignee: fc.constant(null),
   creator: fc.record({
     id: fc.uuid(),
+    username: validUsername,
     name: fc.string({ minLength: 1, maxLength: 100 }),
     email: fc.emailAddress(),
     avatar: fc.constant(null),
   }),
   reporter: fc.record({
     id: fc.uuid(),
+    username: validUsername,
     name: fc.string({ minLength: 1, maxLength: 100 }),
     email: fc.emailAddress(),
     avatar: fc.constant(null),

--- a/src/__tests__/fuzz/arbitraries/user.ts
+++ b/src/__tests__/fuzz/arbitraries/user.ts
@@ -71,6 +71,7 @@ export const userId = fc.uuid()
  */
 export const userSummary = fc.record({
   id: fc.uuid(),
+  username: validUsername,
   name: fc.string({ minLength: 1, maxLength: 100 }),
   email: fc.option(fc.emailAddress(), { nil: null }),
   avatar: fc.option(fc.webUrl(), { nil: null }),


### PR DESCRIPTION
## Summary
- Add missing `username` field to `userSummary` arbitraries in fuzz test files
- Resolves 12 TypeScript errors where `UserSummary` type now requires `username` after PR #96

## Changes
- `src/__tests__/fuzz/arbitraries/user.ts` - Added `username` to exported `userSummary`
- `src/__tests__/fuzz/arbitraries/ticket.ts` - Added `username` to local `userSummary` and `maliciousTicket` creator/reporter

## Test plan
- [x] `pnpm exec tsc --noEmit` passes with no errors
- [x] All 886 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)