### PR TITLE
fix(backlog): add border to filter row search input (PUNT-118)

### DIFF
--- a/src/components/backlog/backlog-filters.tsx
+++ b/src/components/backlog/backlog-filters.tsx
@@ -915,7 +915,7 @@ export function BacklogFilters({ statusColumns: _statusColumns, projectId }: Bac
           placeholder="Search tickets..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="pl-9"
+          className="pl-9 border-zinc-800 bg-zinc-900/50 hover:border-zinc-700"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Added visible border styling to the backlog filter row search input (`border-zinc-800 bg-zinc-900/50 hover:border-zinc-700`) to match the main search input's style in the header

## Test plan
- [x] Open the backlog view and verify the search input has a visible border
- [x] Compare with the main search input — styles should be consistent (minus Ctrl+K indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #130