### PR TITLE
fix: remove duplicate parent key in TICKET_SELECT_FULL

### DIFF
--- a/src/lib/prisma-selects.ts
+++ b/src/lib/prisma-selects.ts
@@ -135,9 +135,6 @@ export const TICKET_SELECT_FULL = {
       },
     },
   },
-  parent: {
-    select: { id: true, number: true, title: true, type: true },
-  },
   attachments: {
     select: ATTACHMENT_SELECT,
     orderBy: { createdAt: 'desc' as const },


### PR DESCRIPTION
## Summary
- Squash merge of PR #157 resulted in two `parent` properties in `TICKET_SELECT_FULL`, causing Biome lint failure (`noDuplicateObjectKeys`)
- Removes the duplicate to fix CI

## Test plan
- [x] `pnpm lint` passes locally

🤖 Generated with [Claude Code](https://claude.ai/code)