### PR TITLE
fix(color-picker): show toast when removing color in use (PUNT-59)

### DIFF
--- a/src/components/board/column-menu.tsx
+++ b/src/components/board/column-menu.tsx
@@ -642,6 +642,7 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
                     onColorChange={setColorValue}
                     onApply={setColorValue}
                     isDisabled={renameLoading}
+                    projectId={projectId}
                   />
                   {/* PUNT-74: Ghost button style for reset */}
                   <button
@@ -665,6 +666,7 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
                     onColorChange={setColorValue}
                     onApply={setColorValue}
                     isDisabled={renameLoading}
+                    projectId={projectId}
                   />
                 </>
               )}

--- a/src/components/projects/permissions/roles-tab.tsx
+++ b/src/components/projects/permissions/roles-tab.tsx
@@ -905,6 +905,7 @@ export function RolesTab({ projectId }: RolesTabProps) {
                           }
                         }}
                         isDisabled={!canManageRoles}
+                        projectId={projectId}
                       />
                     </div>
 

--- a/src/components/projects/settings/labels-tab.tsx
+++ b/src/components/projects/settings/labels-tab.tsx
@@ -371,6 +371,7 @@ export function LabelsTab({ projectId }: LabelsTabProps) {
                         }
                       }}
                       isDisabled={!canManageLabels}
+                      projectId={projectId}
                     />
                   </div>
 


### PR DESCRIPTION
## Summary
- When removing a saved custom color from the color picker swatches, show an info toast if that color is currently in use by columns or labels in the current project
- The color is removed from saved swatches regardless, but users are informed that existing entities will keep their color
- This addresses user confusion about whether removing a saved color would affect entities already using it

## Changes
- Added `projectId` prop to `ColorPickerBody` component (optional)
- Added `handleRemoveColor` function that:
  - Removes the color from settings store
  - Checks columns in board store for matching colors
  - Checks labels in React Query cache for matching colors
  - Shows info toast with count of affected items
- Updated all `ColorPickerBody` call sites to pass `projectId` where available:
  - Column menu (column color picker)
  - Labels tab (label color picker)
  - Roles tab (role color picker)
  - Label select component (inline label color picker)
  - Profile page (avatar color) - no projectId, usage check skipped

## Test plan
- [x] Open a project with columns that have custom colors
- [x] Add a column's color to saved swatches
- [x] Remove the saved color - verify info toast appears showing the column count
- [x] Repeat with labels - verify toast shows label count
- [x] Verify columns/labels retain their colors after swatch removal
- [x] Verify toast does not appear when removing colors not in use
- [x] Verify profile page color picker still works (no projectId context)

---
Generated with [Claude Code](https://claude.com/claude-code)