### PR TITLE
fix(backlog): show no active sprint banner (PUNT-104)

### DIFF
--- a/src/app/(app)/projects/[projectId]/backlog/page.tsx
+++ b/src/app/(app)/projects/[projectId]/backlog/page.tsx
@@ -19,7 +19,7 @@ import { List, Loader2, Plus } from 'lucide-react'
 import { useParams, useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { BacklogTable, ColumnConfig } from '@/components/backlog'
-import { SprintSection } from '@/components/sprints'
+import { SprintHeader, SprintSection } from '@/components/sprints'
 import { TicketTableRow } from '@/components/table'
 import { TicketDetailDrawer } from '@/components/tickets'
 import { Button } from '@/components/ui/button'
@@ -1007,6 +1007,13 @@ export default function BacklogPage() {
           </div>
         )}
       </div>
+
+      {/* No active sprint banner */}
+      {!hasActiveSprints && (
+        <div className="flex-shrink-0 px-4 py-4 lg:px-6 border-b border-zinc-800">
+          <SprintHeader projectId={projectId} />
+        </div>
+      )}
 
       {/* Unified DnD context wrapping sprint sections AND backlog table */}
       <DndContext


### PR DESCRIPTION
## Summary
- Add `SprintHeader` component to the backlog page to display a "no active sprint" banner when there are no active or planning sprints
- Provides visual consistency with the board view which already shows this message via the same component
- Banner includes the target icon, "No active sprint" message, and a "Create Sprint" button (when user has permission)

## Test plan
- [x] Navigate to a project backlog with no active or planning sprints
- [x] Verify the "No active sprint" banner appears above the backlog table
- [x] Verify clicking "Create Sprint" opens the sprint creation dialog
- [x] Navigate to a project with an active sprint
- [x] Verify the banner does NOT appear (sprint sections show instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)