### PR TITLE
fix: resolve TypeScript build errors breaking CI

### DIFF
--- a/src/components/tickets/create-ticket-dialog.tsx
+++ b/src/components/tickets/create-ticket-dialog.tsx
@@ -195,6 +195,7 @@ export function CreateTicketDialog() {
       startDate: formData.startDate,
       dueDate: formData.dueDate,
       resolution: formData.resolution || null,
+      resolvedAt: null,
       environment: formData.environment || null,
       affectedVersion: formData.affectedVersion || null,
       fixVersion: formData.fixVersion || null,

--- a/src/lib/database-export.ts
+++ b/src/lib/database-export.ts
@@ -127,6 +127,7 @@ export async function exportDatabase(): Promise<ExportData> {
     ...ticket,
     startDate: ticket.startDate?.toISOString() ?? null,
     dueDate: ticket.dueDate?.toISOString() ?? null,
+    resolvedAt: ticket.resolvedAt?.toISOString() ?? null,
     createdAt: ticket.createdAt.toISOString(),
     updatedAt: ticket.updatedAt.toISOString(),
     labelIds: ticket.labels.map((l) => l.id),

--- a/src/lib/demo/demo-storage.ts
+++ b/src/lib/demo/demo-storage.ts
@@ -290,6 +290,7 @@ class DemoStorage {
       startDate: data.startDate ?? null,
       dueDate: data.dueDate ?? null,
       resolution: data.resolution ?? null,
+      resolvedAt: null,
       environment: data.environment ?? null,
       affectedVersion: data.affectedVersion ?? null,
       fixVersion: data.fixVersion ?? null,

--- a/src/stores/sprint-store.ts
+++ b/src/stores/sprint-store.ts
@@ -111,7 +111,7 @@ export const useSprintStore = create<SprintState>()(
           // v1 → v2: add sprintSorts
           state.sprintSorts = state.sprintSorts ?? {}
         }
-        return state as SprintState
+        return state as unknown as SprintState
       },
     },
   ),


### PR DESCRIPTION
## Summary
- Add missing `resolvedAt` field to temp ticket object in `create-ticket-dialog.tsx` and `demo-storage.ts` (introduced by PUNT-78 `resolvedAt` feature but not propagated to all construction sites)
- Serialize `resolvedAt` Date to ISO string in `database-export.ts` (was passing raw Date where string was expected)
- Fix `sprint-store.ts` migrate function return type cast (`Record<string, unknown>` can't directly cast to `SprintState`)

All four errors caused the `pnpm build` TypeScript check to fail on every push to `main` since PUNT-78 was merged.

## Test plan
- [x] `pnpm build` passes with `NEXT_PUBLIC_DEMO_MODE=true`
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (914/914)

🤖 Generated with [Claude Code](https://claude.com/claude-code)