### PR TITLE
fix(docs): replace placeholder GitHub URLs with canonical repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ PUNT is a lightweight, local-first issue tracking system for teams who want the 
 
 ```bash
 # Clone and install
-git clone https://github.com/yourusername/punt.git
+git clone https://github.com/jmynes/punt.git
 cd punt
 pnpm install
 


### PR DESCRIPTION
## Summary
- Replace `yourusername` placeholder in README.md clone URL with the canonical `jmynes/punt` repo URL

## Test plan
- [x] Verified no remaining occurrences of `yourusername` in the codebase
- [x] Confirmed all other GitHub URLs already point to `jmynes/punt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)