### PR TITLE
feat(tickets): add ability to move tickets across projects (PUNT-8)

### DIFF
--- a/src/app/api/projects/[projectId]/tickets/[ticketId]/move/route.ts
+++ b/src/app/api/projects/[projectId]/tickets/[ticketId]/move/route.ts
@@ -1,0 +1,236 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { badRequestError, handleApiError, notFoundError, validationError } from '@/lib/api-utils'
+import { requireAuth, requireMembership, requireProjectByKey } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { projectEvents } from '@/lib/events'
+import { TICKET_SELECT_FULL, transformTicket } from '@/lib/prisma-selects'
+
+const moveTicketSchema = z.object({
+  targetProjectId: z.string().min(1, 'Target project ID is required'),
+})
+
+/**
+ * POST /api/projects/[projectId]/tickets/[ticketId]/move - Move a ticket to another project
+ *
+ * This endpoint moves a ticket from one project to another. It:
+ * - Validates user has access to both source and target projects
+ * - Generates a new ticket number in the target project
+ * - Clears project-scoped fields: sprintId, labelIds, parentId
+ * - Assigns the ticket to the first column of the target project
+ * - Clears assigneeId if the assignee is not a member of the target project
+ * - Clears watchers who are not members of the target project
+ * - Removes ticket links (as linked tickets may be in different projects)
+ * - Preserves: title, description, type, priority, storyPoints, etc.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ projectId: string; ticketId: string }> },
+) {
+  try {
+    const user = await requireAuth()
+    const { projectId: sourceProjectKey, ticketId } = await params
+    const sourceProjectId = await requireProjectByKey(sourceProjectKey)
+
+    // Check source project membership
+    await requireMembership(user.id, sourceProjectId)
+
+    // Parse and validate request body
+    const body = await request.json()
+    const parsed = moveTicketSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return validationError(parsed)
+    }
+
+    const { targetProjectId: targetProjectKey } = parsed.data
+
+    // Resolve target project key to ID
+    const targetProjectId = await requireProjectByKey(targetProjectKey).catch(() => null)
+    if (!targetProjectId) {
+      return notFoundError('Target project')
+    }
+
+    // Check target project membership
+    await requireMembership(user.id, targetProjectId)
+
+    // Prevent moving to the same project
+    if (sourceProjectId === targetProjectId) {
+      return badRequestError('Cannot move ticket to the same project')
+    }
+
+    // Get the ticket with full details
+    const ticket = await db.ticket.findFirst({
+      where: { id: ticketId, projectId: sourceProjectId },
+      select: {
+        ...TICKET_SELECT_FULL,
+        // Also get watcher user IDs for filtering
+        watchers: {
+          select: {
+            userId: true,
+            user: {
+              select: {
+                id: true,
+                username: true,
+                name: true,
+                email: true,
+                avatar: true,
+                avatarColor: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    if (!ticket) {
+      return notFoundError('Ticket')
+    }
+
+    // Get the first column of the target project
+    const targetColumn = await db.column.findFirst({
+      where: { projectId: targetProjectId },
+      orderBy: { order: 'asc' },
+    })
+
+    if (!targetColumn) {
+      return badRequestError('Target project has no columns')
+    }
+
+    // Check if assignee is a member of the target project
+    let newAssigneeId: string | null = null
+    if (ticket.assigneeId) {
+      const assigneeMembership = await db.projectMember.findUnique({
+        where: {
+          userId_projectId: {
+            userId: ticket.assigneeId,
+            projectId: targetProjectId,
+          },
+        },
+      })
+      if (assigneeMembership) {
+        newAssigneeId = ticket.assigneeId
+      }
+    }
+
+    // Get list of watchers who are members of the target project
+    const watcherUserIds = ticket.watchers.map((w) => w.userId)
+    let validWatcherIds: string[] = []
+    if (watcherUserIds.length > 0) {
+      const validMembers = await db.projectMember.findMany({
+        where: {
+          projectId: targetProjectId,
+          userId: { in: watcherUserIds },
+        },
+        select: { userId: true },
+      })
+      validWatcherIds = validMembers.map((m) => m.userId)
+    }
+
+    // Move the ticket in a transaction
+    const movedTicket = await db.$transaction(async (tx) => {
+      // Get max ticket number for target project
+      const maxResult = await tx.ticket.aggregate({
+        where: { projectId: targetProjectId },
+        _max: { number: true },
+      })
+      const nextNumber = (maxResult._max.number ?? 0) + 1
+
+      // Get max order in target column
+      const maxOrderResult = await tx.ticket.aggregate({
+        where: { columnId: targetColumn.id },
+        _max: { order: true },
+      })
+      const nextOrder = (maxOrderResult._max.order ?? -1) + 1
+
+      // Delete existing ticket links (they're project-scoped)
+      await tx.ticketLink.deleteMany({
+        where: {
+          OR: [{ fromTicketId: ticketId }, { toTicketId: ticketId }],
+        },
+      })
+
+      // Delete existing watchers (will recreate valid ones)
+      await tx.ticketWatcher.deleteMany({
+        where: { ticketId },
+      })
+
+      // Update the ticket
+      await tx.ticket.update({
+        where: { id: ticketId },
+        data: {
+          projectId: targetProjectId,
+          number: nextNumber,
+          columnId: targetColumn.id,
+          order: nextOrder,
+          // Clear project-scoped fields
+          sprintId: null,
+          parentId: null,
+          // Clear assignee if not a member of target project
+          assigneeId: newAssigneeId,
+          // Clear labels (they're project-scoped)
+          labels: { set: [] },
+          // Clear carryover tracking (sprint-related)
+          isCarriedOver: false,
+          carriedFromSprintId: null,
+          carriedOverCount: 0,
+          // Clear resolution tracking (may have different done columns)
+          resolution: null,
+          resolvedAt: null,
+        },
+        select: TICKET_SELECT_FULL,
+      })
+
+      // Recreate watchers for valid members
+      if (validWatcherIds.length > 0) {
+        await tx.ticketWatcher.createMany({
+          data: validWatcherIds.map((userId) => ({ ticketId, userId })),
+        })
+      }
+
+      // Re-fetch to get updated watchers
+      const finalTicket = await tx.ticket.findUnique({
+        where: { id: ticketId },
+        select: TICKET_SELECT_FULL,
+      })
+
+      return finalTicket
+    })
+
+    if (!movedTicket) {
+      return badRequestError('Failed to move ticket')
+    }
+
+    // Emit real-time events
+    const tabId = request.headers.get('X-Tab-Id') || undefined
+
+    // Emit delete event for source project (so it disappears from source board)
+    projectEvents.emitTicketEvent({
+      type: 'ticket.deleted',
+      projectId: sourceProjectId,
+      ticketId,
+      userId: user.id,
+      tabId,
+      timestamp: Date.now(),
+    })
+
+    // Emit create event for target project (so it appears on target board)
+    projectEvents.emitTicketEvent({
+      type: 'ticket.created',
+      projectId: targetProjectId,
+      ticketId,
+      userId: user.id,
+      tabId,
+      timestamp: Date.now(),
+    })
+
+    return NextResponse.json({
+      success: true,
+      ticket: transformTicket(movedTicket),
+      sourceProjectId,
+      targetProjectId,
+    })
+  } catch (error) {
+    return handleApiError(error, 'move ticket')
+  }
+}

--- a/src/components/board/ticket-context-menu.tsx
+++ b/src/components/board/ticket-context-menu.tsx
@@ -7,6 +7,7 @@ import {
   ChevronRight,
   ClipboardCopy,
   ClipboardPaste,
+  FolderOpen,
   Hash,
   Pencil,
   Plus,
@@ -29,6 +30,7 @@ import { createPortal } from 'react-dom'
 import { toast } from 'sonner'
 import { PriorityBadge } from '@/components/common/priority-badge'
 import { resolutionConfig } from '@/components/common/resolution-badge'
+import { MoveToProjectDialog } from '@/components/tickets/move-to-project-dialog'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -98,6 +100,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
   )
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<TicketWithRelations[]>([])
+  const [showMoveToProject, setShowMoveToProject] = useState(false)
   // Track if component has mounted to avoid hydration mismatch
   const [isMounted, setIsMounted] = useState(false)
 
@@ -1074,6 +1077,18 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                 onMouseEnter={closeSubmenu}
                 onClick={doPaste}
               />
+              {!multi && (
+                <MenuButton
+                  icon={<FolderOpen className="h-4 w-4" />}
+                  label="Move to Project"
+                  onMouseEnter={closeSubmenu}
+                  onClick={() => {
+                    setShowMoveToProject(true)
+                    setOpen(false)
+                    setSubmenu(null)
+                  }}
+                />
+              )}
               <MenuButton
                 icon={<Trash2 className="h-4 w-4" />}
                 label="Delete"
@@ -1356,6 +1371,15 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
+      )}
+      {isMounted && (
+        <MoveToProjectDialog
+          open={showMoveToProject}
+          onOpenChange={setShowMoveToProject}
+          ticket={ticket}
+          projectKey={ticket.project?.key || ''}
+          projectId={projectId}
+        />
       )}
     </>
   )

--- a/src/components/tickets/move-to-project-dialog.tsx
+++ b/src/components/tickets/move-to-project-dialog.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { FolderOpen } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useProjects } from '@/hooks/queries/use-projects'
+import { getTabId } from '@/hooks/use-realtime'
+import { useBoardStore } from '@/stores/board-store'
+import type { TicketWithRelations } from '@/types'
+
+interface MoveToProjectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  ticket: TicketWithRelations
+  projectKey: string
+  projectId: string
+}
+
+export function MoveToProjectDialog({
+  open,
+  onOpenChange,
+  ticket,
+  projectKey,
+  projectId,
+}: MoveToProjectDialogProps) {
+  const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(null)
+  const [isMoving, setIsMoving] = useState(false)
+
+  const { data: projects = [] } = useProjects()
+  const { removeTicket } = useBoardStore()
+
+  // Filter out the current project
+  const availableProjects = useMemo(() => {
+    return projects.filter((p) => p.id !== projectId)
+  }, [projects, projectId])
+
+  const selectedProject = availableProjects.find((p) => p.key === selectedProjectKey)
+
+  const handleMove = async () => {
+    if (!selectedProjectKey) return
+
+    setIsMoving(true)
+    try {
+      const tabId = getTabId()
+      const res = await fetch(`/api/projects/${projectKey}/tickets/${ticket.id}/move`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(tabId ? { 'X-Tab-Id': tabId } : {}),
+        },
+        body: JSON.stringify({ targetProjectId: selectedProjectKey }),
+      })
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({ error: 'Failed to move ticket' }))
+        throw new Error(error.error || 'Failed to move ticket')
+      }
+
+      const data = await res.json()
+
+      // Remove ticket from current project's board
+      removeTicket(projectId, ticket.id, ticket.columnId)
+
+      toast.success('Ticket moved', {
+        description: `${projectKey}-${ticket.number} moved to ${selectedProjectKey}-${data.ticket.number}`,
+        duration: 5000,
+      })
+
+      onOpenChange(false)
+      setSelectedProjectKey(null)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to move ticket')
+    } finally {
+      setIsMoving(false)
+    }
+  }
+
+  const handleClose = () => {
+    if (isMoving) return
+    onOpenChange(false)
+    setSelectedProjectKey(null)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="bg-zinc-950 border-zinc-800 max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-zinc-100">Move Ticket to Another Project</DialogTitle>
+          <DialogDescription className="text-zinc-400">
+            Move {projectKey}-{ticket.number} to a different project. The ticket will get a new
+            number in the target project.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Warning about what will be cleared */}
+          <div className="p-3 rounded bg-amber-500/10 border border-amber-500/30 text-sm text-amber-200">
+            <p className="font-medium mb-1">The following will be cleared:</p>
+            <ul className="list-disc list-inside text-amber-300/80 space-y-0.5">
+              <li>Sprint assignment</li>
+              <li>Labels (project-specific)</li>
+              <li>Parent/subtask relationship</li>
+              <li>Ticket links</li>
+              {ticket.assignee && <li>Assignee (if not a member of target project)</li>}
+            </ul>
+          </div>
+
+          {/* Project Selection */}
+          <div className="space-y-2">
+            <span className="text-sm text-zinc-400">Select Target Project</span>
+            <div className="max-h-60 overflow-y-auto rounded border border-zinc-800 bg-zinc-900/50">
+              {availableProjects.length === 0 ? (
+                <div className="p-4 text-center text-sm text-zinc-500">
+                  No other projects available
+                </div>
+              ) : (
+                <div className="divide-y divide-zinc-800">
+                  {availableProjects.map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      className={`w-full flex items-center gap-3 p-3 text-left transition-colors ${
+                        selectedProjectKey === p.key
+                          ? 'bg-amber-500/20 border-l-2 border-amber-500'
+                          : 'hover:bg-zinc-800/50'
+                      }`}
+                      onClick={() => setSelectedProjectKey(p.key)}
+                    >
+                      <div
+                        className="w-8 h-8 rounded flex items-center justify-center text-white text-sm font-bold"
+                        style={{ backgroundColor: p.color }}
+                      >
+                        {p.key.charAt(0)}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-xs text-zinc-500">{p.key}</span>
+                          <span className="text-sm text-zinc-200 truncate">{p.name}</span>
+                        </div>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Selected Project Preview */}
+          {selectedProject && (
+            <div className="p-3 rounded bg-zinc-800/50 border border-zinc-700">
+              <div className="text-xs text-zinc-500 mb-1">Moving to:</div>
+              <div className="flex items-center gap-2">
+                <div
+                  className="w-6 h-6 rounded flex items-center justify-center text-white text-xs font-bold"
+                  style={{ backgroundColor: selectedProject.color }}
+                >
+                  {selectedProject.key.charAt(0)}
+                </div>
+                <span className="font-mono text-sm text-zinc-400">{selectedProject.key}</span>
+                <span className="text-sm text-zinc-200">{selectedProject.name}</span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={isMoving}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleMove} disabled={!selectedProjectKey || isMoving}>
+            <FolderOpen className="h-4 w-4 mr-2" />
+            {isMoving ? 'Moving...' : 'Move Ticket'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- Add POST `/api/projects/[projectId]/tickets/[ticketId]/move` endpoint to move tickets between projects
- Add "Move to Project" option in ticket context menu (single ticket selection only)
- Create `MoveToProjectDialog` component for selecting the target project

## Details
When moving a ticket:
- Generates a new ticket number in the target project
- Clears project-scoped fields: sprint assignment, labels, parent/subtask relationships, and ticket links
- Preserves assignee only if they are a member of the target project
- Preserves watchers only if they are members of the target project
- Moves ticket to the first column of the target project
- Emits SSE events for both source (delete) and target (create) projects for real-time UI updates

## Test plan
- [x] Create tickets in two different projects
- [x] Right-click a ticket and select "Move to Project"
- [x] Verify the dialog shows all other projects the user has access to
- [x] Move a ticket and verify it appears in the target project with a new ticket number
- [x] Verify sprint, labels, and parent relationships are cleared
- [x] Verify assignee is cleared if not a member of target project
- [x] Verify the ticket disappears from the source project board immediately (SSE)
- [x] Verify multi-select does not show the "Move to Project" option

Generated with [Claude Code](https://claude.com/claude-code)