### PR TITLE
feat(admin): support configurable fork URL for updates (PUNT-123)

### DIFF
--- a/src/components/admin/repository-settings-form.tsx
+++ b/src/components/admin/repository-settings-form.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   GitBranch,
   GitCommit,
+  GitFork,
   Loader2,
   RefreshCw,
   RotateCcw,
@@ -16,6 +17,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import { useSystemSettings, useUpdateSystemSettings } from '@/hooks/queries/use-system-settings'
 import { useCheckForUpdates, useLocalVersion } from '@/hooks/queries/use-version'
 
@@ -80,6 +82,62 @@ function CommitStatusInline({ status }: CommitStatusProps) {
   return <span className={colorClass}>{message}</span>
 }
 
+interface ForkComparisonProps {
+  forkVsLocal: CommitStatusProps['status'] | null
+  forkVsUpstream: CommitStatusProps['status'] | null
+}
+
+function ForkComparisonDisplay({ forkVsLocal, forkVsUpstream }: ForkComparisonProps) {
+  return (
+    <div className="space-y-1">
+      {forkVsLocal && (
+        <div className="flex items-center gap-2">
+          <span className="text-zinc-500 text-xs w-24">vs Local:</span>
+          {forkVsLocal.status === 'identical' ? (
+            <span className="text-green-400 text-xs">In sync</span>
+          ) : forkVsLocal.status === 'ahead' ? (
+            <span className="text-amber-400 text-xs">
+              Fork is {forkVsLocal.aheadBy} commit{forkVsLocal.aheadBy === 1 ? '' : 's'} ahead
+            </span>
+          ) : forkVsLocal.status === 'behind' ? (
+            <span className="text-blue-400 text-xs">
+              Local is {forkVsLocal.behindBy} commit{forkVsLocal.behindBy === 1 ? '' : 's'} ahead
+            </span>
+          ) : forkVsLocal.status === 'diverged' ? (
+            <span className="text-amber-400 text-xs">
+              Diverged (+{forkVsLocal.aheadBy}/-{forkVsLocal.behindBy})
+            </span>
+          ) : (
+            <span className="text-zinc-500 text-xs">Unknown</span>
+          )}
+        </div>
+      )}
+      {forkVsUpstream && (
+        <div className="flex items-center gap-2">
+          <span className="text-zinc-500 text-xs w-24">vs Upstream:</span>
+          {forkVsUpstream.status === 'identical' ? (
+            <span className="text-green-400 text-xs">In sync with upstream</span>
+          ) : forkVsUpstream.status === 'ahead' ? (
+            <span className="text-blue-400 text-xs">
+              {forkVsUpstream.aheadBy} commit{forkVsUpstream.aheadBy === 1 ? '' : 's'} ahead
+            </span>
+          ) : forkVsUpstream.status === 'behind' ? (
+            <span className="text-amber-400 text-xs">
+              {forkVsUpstream.behindBy} commit{forkVsUpstream.behindBy === 1 ? '' : 's'} behind
+            </span>
+          ) : forkVsUpstream.status === 'diverged' ? (
+            <span className="text-amber-400 text-xs">
+              Diverged (+{forkVsUpstream.aheadBy}/-{forkVsUpstream.behindBy})
+            </span>
+          ) : (
+            <span className="text-zinc-500 text-xs">Unknown</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function RepositorySettingsForm() {
   const { data: settings, isLoading, error } = useSystemSettings()
   const { data: localVersion } = useLocalVersion()
@@ -88,19 +146,25 @@ export function RepositorySettingsForm() {
 
   // Local form state - default to the canonical Punt repo
   const [repoUrl, setRepoUrl] = useState(DEFAULT_REPO_URL)
+  const [forkUrl, setForkUrl] = useState('')
+  const [checkForkForUpdates, setCheckForkForUpdates] = useState(false)
 
   // Validation state
   const [urlError, setUrlError] = useState<string | null>(null)
+  const [forkUrlError, setForkUrlError] = useState<string | null>(null)
 
   // Sync form state when settings are loaded
   useEffect(() => {
     if (settings) {
       // Use saved value if exists, otherwise use default
       setRepoUrl(settings.canonicalRepoUrl ?? DEFAULT_REPO_URL)
+      setForkUrl(settings.forkRepoUrl ?? '')
+      // If fork URL is set, assume user wants to check against it
+      setCheckForkForUpdates(!!settings.forkRepoUrl)
     }
   }, [settings])
 
-  // Validate URL on change
+  // Validate URLs on change
   useEffect(() => {
     if (repoUrl && !isValidUrl(repoUrl)) {
       setUrlError('Please enter a valid URL (http:// or https://)')
@@ -109,23 +173,36 @@ export function RepositorySettingsForm() {
     }
   }, [repoUrl])
 
-  // Compare against saved value (or default if never saved)
+  useEffect(() => {
+    if (forkUrl && !isValidUrl(forkUrl)) {
+      setForkUrlError('Please enter a valid URL (http:// or https://)')
+    } else {
+      setForkUrlError(null)
+    }
+  }, [forkUrl])
+
+  // Compare against saved values
   const savedUrl = settings?.canonicalRepoUrl ?? DEFAULT_REPO_URL
-  const hasChanges = settings && repoUrl !== savedUrl
+  const savedForkUrl = settings?.forkRepoUrl ?? ''
+  const hasChanges = settings && (repoUrl !== savedUrl || forkUrl !== savedForkUrl)
 
   const handleSave = () => {
-    if (urlError) return
+    if (urlError || forkUrlError) return
 
     updateSettings.mutate({
       canonicalRepoUrl: repoUrl || null,
-      // Auto-detect GitHub
+      forkRepoUrl: forkUrl || null,
+      // Auto-detect GitHub from canonical URL
       repoHostingProvider: repoUrl?.includes('github.com') ? 'github' : null,
     })
   }
 
   const handleReset = () => {
     setRepoUrl(savedUrl)
+    setForkUrl(savedForkUrl)
+    setCheckForkForUpdates(!!savedForkUrl)
     setUrlError(null)
+    setForkUrlError(null)
   }
 
   const handleCheckForUpdates = () => {
@@ -186,8 +263,8 @@ export function RepositorySettingsForm() {
           </div>
 
           {/* Update Check Section - fixed height to prevent reflow */}
-          <div className="mt-4 pt-4 border-t border-zinc-800 flex items-start justify-between gap-4 h-[2.5rem]">
-            <div className="flex items-center gap-2 text-sm h-full">
+          <div className="mt-4 pt-4 border-t border-zinc-800 flex items-start justify-between gap-4 min-h-[2.5rem]">
+            <div className="flex items-center gap-2 text-sm h-full flex-wrap">
               {checkForUpdates.isPending ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin text-zinc-400" />
@@ -246,21 +323,21 @@ export function RepositorySettingsForm() {
         </CardContent>
       </Card>
 
-      {/* Repository Configuration */}
+      {/* Upstream Repository Configuration */}
       <Card className="border-zinc-800 bg-zinc-900/50">
         <CardHeader>
           <div className="flex items-center gap-2">
             <GitBranch className="h-5 w-5 text-amber-500" />
-            <CardTitle className="text-zinc-100">Punt Repository</CardTitle>
+            <CardTitle className="text-zinc-100">Upstream Repository</CardTitle>
           </div>
           <CardDescription className="text-zinc-400">
-            The source repository for Punt. Change this if you&apos;re running a fork.
+            The canonical Punt repository. Used for checking for official releases and updates.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="repoUrl" className="text-zinc-300">
-              Repository URL
+              Upstream URL
             </Label>
             <Input
               id="repoUrl"
@@ -274,10 +351,89 @@ export function RepositorySettingsForm() {
               <p className="text-xs text-red-400">{urlError}</p>
             ) : (
               <p className="text-xs text-zinc-500">
-                The repository URL used for linking to source code and checking for updates.
+                The official Punt repository for release updates and source code links.
               </p>
             )}
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Fork Configuration */}
+      <Card className="border-zinc-800 bg-zinc-900/50">
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <GitFork className="h-5 w-5 text-amber-500" />
+            <CardTitle className="text-zinc-100">Fork Repository</CardTitle>
+          </div>
+          <CardDescription className="text-zinc-400">
+            If you&apos;re running a fork, configure it here to track your fork&apos;s updates
+            separately from the upstream repository.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="checkFork" className="text-zinc-300">
+                Track fork separately
+              </Label>
+              <p className="text-xs text-zinc-500">
+                Enable to compare your local version against your fork repository
+              </p>
+            </div>
+            <Switch
+              id="checkFork"
+              checked={checkForkForUpdates}
+              onCheckedChange={(checked) => {
+                setCheckForkForUpdates(checked)
+                if (!checked) {
+                  setForkUrl('')
+                }
+              }}
+            />
+          </div>
+
+          {checkForkForUpdates && (
+            <div className="space-y-2">
+              <Label htmlFor="forkUrl" className="text-zinc-300">
+                Fork URL
+              </Label>
+              <Input
+                id="forkUrl"
+                type="url"
+                value={forkUrl}
+                onChange={(e) => setForkUrl(e.target.value)}
+                className="bg-zinc-800 border-zinc-700 text-zinc-100 max-w-lg"
+                placeholder="https://github.com/your-username/punt/"
+              />
+              {forkUrlError ? (
+                <p className="text-xs text-red-400">{forkUrlError}</p>
+              ) : (
+                <p className="text-xs text-zinc-500">
+                  Your forked repository URL. Update checks will show how your fork compares to both
+                  your local version and the upstream repository.
+                </p>
+              )}
+            </div>
+          )}
+
+          {checkForkForUpdates && forkUrl && updateResult?.forkStatus && (
+            <div className="mt-4 pt-4 border-t border-zinc-800">
+              <p className="text-xs text-zinc-500 mb-2">Fork Status</p>
+              <div className="flex items-center gap-2 text-sm">
+                {updateResult.forkStatus.error ? (
+                  <>
+                    <AlertCircle className="h-4 w-4 text-red-400" />
+                    <span className="text-red-400">{updateResult.forkStatus.error}</span>
+                  </>
+                ) : (
+                  <ForkComparisonDisplay
+                    forkVsLocal={updateResult.forkStatus.forkVsLocal ?? null}
+                    forkVsUpstream={updateResult.forkStatus.forkVsUpstream ?? null}
+                  />
+                )}
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -296,7 +452,9 @@ export function RepositorySettingsForm() {
 
         <Button
           onClick={handleSave}
-          disabled={!hasChanges || urlError !== null || updateSettings.isPending}
+          disabled={
+            !hasChanges || urlError !== null || forkUrlError !== null || updateSettings.isPending
+          }
           variant="primary"
         >
           {updateSettings.isPending ? (


### PR DESCRIPTION
## Summary
- Add Fork Repository card in Updates tab with toggle to enable fork tracking
- Add fork URL input field with URL validation
- Update version check API to compare against fork when configured
- Show fork status comparison vs both local and upstream repositories

This allows users running forks to:
1. Track updates from their own fork separately from upstream
2. See if their fork is ahead/behind the canonical repository  
3. Compare their local version against both fork and upstream

## Test plan
- [ ] Navigate to Admin Settings > Updates tab
- [ ] Verify Upstream Repository card shows canonical URL
- [ ] Enable "Track fork separately" toggle in Fork Repository card
- [ ] Enter a valid fork URL and save
- [ ] Click "Check for updates" and verify fork status displays
- [ ] Verify fork comparison shows vs Local and vs Upstream statuses
- [ ] Test with invalid URL to verify error message appears
- [ ] Test disabling fork tracking clears the fork URL

Generated with [Claude Code](https://claude.ai/code)