### PR TITLE
fix(test): add missing linkedFrom/linkedTo to permissions test mock (PUNT-135)

### DIFF
--- a/src/app/api/projects/[projectId]/tickets/__tests__/permissions.test.ts
+++ b/src/app/api/projects/[projectId]/tickets/__tests__/permissions.test.ts
@@ -196,6 +196,8 @@ describe('Ticket API - Permission Tests', () => {
         columnId: 'column-1',
         creatorId: TEST_USER.id,
         watchers: [],
+        linkedFrom: [],
+        linkedTo: [],
       }
       // biome-ignore lint/suspicious/noExplicitAny: mock typing
       ;(mockDb.$transaction as any).mockImplementation(async (_fn: any) => {
@@ -229,6 +231,8 @@ describe('Ticket API - Permission Tests', () => {
         columnId: 'column-1',
         creatorId: ADMIN_USER.id,
         watchers: [],
+        linkedFrom: [],
+        linkedTo: [],
       }
       // biome-ignore lint/suspicious/noExplicitAny: mock typing
       ;(mockDb.$transaction as any).mockImplementation(async (_fn: any) => {


### PR DESCRIPTION
## Summary
- PR #157 (ticket linking) updated `transformTicket()` to destructure `linkedFrom` and `linkedTo`
- The permissions test mock tickets didn't include these fields, so `undefined.map()` threw a 500
- Adds `linkedFrom: []` and `linkedTo: []` to both mock ticket objects

Resolves PUNT-135

## Test plan
- [x] `permissions.test.ts` — all 10 tests pass (was 2 failures)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)