### PR TITLE
fix: prevent PrismaClient from being bundled into browser

### DIFF
--- a/scripts/test-permissions-direct.ts
+++ b/scripts/test-permissions-direct.ts
@@ -11,14 +11,14 @@ import {
   requireTicketPermission,
 } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
+import { PERMISSIONS } from '@/lib/permissions'
 import {
   canAssignRole,
   canManageMember,
   getEffectivePermissions,
   hasPermission,
   isMember,
-} from '@/lib/permissions'
-import { PERMISSIONS } from '@/lib/permissions/constants'
+} from '@/lib/permissions/check'
 
 interface TestResult {
   test: string

--- a/src/app/api/projects/[projectId]/__tests__/permissions.test.ts
+++ b/src/app/api/projects/[projectId]/__tests__/permissions.test.ts
@@ -39,19 +39,20 @@ vi.mock('@/lib/auth-helpers', async (importOriginal) => {
   }
 })
 
-vi.mock('@/lib/permissions', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/lib/permissions')>()
-  return {
-    ...original,
-    hasPermission: vi.fn(),
-    isMember: vi.fn(),
-    getEffectivePermissions: vi.fn(),
-  }
-})
+vi.mock('@/lib/permissions/check', () => ({
+  hasPermission: vi.fn(),
+  hasAnyPermission: vi.fn(),
+  hasAllPermissions: vi.fn(),
+  isMember: vi.fn(),
+  getEffectivePermissions: vi.fn(),
+  getRolePermissions: vi.fn(),
+  canManageMember: vi.fn(),
+  canAssignRole: vi.fn(),
+}))
 
 import { requireAuth } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
-import { hasPermission, isMember } from '@/lib/permissions'
+import { hasPermission, isMember } from '@/lib/permissions/check'
 // Import routes after mocks
 import { DELETE, GET, PATCH } from '../route'
 

--- a/src/app/api/projects/[projectId]/members/[memberId]/route.ts
+++ b/src/app/api/projects/[projectId]/members/[memberId]/route.ts
@@ -4,14 +4,8 @@ import { handleApiError, notFoundError } from '@/lib/api-utils'
 import { requireAuth, requirePermission, requireProjectByKey } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
 import { projectEvents } from '@/lib/events'
