### PR TITLE
fix: resolve type errors in move ticket feature

### DIFF
--- a/src/components/board/ticket-context-menu.tsx
+++ b/src/components/board/ticket-context-menu.tsx
@@ -53,6 +53,7 @@ import { formatTicketIds } from '@/lib/ticket-format'
 import { showUndoRedoToast } from '@/lib/undo-toast'
 import { cn, getAvatarColor, getInitials } from '@/lib/utils'
 import { useBoardStore } from '@/stores/board-store'
+import { useProjectsStore } from '@/stores/projects-store'
 import { useSelectionStore } from '@/stores/selection-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useUIStore } from '@/stores/ui-store'
@@ -77,9 +78,11 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
   const submenuRef = useRef<HTMLDivElement | null>(null)
 
   const { getColumns } = useBoardStore()
+  const { getProject } = useProjectsStore()
   // Use the ticket's projectId directly instead of relying on activeProjectId from UI store
   // This ensures we always use the correct project context
   const projectId = ticket.projectId
+  const project = getProject(projectId)
   const columns = getColumns(projectId)
   // Call hooks unconditionally at top level for reactivity
   const _boardState = useBoardStore()
@@ -1377,7 +1380,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
           open={showMoveToProject}
           onOpenChange={setShowMoveToProject}
           ticket={ticket}
-          projectKey={ticket.project?.key || ''}
+          projectKey={project?.key || ''}
           projectId={projectId}
         />
       )}

--- a/src/components/tickets/move-to-project-dialog.tsx
+++ b/src/components/tickets/move-to-project-dialog.tsx
@@ -68,7 +68,7 @@ export function MoveToProjectDialog({
       const data = await res.json()
 
       // Remove ticket from current project's board
-      removeTicket(projectId, ticket.id, ticket.columnId)
+      removeTicket(projectId, ticket.id)
 
       toast.success('Ticket moved', {
         description: `${projectKey}-${ticket.number} moved to ${selectedProjectKey}-${data.ticket.number}`,


### PR DESCRIPTION
## Summary
- Fix type error: Use `useProjectsStore.getProject()` to get project key instead of non-existent `ticket.project`
- Fix type error: Update `removeTicket` call to use correct 2-argument signature

## Problem
CI build was failing on main with:
```
Type error: Property 'project' does not exist on type 'TicketWithRelations'
Type error: Expected 2 arguments, but got 3
```

## Test plan
- [x] Build passes locally
- [x] CI passes

Generated with [Claude Code](https://claude.com/claude-code)