### PR TITLE
fix(sprints): persist sprint table sort configuration on refresh (PUNT-115)

### DIFF
--- a/src/app/(app)/preferences/page.tsx
+++ b/src/app/(app)/preferences/page.tsx
@@ -27,6 +27,8 @@ export default function PreferencesPage() {
     setAutoSaveOnRoleEditorClose,
     showUndoButtons,
     setShowUndoButtons,
+    persistTableSort,
+    setPersistTableSort,
     sidebarExpandedSections,
     setSidebarSectionExpanded,
     hideColorRemovalWarning,
@@ -140,6 +142,35 @@ export default function PreferencesPage() {
                 id="show-undo-buttons"
                 checked={showUndoButtons}
                 onCheckedChange={(checked) => setShowUndoButtons(checked === true)}
+                className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Table Behavior */}
+        <Card className="border-zinc-800 bg-zinc-900/50">
+          <CardHeader>
+            <CardTitle className="text-zinc-100">Table Behavior</CardTitle>
+            <CardDescription className="text-zinc-500">
+              Configure how backlog and sprint tables behave
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="flex items-start justify-between space-x-4">
+              <div className="flex-1 space-y-1">
+                <Label htmlFor="persist-table-sort" className="text-zinc-300">
+                  Persist sort on refresh
+                </Label>
+                <p className="text-sm text-zinc-500">
+                  Remember table sort configuration across page refreshes. When disabled, tables
+                  always reset to their default sort order on page load.
+                </p>
+              </div>
+              <Checkbox
+                id="persist-table-sort"
+                checked={persistTableSort}
+                onCheckedChange={(checked) => setPersistTableSort(checked === true)}
                 className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
               />
             </div>

--- a/src/components/backlog/backlog-table.tsx
+++ b/src/components/backlog/backlog-table.tsx
@@ -27,6 +27,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { filterTickets } from '@/lib/filter-tickets'
 import { type SortConfig, useBacklogStore } from '@/stores/backlog-store'
 import { useSelectionStore } from '@/stores/selection-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import type { ColumnWithTickets, TicketWithRelations } from '@/types'
 import { BacklogFilters } from './backlog-filters'
 
@@ -62,6 +63,7 @@ export function BacklogTable({
     columns,
     reorderColumns,
     sort,
+    setSort,
     toggleSort,
     filterByType,
     filterByPriority,
@@ -79,6 +81,18 @@ export function BacklogTable({
     setBacklogOrder,
     clearBacklogOrder: _clearBacklogOrder,
   } = useBacklogStore()
+  const persistTableSort = useSettingsStore((s) => s.persistTableSort)
+
+  // Reset backlog sort to default on mount when sort persistence is disabled
+  const sortResetRef = useRef(false)
+  useEffect(() => {
+    if (!sortResetRef.current) {
+      sortResetRef.current = true
+      if (!persistTableSort) {
+        setSort({ column: 'key', direction: 'desc' })
+      }
+    }
+  }, [persistTableSort, setSort])
 
   // Apply persisted backlog order (per project) while keeping any new tickets appended
   const applyBacklogOrder = useMemo(

--- a/src/components/sprints/sprint-backlog-view.tsx
+++ b/src/components/sprints/sprint-backlog-view.tsx
@@ -12,7 +12,7 @@ import {
   useSensors,
 } from '@dnd-kit/core'
 import { Plus, Target } from 'lucide-react'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   useDeleteSprint,
@@ -27,6 +27,8 @@ import { cn } from '@/lib/utils'
 import { useBacklogStore } from '@/stores/backlog-store'
 import { useBoardStore } from '@/stores/board-store'
 import { useSelectionStore } from '@/stores/selection-store'
+import { useSettingsStore } from '@/stores/settings-store'
+import { useSprintStore } from '@/stores/sprint-store'
 import { useUIStore } from '@/stores/ui-store'
 import { useUndoStore } from '@/stores/undo-store'
 import type { TicketWithRelations } from '@/types'
@@ -74,6 +76,19 @@ export function SprintBacklogView({
     showSubtasks,
   } = useBacklogStore()
   const visibleColumns = backlogColumns.filter((c) => c.visible)
+  const persistTableSort = useSettingsStore((s) => s.persistTableSort)
+  const clearAllSprintSorts = useSprintStore((s) => s.clearAllSprintSorts)
+
+  // Clear sprint sorts on mount when sort persistence is disabled
+  const sortResetRef = useRef(false)
+  useEffect(() => {
+    if (!sortResetRef.current) {
+      sortResetRef.current = true
+      if (!persistTableSort) {
+        clearAllSprintSorts()
+      }
+    }
+  }, [persistTableSort, clearAllSprintSorts])
 
   // Apply filters from the shared backlog store
   const filteredTickets = useMemo(() => {

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -38,6 +38,10 @@ interface SettingsState {
   hideColorRemovalWarning: boolean
   setHideColorRemovalWarning: (value: boolean) => void
 
+  // Persist table sort configuration across page refreshes
+  persistTableSort: boolean
+  setPersistTableSort: (value: boolean) => void
+
   // Projects where user has dismissed the "Add Column" button
   dismissedAddColumnProjects: string[]
   dismissAddColumn: (projectId: string) => void
@@ -99,6 +103,10 @@ export const useSettingsStore = create<SettingsState>()(
       // Hide color removal warning (off by default - show warning)
       hideColorRemovalWarning: false,
       setHideColorRemovalWarning: (value) => set({ hideColorRemovalWarning: value }),
+
+      // Persist table sort across refreshes (on by default)
+      persistTableSort: true,
+      setPersistTableSort: (value) => set({ persistTableSort: value }),
 
       // Add column dismiss per project
       dismissedAddColumnProjects: [],


### PR DESCRIPTION
## Summary
- Sprint table sort now persists across page refreshes via Zustand persist in the sprint store, matching the existing backlog store pattern
- Added per-section sort state keyed by sprint ID (or 'backlog' for the backlog section within the sprints view)
- Added migration from sprint store v1 to v2 for existing users
- Added a global "Persist sort on refresh" toggle in Preferences > Table Behavior that controls both backlog and sprint table sort persistence

## Test plan
- [x] Open sprints view and sort by a column (e.g. priority) -- sort should persist after page refresh
- [x] Verify backlog sort persistence still works as before
- [x] Toggle "Persist sort on refresh" off in Preferences, then refresh -- both backlog and sprint sorts should reset to defaults
- [x] Toggle it back on -- sorts should persist again across refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)