### PR TITLE
feat(tickets): add sprint field to ticket drawer and new ticket modal (PUNT-111)

### DIFF
--- a/src/components/tickets/ticket-detail-drawer.tsx
+++ b/src/components/tickets/ticket-detail-drawer.tsx
@@ -1044,18 +1044,28 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
                     >
                       No sprint (Backlog)
                     </DropdownMenuCheckboxItem>
-                    {availableSprints.map((sprint) => (
-                      <DropdownMenuCheckboxItem
-                        key={sprint.id}
-                        checked={tempSprintId === sprint.id}
-                        onCheckedChange={() => {
-                          handleChange('sprint', sprint.id)
-                        }}
-                        className="cursor-pointer"
-                      >
-                        {sprint.name} {sprint.status === 'active' && '(Active)'}
-                      </DropdownMenuCheckboxItem>
-                    ))}
+                    {availableSprints
+                      .filter(
+                        (s) =>
+                          s.status === 'active' || s.status === 'planning' || s.id === tempSprintId,
+                      )
+                      .map((sprint) => (
+                        <DropdownMenuCheckboxItem
+                          key={sprint.id}
+                          checked={tempSprintId === sprint.id}
+                          onCheckedChange={() => {
+                            handleChange('sprint', sprint.id)
+                          }}
+                          className="cursor-pointer"
+                        >
+                          {sprint.name}{' '}
+                          {sprint.status === 'active'
+                            ? '(Active)'
+                            : sprint.status === 'completed'
+                              ? '(Completed)'
+                              : ''}
+                        </DropdownMenuCheckboxItem>
+                      ))}
                   </DropdownMenuContent>
                 </DropdownMenu>
 

--- a/src/components/tickets/ticket-form.tsx
+++ b/src/components/tickets/ticket-form.tsx
@@ -208,15 +208,17 @@ export function TicketForm({
             <SelectItem value="none" className="focus:bg-zinc-800 focus:text-zinc-100">
               No sprint (Backlog)
             </SelectItem>
-            {sprints.map((sprint) => (
-              <SelectItem
-                key={sprint.id}
-                value={sprint.id}
-                className="focus:bg-zinc-800 focus:text-zinc-100"
-              >
-                {sprint.name} {sprint.status === 'active' && '(Active)'}
-              </SelectItem>
-            ))}
+            {sprints
+              .filter((s) => s.status === 'active' || s.status === 'planning')
+              .map((sprint) => (
+                <SelectItem
+                  key={sprint.id}
+                  value={sprint.id}
+                  className="focus:bg-zinc-800 focus:text-zinc-100"
+                >
+                  {sprint.name} {sprint.status === 'active' && '(Active)'}
+                </SelectItem>
+              ))}
           </SelectContent>
         </Select>
       </div>


### PR DESCRIPTION
## Summary
- Sprint selector was already present in both the new ticket creation modal and the ticket detail drawer
- Filtered sprint dropdowns to only show **active** and **planning** sprints (excluding completed sprints)
- In the ticket detail drawer, the currently-assigned sprint is always shown even if completed, with a "(Completed)" label for clarity
- "No sprint (Backlog)" option remains as the default/deselect option

## Test plan
- [x] Create a new ticket -- Sprint dropdown should show only active and planning sprints (not completed ones)
- [x] Select a sprint and create -- ticket appears in the sprint
- [x] Open an existing ticket in the drawer -- sprint assignment is shown in the meta row badge
- [x] Change sprint assignment from the drawer dropdown -- ticket moves to the new sprint
- [x] Set to "No sprint (Backlog)" -- ticket goes to backlog
- [x] If a ticket is assigned to a completed sprint, that sprint still shows in the drawer dropdown with "(Completed)" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #127