### PR TITLE
feat(mcp): log prompt context in ticket comments (PUNT-130)

### DIFF
--- a/mcp/src/api-client.ts
+++ b/mcp/src/api-client.ts
@@ -434,3 +434,40 @@ export async function listRoles(projectKey: string) {
     ] as RoleData[],
   }
 }
+
+// ============================================================================
+// Comments API
+// ============================================================================
+
+export interface CommentData {
+  id: string
+  content: string
+  createdAt: string
+  updatedAt: string
+  isSystemGenerated: boolean
+  source: string | null
+  author: {
+    id: string
+    name: string
+    email: string | null
+    avatar: string | null
+  }
+}
+
+export interface CreateCommentInput {
+  content: string
+  isSystemGenerated?: boolean
+  source?: string
+}
+
+export async function createComment(
+  projectKey: string,
+  ticketId: string,
+  data: CreateCommentInput,
+) {
+  return apiRequest<CommentData>(
+    'POST',
+    `/api/projects/${projectKey}/tickets/${ticketId}/comments`,
+    data,
+  )
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -404,6 +404,10 @@ model Comment {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // Track system-generated comments (e.g., MCP context logs)
+  isSystemGenerated Boolean @default(false)
+  source            String? // Optional source identifier (e.g., "mcp", "automation")
+
   ticketId String
   ticket   Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
   authorId String

--- a/src/app/api/projects/[projectId]/tickets/[ticketId]/comments/route.ts
+++ b/src/app/api/projects/[projectId]/tickets/[ticketId]/comments/route.ts
@@ -1,0 +1,122 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { handleApiError, notFoundError, validationError } from '@/lib/api-utils'
+import { requireAuth, requireMembership, requireProjectByKey } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { projectEvents } from '@/lib/events'
+import { USER_SELECT_SUMMARY } from '@/lib/prisma-selects'
+
+const createCommentSchema = z.object({
+  content: z.string().min(1, 'Comment content is required'),
+  isSystemGenerated: z.boolean().optional().default(false),
+  source: z.string().optional(),
+})
+
+/**
+ * GET /api/projects/[projectId]/tickets/[ticketId]/comments
+ * Get all comments for a ticket
+ * Requires project membership
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ projectId: string; ticketId: string }> },
+) {
+  try {
+    const user = await requireAuth()
+    const { projectId: projectKey, ticketId } = await params
+    const projectId = await requireProjectByKey(projectKey)
+
+    await requireMembership(user.id, projectId)
+
+    // Verify ticket exists and belongs to project
+    const ticket = await db.ticket.findFirst({
+      where: { id: ticketId, projectId },
+      select: { id: true },
+    })
+
+    if (!ticket) {
+      return notFoundError('Ticket')
+    }
+
+    const comments = await db.comment.findMany({
+      where: { ticketId },
+      include: {
+        author: {
+          select: USER_SELECT_SUMMARY,
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+    })
+
+    return NextResponse.json(comments)
+  } catch (error) {
+    return handleApiError(error, 'fetch comments')
+  }
+}
+
+/**
+ * POST /api/projects/[projectId]/tickets/[ticketId]/comments
+ * Add a comment to a ticket
+ * Requires project membership
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ projectId: string; ticketId: string }> },
+) {
+  try {
+    const user = await requireAuth()
+    const { projectId: projectKey, ticketId } = await params
+    const projectId = await requireProjectByKey(projectKey)
+
+    await requireMembership(user.id, projectId)
+
+    // Verify ticket exists and belongs to project
+    const ticket = await db.ticket.findFirst({
+      where: { id: ticketId, projectId },
+      select: { id: true },
+    })
+
+    if (!ticket) {
+      return notFoundError('Ticket')
+    }
+
+    const body = await request.json()
+    const parsed = createCommentSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return validationError(parsed)
+    }
+
+    const { content, isSystemGenerated, source } = parsed.data
+
+    const comment = await db.comment.create({
+      data: {
+        content,
+        isSystemGenerated,
+        source,
+        ticketId,
+        authorId: user.id,
+      },
+      include: {
+        author: {
+          select: USER_SELECT_SUMMARY,
+        },
+      },
+    })
+
+    // Emit SSE event so other clients refresh the ticket
+    const tabId = request.headers.get('X-Tab-Id') || undefined
+    projectEvents.emitTicketEvent({
+      type: 'ticket.updated',
+      projectId,
+      ticketId,
+      userId: user.id,
+      tabId,
+      timestamp: Date.now(),
+    })
+
+    return NextResponse.json(comment, { status: 201 })
+  } catch (error) {
+    return handleApiError(error, 'create comment')
+  }
+}


### PR DESCRIPTION
## Summary
- Add `context` parameter to MCP `create_ticket` and `update_ticket` tools
- When provided, the context/reasoning is logged as a system-generated comment on the ticket
- Comments are marked with `isSystemGenerated=true` and `source="mcp"` for identification
- Creates an audit trail of AI-assisted ticket management decisions

## Changes
- **Prisma Schema**: Add `isSystemGenerated` (boolean) and `source` (string?) fields to Comment model
- **API**: New `/api/projects/[projectId]/tickets/[ticketId]/comments` endpoint (GET/POST)
- **MCP api-client**: Add `createComment` function
- **MCP tools**: Add `context` parameter to `create_ticket` and `update_ticket` tools

## Test plan
- [ ] Create a ticket via MCP with a `context` parameter
- [ ] Verify a system comment is created on the ticket
- [ ] Update a ticket via MCP with a `context` parameter
- [ ] Verify a system comment is created for the update
- [ ] Verify comments without context don't create extra comments
- [ ] Verify the comment shows `isSystemGenerated: true` and `source: "mcp"`

---
Generated with [Claude Code](https://claude.com/claude-code)