### PR TITLE
fix(layout): add scrolling to sidebar drawer (PUNT-107)

### DIFF
--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -13,12 +13,12 @@ function ScrollArea({
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn('relative', className)}
+      className={cn('relative overflow-hidden', className)}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="size-full overflow-y-auto overflow-x-hidden rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 scroll-smooth motion-reduce:scroll-auto"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
## Summary
- Fixes the sidebar/drawer scrolling issue where content extending past the viewport was inaccessible
- Adds `overflow-hidden` to `ScrollArea` root to properly contain scrollable content
- Adds `overflow-y-auto` to viewport to enable vertical scrolling when content overflows
- Respects `motion-reduce` user preference for smooth scrolling behavior

## Test plan
- [x] Open the app with many projects to overflow the sidebar
- [x] Verify overflow content is accessible via scrolling
- [x] Verify scrollbar styling matches the app's zinc-600/zinc-500 design system
- [x] Test on both desktop sidebar and mobile navigation drawer
- [x] Test with `prefers-reduced-motion` to verify scroll behavior respects the preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)