### PR TITLE
fix(ui): match preferences icon in avatar dropdown to sidebar (PUNT-116)

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { LogOut, Settings, Shield, User } from 'lucide-react'
+import { LogOut, Shield, SlidersHorizontal, User } from 'lucide-react'
 import Link from 'next/link'
 import { signOut } from 'next-auth/react'
 import { AnimatedMenuIcon } from '@/components/ui/animated-menu-icon'
@@ -130,7 +130,7 @@ export function Header() {
                 className="text-zinc-300 focus:bg-zinc-800 focus:text-zinc-100 cursor-pointer"
               >
                 <Link href="/preferences">
-                  <Settings className="mr-2 h-4 w-4" />
+                  <SlidersHorizontal className="mr-2 h-4 w-4" />
                   <span>Preferences</span>
                 </Link>
               </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- Updated the Preferences icon in the avatar dropdown menu to use the same `SlidersHorizontal` icon as the sidebar navigation for visual consistency

## Test plan
- [x] Open the app and check the avatar dropdown menu — Preferences icon should match sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #132