### PR TITLE
fix(backlog): prevent context menu edits from resetting table sort (PUNT-121)

### DIFF
--- a/src/components/backlog/backlog-table.tsx
+++ b/src/components/backlog/backlog-table.tsx
@@ -97,7 +97,9 @@ export function BacklogTable({
   const [orderedTickets, setOrderedTickets] = useState<TicketWithRelations[]>(() =>
     applyBacklogOrder(tickets, backlogOrder[projectId] || []),
   )
-  const [hasManualOrder, setHasManualOrder] = useState((backlogOrder[projectId] || []).length > 0)
+  const [hasManualOrder, setHasManualOrder] = useState(
+    !sort && (backlogOrder[projectId] || []).length > 0,
+  )
   const sortInitRef = useRef<SortConfig | null>(sort)
   const sortDidInitRef = useRef(false)
 
@@ -111,8 +113,14 @@ export function BacklogTable({
     const projectOrder = backlogOrder[projectId] || []
     const ordered = applyBacklogOrder(tickets, projectOrder)
     setOrderedTickets(ordered)
-    setHasManualOrder(projectOrder.length > 0)
-  }, [tickets, backlogOrder, projectId, applyBacklogOrder])
+    // Only apply manual order when no sort is active. When a sort is active,
+    // keep hasManualOrder false so the sort is applied. This prevents ticket
+    // data updates (e.g. from context menu edits) from reverting to manual
+    // order and making it look like the sort column was reset.
+    if (!sort) {
+      setHasManualOrder(projectOrder.length > 0)
+    }
+  }, [tickets, backlogOrder, projectId, applyBacklogOrder, sort])
 
   // Reset manual order when sort changes (user clicked a column header to sort)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixed bug where editing ticket fields via context menu (assign, priority, points, etc.) would reset the backlog table sort order when the user had previously reordered tickets via drag-and-drop
- The ticket sync `useEffect` was unconditionally setting `hasManualOrder` from persisted backlog order on every ticket data change, which bypassed the active sort comparator
- Now `hasManualOrder` is only restored from persisted order when no sort column is active, keeping the sort stable during ticket edits

## Test plan
- [x] Open backlog, sort by Points column (ascending)
- [x] Right-click an unassigned ticket and assign it via context menu
- [x] Verify sort column remains on Points with same direction (ascending arrow still visible)
- [x] Repeat with other sort columns (Priority, Key, Due Date, etc.)
- [x] Repeat with other context menu actions (change priority, set story points, change status)
- [x] Verify drag-and-drop reordering still works correctly when no sort is active
- [x] Verify that clicking a column header to sort still overrides manual drag order

🤖 Generated with [Claude Code](https://claude.com/claude-code)