### PR TITLE
feat(projects): add color palette to edit project modal (PUNT-109)

### DIFF
--- a/src/components/projects/create-project-dialog.tsx
+++ b/src/components/projects/create-project-dialog.tsx
@@ -16,21 +16,8 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { useCreateProject } from '@/hooks/queries/use-projects'
+import { LABEL_COLORS } from '@/lib/constants'
 import { useUIStore } from '@/stores/ui-store'
-
-// Preset colors for projects
-const PROJECT_COLORS = [
-  '#f59e0b', // amber
-  '#10b981', // emerald
-  '#8b5cf6', // violet
-  '#ec4899', // pink
-  '#06b6d4', // cyan
-  '#ef4444', // red
-  '#3b82f6', // blue
-  '#22c55e', // green
-  '#f97316', // orange
-  '#a855f7', // purple
-]
 
 interface FormData {
   name: string
@@ -43,7 +30,7 @@ const DEFAULT_FORM: FormData = {
   name: '',
   key: '',
   description: '',
-  color: PROJECT_COLORS[0],
+  color: LABEL_COLORS[0],
 }
 
 export function CreateProjectDialog() {
@@ -204,7 +191,7 @@ export function CreateProjectDialog() {
           <div className="space-y-2">
             <Label className="text-zinc-300">Project Color</Label>
             <div className="flex flex-wrap gap-2">
-              {PROJECT_COLORS.map((color) => (
+              {LABEL_COLORS.map((color) => (
                 <button
                   key={color}
                   type="button"

--- a/src/components/projects/edit-project-dialog.tsx
+++ b/src/components/projects/edit-project-dialog.tsx
@@ -26,22 +26,9 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { useDeleteProject, useUpdateProject } from '@/hooks/queries/use-projects'
+import { LABEL_COLORS } from '@/lib/constants'
 import { useProjectsStore } from '@/stores/projects-store'
 import { useUIStore } from '@/stores/ui-store'
-
-// Preset colors for projects
-const PROJECT_COLORS = [
-  '#f59e0b', // amber
-  '#10b981', // emerald
-  '#8b5cf6', // violet
-  '#ec4899', // pink
-  '#06b6d4', // cyan
-  '#ef4444', // red
-  '#3b82f6', // blue
-  '#22c55e', // green
-  '#f97316', // orange
-  '#a855f7', // purple
-]
 
 interface FormData {
   name: string
@@ -59,7 +46,7 @@ export function EditProjectDialog() {
     name: '',
     key: '',
     description: '',
-    color: PROJECT_COLORS[0],
+    color: LABEL_COLORS[0],
   })
   const [originalKey, setOriginalKey] = useState('')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -90,7 +77,7 @@ export function EditProjectDialog() {
         name: '',
         key: '',
         description: '',
-        color: PROJECT_COLORS[0],
+        color: LABEL_COLORS[0],
       })
       setOriginalKey('')
     }, 200)
@@ -246,7 +233,7 @@ export function EditProjectDialog() {
             <div className="space-y-2">
               <Label className="text-zinc-300">Project Color</Label>
               <div className="flex flex-wrap gap-2">
-                {PROJECT_COLORS.map((color) => (
+                {LABEL_COLORS.map((color) => (
                   <button
                     key={color}
                     type="button"


### PR DESCRIPTION
## Summary
- Replace local `PROJECT_COLORS` constant with shared `LABEL_COLORS` from `constants.ts` in both create and edit project dialogs
- Ensures consistent color palette (19 colors, ordered by hue) across the entire app

## Test plan
- [x] Lint passes (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] Manually verify color palette appears correctly in create project modal
- [x] Manually verify color palette appears correctly in edit project modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)