### PR TITLE
feat(ui): add color coding to resolution status icons (PUNT-139)

### DIFF
--- a/src/components/common/resolution-badge.tsx
+++ b/src/components/common/resolution-badge.tsx
@@ -23,28 +23,28 @@ export const resolutionConfig: Record<
   },
   "Won't Fix": {
     icon: Ban,
-    className: 'border-zinc-600 bg-zinc-800/50 text-zinc-300',
-    color: '#d4d4d8',
+    className: 'border-zinc-600 bg-zinc-800/50 text-zinc-400',
+    color: '#a1a1aa',
   },
   Duplicate: {
     icon: Copy,
-    className: 'border-zinc-600 bg-zinc-800/50 text-zinc-300',
-    color: '#d4d4d8',
+    className: 'border-orange-600 bg-orange-900/30 text-orange-400',
+    color: '#fb923c',
   },
   'Cannot Reproduce': {
     icon: HelpCircle,
-    className: 'border-zinc-600 bg-zinc-800/50 text-zinc-300',
-    color: '#d4d4d8',
+    className: 'border-purple-600 bg-purple-900/30 text-purple-400',
+    color: '#c084fc',
   },
   Incomplete: {
     icon: MinusCircle,
-    className: 'border-zinc-600 bg-zinc-800/50 text-zinc-300',
-    color: '#d4d4d8',
+    className: 'border-amber-600 bg-amber-900/30 text-amber-400',
+    color: '#fbbf24',
   },
   "Won't Do": {
     icon: XCircle,
-    className: 'border-zinc-600 bg-zinc-800/50 text-zinc-300',
-    color: '#d4d4d8',
+    className: 'border-red-600 bg-red-900/30 text-red-400',
+    color: '#f87171',
   },
 }
 


### PR DESCRIPTION
## Summary
- Add distinct color coding to resolution status icons in backlog/sprint tables for quick visual identification
- Done remains green; Won't Fix is gray; Duplicate is orange; Cannot Reproduce is purple; Incomplete is amber; Won't Do is red
- Improves scannability by allowing users to distinguish resolution types at a glance

## Test plan
- [x] Open a project with tickets that have different resolution statuses
- [x] Navigate to the backlog view and verify each resolution type has its distinct color
- [x] Navigate to the sprint view and verify colors are consistent
- [x] Verify the color scheme is readable on both light and dark backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)