-import {
-  canAssignRole,
-  canManageMember,
-  isMember,
-  isValidPermission,
-  PERMISSIONS,
-  parsePermissions,
-} from '@/lib/permissions'
+import { isValidPermission, PERMISSIONS, parsePermissions } from '@/lib/permissions'
+import { canAssignRole, canManageMember, isMember } from '@/lib/permissions/check'
 
 // Schema for updating a member
 const updateMemberSchema = z.object({

--- a/src/app/api/projects/[projectId]/my-permissions/route.ts
+++ b/src/app/api/projects/[projectId]/my-permissions/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server'
 import { handleApiError } from '@/lib/api-utils'
 import { requireAuth, requireProjectByKey } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
-import { getEffectivePermissions, parsePermissions } from '@/lib/permissions'
+import { parsePermissions } from '@/lib/permissions'
+import { getEffectivePermissions } from '@/lib/permissions/check'
 
 /**
  * GET /api/projects/[projectId]/my-permissions

--- a/src/app/api/projects/[projectId]/roles/[roleId]/route.ts
+++ b/src/app/api/projects/[projectId]/roles/[roleId]/route.ts
@@ -3,7 +3,8 @@ import { z } from 'zod'
 import { handleApiError, notFoundError } from '@/lib/api-utils'
 import { requireAuth, requirePermission, requireProjectByKey } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
-import { isMember, isValidPermission, PERMISSIONS, parsePermissions } from '@/lib/permissions'
+import { isValidPermission, PERMISSIONS, parsePermissions } from '@/lib/permissions'
+import { isMember } from '@/lib/permissions/check'
 
 // Schema for updating a role
 const updateRoleSchema = z.object({

--- a/src/app/api/projects/[projectId]/roles/route.ts
+++ b/src/app/api/projects/[projectId]/roles/route.ts
@@ -3,7 +3,8 @@ import { z } from 'zod'
 import { handleApiError, validationError } from '@/lib/api-utils'
 import { requireAuth, requirePermission, requireProjectByKey } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
-import { isMember, isValidPermission, PERMISSIONS, parsePermissions } from '@/lib/permissions'
+import { isValidPermission, PERMISSIONS, parsePermissions } from '@/lib/permissions'
+import { isMember } from '@/lib/permissions/check'
 
 // Schema for creating a new role
 const createRoleSchema = z.object({

--- a/src/app/api/projects/[projectId]/tickets/__tests__/permissions.test.ts
+++ b/src/app/api/projects/[projectId]/tickets/__tests__/permissions.test.ts
@@ -42,20 +42,20 @@ vi.mock('@/lib/auth-helpers', async (importOriginal) => {
   }
 })
 
-vi.mock('@/lib/permissions', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/lib/permissions')>()
-  return {
-    ...original,
-    hasPermission: vi.fn(),
-    hasAnyPermission: vi.fn(),
-    isMember: vi.fn(),
-    getEffectivePermissions: vi.fn(),
-  }
-})
+vi.mock('@/lib/permissions/check', () => ({
+  hasPermission: vi.fn(),
+  hasAnyPermission: vi.fn(),
+  hasAllPermissions: vi.fn(),
+  isMember: vi.fn(),
+  getEffectivePermissions: vi.fn(),
+  getRolePermissions: vi.fn(),
+  canManageMember: vi.fn(),
+  canAssignRole: vi.fn(),
+}))
 
 import { requireAuth } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
-import { getEffectivePermissions, hasPermission, isMember } from '@/lib/permissions'
+import { getEffectivePermissions, hasPermission, isMember } from '@/lib/permissions/check'
 // Import routes after mocks
 import { GET, POST } from '../route'
 

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -3,7 +3,8 @@ import { z } from 'zod'
 import { requireAuth } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
 import { projectEvents } from '@/lib/events'
-import { createDefaultRolesForProject, DEFAULT_ROLE_NAMES } from '@/lib/permissions'
+import { DEFAULT_ROLE_NAMES } from '@/lib/permissions'
+import { createDefaultRolesForProject } from '@/lib/permissions/create-default-roles'
 
 const createProjectSchema = z.object({
   name: z.string().min(1, 'Name is required'),

--- a/src/components/admin/branding-settings-form.tsx
+++ b/src/components/admin/branding-settings-form.tsx
@@ -13,7 +13,7 @@ import {
   useUpdateSystemSettings,
   useUploadLogo,
 } from '@/hooks/queries/use-system-settings'
-import { DEFAULT_BRANDING } from '@/lib/system-settings'
+import { DEFAULT_BRANDING } from '@/lib/branding'
 
 export function BrandingSettingsForm() {
   const { data: settings, isLoading, error } = useSystemSettings()

--- a/src/hooks/queries/use-branding.ts
+++ b/src/hooks/queries/use-branding.ts
@@ -1,9 +1,9 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import { DEFAULT_BRANDING } from '@/lib/branding'
 import type { BrandingSettings } from '@/lib/data-provider'
 import { getDataProvider } from '@/lib/data-provider'
-import { DEFAULT_BRANDING } from '@/lib/system-settings'
 
 export const brandingKeys = {
   all: ['branding'] as const,

--- a/src/lib/__tests__/auth-helpers-permissions.test.ts
+++ b/src/lib/__tests__/auth-helpers-permissions.test.ts
@@ -14,27 +14,16 @@ vi.mock('@/lib/db', () => ({
   },
 }))
 
-// Mock the permissions module
-vi.mock('@/lib/permissions', () => ({
+// Mock the permissions check module (server-only, uses db)
+vi.mock('@/lib/permissions/check', () => ({
   hasPermission: vi.fn(),
   hasAnyPermission: vi.fn(),
+  hasAllPermissions: vi.fn(),
   isMember: vi.fn(),
   getEffectivePermissions: vi.fn(),
-  PERMISSIONS: {
-    PROJECT_SETTINGS: 'project.settings',
-    PROJECT_DELETE: 'project.delete',
-    MEMBERS_INVITE: 'members.invite',
-    MEMBERS_MANAGE: 'members.manage',
-    MEMBERS_ADMIN: 'members.admin',
-    BOARD_MANAGE: 'board.manage',
-    TICKETS_CREATE: 'tickets.create',
-    TICKETS_MANAGE_OWN: 'tickets.manage_own',
-    TICKETS_MANAGE_ANY: 'tickets.manage_any',
-    SPRINTS_MANAGE: 'sprints.manage',
-    LABELS_MANAGE: 'labels.manage',
-    COMMENTS_MANAGE_ANY: 'comments.manage_any',
-    ATTACHMENTS_MANAGE_ANY: 'attachments.manage_any',
-  },
+  getRolePermissions: vi.fn(),
+  canManageMember: vi.fn(),
+  canAssignRole: vi.fn(),
 }))
 
 // Import mocked functions
@@ -43,7 +32,7 @@ import {
   hasAnyPermission,
   hasPermission,
   isMember,
-} from '@/lib/permissions'
+} from '@/lib/permissions/check'
 // Import the auth-helpers after mocks are set up
 import {
   requireAnyPermission,

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -2,13 +2,13 @@ import { headers } from 'next/headers'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { DEMO_USER, isDemoMode } from '@/lib/demo'
+import type { Permission } from '@/lib/permissions'
 import {
   hasAnyPermission as checkAnyPermission,
   hasPermission as checkPermission,
   getEffectivePermissions,
   isMember,
-  type Permission,
-} from '@/lib/permissions'
+} from '@/lib/permissions/check'
 
 /**
  * Check if the current request is authenticated via MCP API key.

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -1,0 +1,20 @@
+/**
+ * Branding constants and types.
+ * Separated from system-settings.ts to avoid pulling PrismaClient into client bundles.
+ */
+
+export const DEFAULT_BRANDING = {
+  appName: 'PUNT',
+  logoUrl: null as string | null,
+  logoLetter: 'P',
+  logoGradientFrom: '#f59e0b',
+  logoGradientTo: '#ea580c',
+}
+
+export interface BrandingSettings {
+  appName: string
+  logoUrl: string | null
+  logoLetter: string
+  logoGradientFrom: string
+  logoGradientTo: string
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,7 +10,8 @@ const globalForPrisma = globalThis as unknown as {
 // string fields before they reach SQLite (which has no native enum support).
 function createPrismaClient() {
   const client = new PrismaClient().$extends({
-    query: enumValidationExtension as Parameters<PrismaClient['$extends']>[0]['query'],
+    // biome-ignore lint/suspicious/noExplicitAny: Prisma's DynamicQueryExtensionArgs generic is too complex to satisfy statically
+    query: enumValidationExtension as any,
   })
   // Cast back to PrismaClient for type compatibility across the codebase.
   // The extended client is a superset of PrismaClient with identical API.

--- a/src/lib/permissions/index.ts
+++ b/src/lib/permissions/index.ts
@@ -1,22 +1,12 @@
 /**
  * Permissions Module
  *
- * Re-exports all permission-related utilities and constants.
+ * Re-exports permission constants, types, and presets.
+ * Server-only modules (check.ts, create-default-roles.ts) are NOT re-exported
+ * here because they import PrismaClient, which cannot be bundled for the browser.
+ * Import those directly: '@/lib/permissions/check', '@/lib/permissions/create-default-roles'.
  */
 
-// Permission checking
-export {
-  canAssignRole,
-  canManageMember,
-  type EffectivePermissions,
-  getEffectivePermissions,
-  getRolePermissions,
-  hasAllPermissions,
-  hasAnyPermission,
-  hasPermission,
-  isMember,
-  type MembershipWithRole,
-} from './check'
 // Constants and types
 export {
   ALL_PERMISSIONS,
@@ -33,13 +23,6 @@ export {
   type PermissionMeta,
   parsePermissions,
 } from './constants'
-// Role creation helpers
-export {
-  createDefaultRolesForProject,
-  getMemberRoleForProject,
-  getOwnerRoleForProject,
-  getRoleByName,
-} from './create-default-roles'
 // Role presets
 export {
   DEFAULT_ROLE_NAMES,

--- a/src/lib/system-settings.ts
+++ b/src/lib/system-settings.ts
@@ -3,16 +3,11 @@
  * Provides cached access to system-wide settings like file upload limits and branding.
  */
 
+import { type BrandingSettings, DEFAULT_BRANDING } from '@/lib/branding'
 import { db } from '@/lib/db'
 
-// Default branding values
-export const DEFAULT_BRANDING = {
-  appName: 'PUNT',
-  logoUrl: null as string | null,
-  logoLetter: 'P',
-  logoGradientFrom: '#f59e0b',
-  logoGradientTo: '#ea580c',
-}
+export type { BrandingSettings } from '@/lib/branding'
+export { DEFAULT_BRANDING } from '@/lib/branding'
 
 // Default values matching Prisma schema defaults
 const DEFAULT_SETTINGS = {
@@ -32,14 +27,6 @@ const DEFAULT_SETTINGS = {
     'text/plain',
     'text/csv',
   ],
-}
-
-export interface BrandingSettings {
-  appName: string
-  logoUrl: string | null
-  logoLetter: string
-  logoGradientFrom: string
-  logoGradientTo: string
 }
 
 export interface SystemSettings {


### PR DESCRIPTION
## Summary
- Two import chains were pulling the server-only `PrismaClient` into client bundles, causing runtime crashes:
  1. `providers.tsx → use-branding.ts → system-settings.ts → db.ts` — Fixed by extracting `DEFAULT_BRANDING` into `src/lib/branding.ts` (no db import)
  2. `sidebar-content.tsx → permissions/index.ts → permissions/check.ts → db.ts` — Fixed by removing server-only re-exports from the permissions barrel; server files now import directly from `@/lib/permissions/check`
- Also fixes `db.ts` `$extends` type cast for Prisma's complex generics

## Test plan
- [x] TypeScript compiles without errors in changed files
- [x] All 1143 tests pass (1 flaky fuzz test unrelated)
- [x] Dev server starts and responds without PrismaClient browser error
- [x] Login page loads (200)
- [x] Authenticated pages redirect correctly (302)

🤖 Generated with [Claude Code](https://claude.com/claude-code)