### PR TITLE
feat(integrations): add git commit hooks integration (PUNT-37)

### DIFF
--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -1,0 +1,235 @@
+# PUNT Git Hooks Integration
+
+Automatically update PUNT tickets based on your git commits. When you mention a ticket in your commit message (e.g., `PUNT-123`), the hook notifies PUNT and can automatically update ticket status.
+
+## Features
+
+- **Auto-close tickets**: Using keywords like `fixes PUNT-123` or `closes PUNT-123` automatically moves tickets to Done
+- **Mark in progress**: Using `wip PUNT-123` or `working on PUNT-123` moves tickets to In Progress
+- **Commit tracking**: All ticket references are logged for future reference
+- **Commit message validation**: Optionally require ticket references in commit messages
+
+## Quick Start
+
+### 1. Generate an API Key
+
+1. Open PUNT and go to your Profile
+2. Navigate to the API Key section
+3. Click "Generate API Key" and copy it
+
+### 2. Install the Hooks
+
+```bash
+# Clone or download the hooks
+curl -o post-commit https://raw.githubusercontent.com/your-org/punt/main/scripts/git-hooks/post-commit
+curl -o commit-msg https://raw.githubusercontent.com/your-org/punt/main/scripts/git-hooks/commit-msg
+
+# Or use the installer
+./scripts/git-hooks/install.sh --repo /path/to/your-repo --hooks post-commit,commit-msg
+```
+
+### 3. Configure Environment
+
+Add to your shell profile (`.bashrc`, `.zshrc`, etc.):
+
+```bash
+export PUNT_API_KEY="your-api-key-here"
+export PUNT_BASE_URL="http://localhost:3000"  # Your PUNT server URL
+```
+
+Or create a `.env` file in your repository and use a tool like [direnv](https://direnv.net/).
+
+## Hook Details
+
+### post-commit
+
+Runs after each commit and sends commit information to PUNT. Updates tickets based on keywords in the commit message.
+
+**Supported Patterns:**
+
+| Pattern | Action | Example |
+|---------|--------|---------|
+| `fixes PROJECT-123` | Move to Done | `fix: login bug fixes PUNT-42` |
+| `closes PROJECT-123` | Move to Done | `feat: add auth (closes PUNT-15)` |
+| `resolves PROJECT-123` | Move to Done | `resolves PUNT-99: null check` |
+| `wip PROJECT-123` | Move to In Progress | `wip PUNT-50: starting refactor` |
+| `working on PROJECT-123` | Move to In Progress | `working on PUNT-33` |
+| `PROJECT-123` | Log reference | `PUNT-100: added validation` |
+
+**Environment Variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PUNT_API_KEY` | Your PUNT API key (required) | - |
+| `PUNT_BASE_URL` | PUNT server URL | `http://localhost:3000` |
+| `PUNT_HOOK_DEBUG` | Enable debug output | `0` |
+| `PUNT_HOOK_QUIET` | Suppress all output | `0` |
+
+### commit-msg
+
+Validates commit messages before the commit is created. Can require or suggest ticket references.
+
+**Environment Variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PUNT_REQUIRE_TICKET` | `require`, `suggest`, or `ignore` | `suggest` |
+| `PUNT_PROJECT_KEYS` | Comma-separated valid project keys | Any |
+| `PUNT_HOOK_DEBUG` | Enable debug output | `0` |
+
+## Manual Installation
+
+Copy hooks to your repository's `.git/hooks/` directory:
+
+```bash
+# post-commit hook (ticket updates)
+cp scripts/git-hooks/post-commit /path/to/your-repo/.git/hooks/
+chmod +x /path/to/your-repo/.git/hooks/post-commit
+
+# commit-msg hook (message validation)
+cp scripts/git-hooks/commit-msg /path/to/your-repo/.git/hooks/
+chmod +x /path/to/your-repo/.git/hooks/commit-msg
+```
+
+## Installer Script
+
+Use the provided installer for easier setup:
+
+```bash
+# Install to current repository
+./scripts/git-hooks/install.sh
+
+# Install to specific repository
+./scripts/git-hooks/install.sh --repo /path/to/repo
+
+# Install specific hooks
+./scripts/git-hooks/install.sh --hooks post-commit,commit-msg
+
+# Force overwrite existing hooks
+./scripts/git-hooks/install.sh --force
+
+# Uninstall hooks
+./scripts/git-hooks/install.sh --uninstall
+```
+
+## API Reference
+
+The hooks communicate with PUNT via the Git Hook Integration API:
+
+**Endpoint:** `POST /api/integrations/git-hook`
+
+**Headers:**
+- `Content-Type: application/json`
+- `X-API-Key: <your-api-key>`
+
+**Request Body:**
+```json
+{
+  "commits": [
+    {
+      "message": "fixes PUNT-123: resolve login bug",
+      "sha": "abc123...",
+      "author": "Jane Developer",
+      "timestamp": "2024-01-15T10:30:00Z",
+      "branch": "feature/auth"
+    }
+  ],
+  "projectKeys": ["PUNT"],
+  "dryRun": false
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "dryRun": false,
+  "processed": 1,
+  "updates": [
+    {
+      "ticketKey": "PUNT-123",
+      "action": "close",
+      "success": true,
+      "message": "Ticket moved to Done (commit: abc123)",
+      "ticketId": "cuid123..."
+    }
+  ],
+  "summary": {
+    "closed": 1,
+    "inProgress": 0,
+    "referenced": 0,
+    "failed": 0
+  }
+}
+```
+
+## Troubleshooting
+
+### Hook not running
+
+1. Ensure the hook file is executable: `chmod +x .git/hooks/post-commit`
+2. Check the file has no `.sample` extension
+3. Verify PUNT_API_KEY is set: `echo $PUNT_API_KEY`
+
+### Connection errors
+
+1. Verify PUNT server is running: `curl $PUNT_BASE_URL/api/integrations/git-hook`
+2. Check PUNT_BASE_URL is correct (no trailing slash)
+3. Ensure your network can reach the PUNT server
+
+### Authentication errors
+
+1. Verify your API key is valid in PUNT Profile page
+2. Check the API key is correctly exported: `echo $PUNT_API_KEY`
+3. Regenerate the API key if needed
+
+### Debug mode
+
+Enable debug output to see what's happening:
+
+```bash
+export PUNT_HOOK_DEBUG=1
+git commit -m "test PUNT-1"
+```
+
+### Bypassing hooks
+
+To skip hooks for a single commit:
+
+```bash
+git commit --no-verify -m "emergency fix"
+```
+
+## Security Considerations
+
+- **API keys**: Keep your API key secret. Never commit it to version control.
+- **Permissions**: The hook uses your PUNT permissions. You can only update tickets in projects you're a member of.
+- **Network**: The hook sends commit metadata to your PUNT server. Ensure you trust the server.
+
+## CI/CD Integration
+
+You can use the same API in your CI/CD pipelines:
+
+```bash
+# Example: GitHub Actions
+- name: Update PUNT tickets
+  run: |
+    curl -X POST "$PUNT_BASE_URL/api/integrations/git-hook" \
+      -H "Content-Type: application/json" \
+      -H "X-API-Key: $PUNT_API_KEY" \
+      -d '{
+        "commits": [{
+          "message": "${{ github.event.head_commit.message }}",
+          "sha": "${{ github.sha }}",
+          "author": "${{ github.actor }}",
+          "branch": "${{ github.ref_name }}"
+        }]
+      }'
+  env:
+    PUNT_BASE_URL: ${{ secrets.PUNT_BASE_URL }}
+    PUNT_API_KEY: ${{ secrets.PUNT_API_KEY }}
+```
+
+## Contributing
+
+Found a bug or have a feature request? Open an issue or submit a pull request!

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# PUNT Git Hook: commit-msg
+#
+# This hook validates that the commit message contains a ticket reference.
+# It can be configured to require, suggest, or ignore ticket references.
+#
+# Configuration (via environment variables):
+#   PUNT_REQUIRE_TICKET  - "require" to block commits without tickets,
+#                          "suggest" to warn but allow (default),
+#                          "ignore" to skip validation
+#   PUNT_PROJECT_KEYS    - Comma-separated list of valid project keys
+#                          (e.g., "PUNT,PROJ,BUG"). If empty, accepts any.
+#   PUNT_HOOK_DEBUG      - Set to "1" to enable debug output
+#
+# Installation:
+#   1. Copy this file to your repository's .git/hooks/commit-msg
+#   2. Make it executable: chmod +x .git/hooks/commit-msg
+#
+
+set -e
+
+# Configuration
+PUNT_REQUIRE_TICKET="${PUNT_REQUIRE_TICKET:-suggest}"
+PUNT_PROJECT_KEYS="${PUNT_PROJECT_KEYS:-}"
+
+# Get the commit message file path
+COMMIT_MSG_FILE="$1"
+
+if [ ! -f "$COMMIT_MSG_FILE" ]; then
+    echo "[PUNT] Error: Commit message file not found"
+    exit 1
+fi
+
+# Read the commit message (excluding comments)
+COMMIT_MSG=$(grep -v '^#' "$COMMIT_MSG_FILE" | head -c 10000)
+
+# Skip validation if configured to ignore
+if [ "$PUNT_REQUIRE_TICKET" = "ignore" ]; then
+    exit 0
+fi
+
+# Build the ticket pattern
+if [ -n "$PUNT_PROJECT_KEYS" ]; then
+    # Create pattern from configured project keys
+    # Convert "PUNT,PROJ,BUG" to "PUNT|PROJ|BUG"
+    KEYS_PATTERN=$(echo "$PUNT_PROJECT_KEYS" | tr ',' '|')
+    TICKET_PATTERN="($KEYS_PATTERN)-[0-9]+"
+else
+    # Accept any project key (2-10 uppercase letters)
+    TICKET_PATTERN="[A-Z]{2,10}-[0-9]+"
+fi
+
+# Debug output
+if [ "$PUNT_HOOK_DEBUG" = "1" ]; then
+    echo "[PUNT] Validating commit message..."
+    echo "[PUNT] Pattern: $TICKET_PATTERN"
+    echo "[PUNT] Message: $(echo "$COMMIT_MSG" | head -1)"
+fi
+
+# Check for ticket reference
+if echo "$COMMIT_MSG" | grep -qE "$TICKET_PATTERN"; then
+    # Found a ticket reference
+    if [ "$PUNT_HOOK_DEBUG" = "1" ]; then
+        TICKET=$(echo "$COMMIT_MSG" | grep -oE "$TICKET_PATTERN" | head -1)
+        echo "[PUNT] Found ticket reference: $TICKET"
+    fi
+    exit 0
+fi
+
+# No ticket reference found
+if [ "$PUNT_REQUIRE_TICKET" = "require" ]; then
+    echo ""
+    echo "[PUNT] Error: Commit message must contain a ticket reference"
+    echo ""
+    echo "  Expected format: PROJECT-123"
+    if [ -n "$PUNT_PROJECT_KEYS" ]; then
+        echo "  Valid projects: $PUNT_PROJECT_KEYS"
+    fi
+    echo ""
+    echo "  Examples:"
+    echo "    fix: resolve bug in login (PUNT-123)"
+    echo "    fixes PUNT-456"
+    echo "    feat(auth): add password reset PROJ-789"
+    echo ""
+    echo "  To bypass this check, use: git commit --no-verify"
+    echo ""
+    exit 1
+else
+    # Just suggest (warning)
+    echo ""
+    echo "[PUNT] Warning: No ticket reference found in commit message"
+    echo "  Consider adding a ticket reference (e.g., PUNT-123)"
+    echo ""
+fi
+
+exit 0

--- a/scripts/git-hooks/install.sh
+++ b/scripts/git-hooks/install.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#
+# PUNT Git Hooks Installer
+#
+# This script installs PUNT's git hooks into your repository.
+#
+# Usage:
+#   ./install.sh [options]
+#
+# Options:
+#   --repo DIR       Target repository directory (default: current directory)
+#   --hooks HOOKS    Comma-separated list of hooks to install (default: post-commit)
+#                    Available: post-commit, commit-msg
+#   --force          Overwrite existing hooks without asking
+#   --uninstall      Remove PUNT hooks
+#   --help           Show this help message
+#
+# Example:
+#   ./install.sh --repo /path/to/my-repo --hooks post-commit,commit-msg
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Script directory (where the hook files are)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Defaults
+TARGET_REPO="$(pwd)"
+HOOKS_TO_INSTALL="post-commit"
+FORCE=false
+UNINSTALL=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            TARGET_REPO="$2"
+            shift 2
+            ;;
+        --hooks)
+            HOOKS_TO_INSTALL="$2"
+            shift 2
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --uninstall)
+            UNINSTALL=true
+            shift
+            ;;
+        --help)
+            head -30 "$0" | grep '^#' | cut -c3-
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+# Verify target is a git repository
+if [ ! -d "$TARGET_REPO/.git" ]; then
+    echo -e "${RED}Error: $TARGET_REPO is not a git repository${NC}"
+    exit 1
+fi
+
+HOOKS_DIR="$TARGET_REPO/.git/hooks"
+
+# Create hooks directory if it doesn't exist
+mkdir -p "$HOOKS_DIR"
+
+# Convert comma-separated hooks to array
+IFS=',' read -ra HOOKS <<< "$HOOKS_TO_INSTALL"
+
+echo ""
+echo "PUNT Git Hooks Installer"
+echo "========================"
+echo ""
+
+# Uninstall mode
+if [ "$UNINSTALL" = true ]; then
+    echo "Uninstalling PUNT hooks from: $TARGET_REPO"
+    echo ""
+
+    for hook in "${HOOKS[@]}"; do
+        hook=$(echo "$hook" | tr -d ' ')
+        hook_path="$HOOKS_DIR/$hook"
+
+        if [ -f "$hook_path" ]; then
+            # Check if it's a PUNT hook
+            if grep -q "PUNT Git Hook" "$hook_path" 2>/dev/null; then
+                rm "$hook_path"
+                echo -e "  ${GREEN}[REMOVED]${NC} $hook"
+            else
+                echo -e "  ${YELLOW}[SKIPPED]${NC} $hook (not a PUNT hook)"
+            fi
+        else
+            echo -e "  ${YELLOW}[SKIPPED]${NC} $hook (not installed)"
+        fi
+    done
+
+    echo ""
+    echo -e "${GREEN}Done!${NC}"
+    exit 0
+fi
+
+# Install mode
+echo "Installing PUNT hooks to: $TARGET_REPO"
+echo ""
+
+for hook in "${HOOKS[@]}"; do
+    hook=$(echo "$hook" | tr -d ' ')
+    source_path="$SCRIPT_DIR/$hook"
+    target_path="$HOOKS_DIR/$hook"
+
+    # Check if source exists
+    if [ ! -f "$source_path" ]; then
+        echo -e "  ${RED}[ERROR]${NC} $hook - source not found"
+        continue
+    fi
+
+    # Check if target exists
+    if [ -f "$target_path" ]; then
+        if [ "$FORCE" = true ]; then
+            # Backup existing hook
+            backup_path="$target_path.backup.$(date +%Y%m%d%H%M%S)"
+            cp "$target_path" "$backup_path"
+            echo -e "  ${YELLOW}[BACKUP]${NC} $hook -> $(basename "$backup_path")"
+        else
+            # Check if it's already a PUNT hook
+            if grep -q "PUNT Git Hook" "$target_path" 2>/dev/null; then
+                echo -e "  ${YELLOW}[SKIPPED]${NC} $hook (already installed, use --force to update)"
+                continue
+            else
+                echo -e "  ${RED}[ERROR]${NC} $hook already exists (use --force to overwrite)"
+                continue
+            fi
+        fi
+    fi
+
+    # Copy hook
+    cp "$source_path" "$target_path"
+    chmod +x "$target_path"
+    echo -e "  ${GREEN}[INSTALLED]${NC} $hook"
+done
+
+echo ""
+echo "Configuration"
+echo "-------------"
+echo ""
+echo "Set these environment variables:"
+echo ""
+echo "  PUNT_API_KEY      Your PUNT API key (required for post-commit)"
+echo "  PUNT_BASE_URL     PUNT server URL (default: http://localhost:3000)"
+echo ""
+echo "Optional:"
+echo ""
+echo "  PUNT_REQUIRE_TICKET  'require', 'suggest' (default), or 'ignore'"
+echo "  PUNT_PROJECT_KEYS    Comma-separated valid project keys"
+echo "  PUNT_HOOK_DEBUG      Set to '1' for debug output"
+echo "  PUNT_HOOK_QUIET      Set to '1' to suppress all output"
+echo ""
+echo -e "${GREEN}Done!${NC}"
+echo ""

--- a/scripts/git-hooks/post-commit
+++ b/scripts/git-hooks/post-commit
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# PUNT Git Hook: post-commit
+#
+# This hook runs after a commit is made and notifies PUNT about the commit.
+# It parses the commit message for ticket references (e.g., PUNT-123) and
+# updates tickets based on keywords:
+#   - "fixes PUNT-X" or "closes PUNT-X" -> moves ticket to Done
+#   - "wip PUNT-X" or "working on PUNT-X" -> moves ticket to In Progress
+#   - "PUNT-X" (standalone) -> logs reference
+#
+# Configuration (via environment variables):
+#   PUNT_API_KEY     - Your PUNT API key (required)
+#   PUNT_BASE_URL    - Base URL of PUNT server (default: http://localhost:3000)
+#   PUNT_HOOK_DEBUG  - Set to "1" to enable debug output
+#   PUNT_HOOK_QUIET  - Set to "1" to suppress all output
+#
+# Installation:
+#   1. Copy this file to your repository's .git/hooks/post-commit
+#   2. Make it executable: chmod +x .git/hooks/post-commit
+#   3. Set PUNT_API_KEY in your environment or .env file
+#
+
+set -e
+
+# Configuration
+PUNT_BASE_URL="${PUNT_BASE_URL:-http://localhost:3000}"
+PUNT_API_ENDPOINT="${PUNT_BASE_URL}/api/integrations/git-hook"
+
+# Check for required configuration
+if [ -z "$PUNT_API_KEY" ]; then
+    if [ -z "$PUNT_HOOK_QUIET" ]; then
+        echo "[PUNT] Warning: PUNT_API_KEY not set. Skipping ticket update."
+    fi
+    exit 0
+fi
+
+# Get commit information
+COMMIT_SHA=$(git rev-parse HEAD)
+COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+COMMIT_AUTHOR=$(git log -1 --pretty=%an)
+COMMIT_TIMESTAMP=$(git log -1 --pretty=%aI)
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+# Debug output
+if [ "$PUNT_HOOK_DEBUG" = "1" ]; then
+    echo "[PUNT] Processing commit: $COMMIT_SHA"
+    echo "[PUNT] Message: $(echo "$COMMIT_MESSAGE" | head -1)"
+    echo "[PUNT] Author: $COMMIT_AUTHOR"
+    echo "[PUNT] Branch: $BRANCH_NAME"
+    echo "[PUNT] Endpoint: $PUNT_API_ENDPOINT"
+fi
+
+# Escape special characters for JSON
+escape_json() {
+    local string="$1"
+    # Escape backslashes first, then other special chars
+    string="${string//\\/\\\\}"
+    string="${string//\"/\\\"}"
+    string="${string//$'\n'/\\n}"
+    string="${string//$'\r'/\\r}"
+    string="${string//$'\t'/\\t}"
+    echo "$string"
+}
+
+# Build JSON payload
+ESCAPED_MESSAGE=$(escape_json "$COMMIT_MESSAGE")
+ESCAPED_AUTHOR=$(escape_json "$COMMIT_AUTHOR")
+ESCAPED_BRANCH=$(escape_json "$BRANCH_NAME")
+
+JSON_PAYLOAD=$(cat <<EOF
+{
+  "commits": [
+    {
+      "message": "$ESCAPED_MESSAGE",
+      "sha": "$COMMIT_SHA",
+      "author": "$ESCAPED_AUTHOR",
+      "timestamp": "$COMMIT_TIMESTAMP",
+      "branch": "$ESCAPED_BRANCH"
+    }
+  ]
+}
+EOF
+)
+
+# Send to PUNT API
+if [ "$PUNT_HOOK_DEBUG" = "1" ]; then
+    echo "[PUNT] Sending payload..."
+fi
+
+# Make the API call
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+    -X POST "$PUNT_API_ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $PUNT_API_KEY" \
+    -d "$JSON_PAYLOAD" 2>/dev/null || echo -e "\n000")
+
+# Extract HTTP status code (last line) and body (everything else)
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
+
+# Handle response
+if [ "$HTTP_CODE" = "200" ]; then
+    if [ -z "$PUNT_HOOK_QUIET" ]; then
+        # Parse response for summary (using basic tools)
+        PROCESSED=$(echo "$RESPONSE_BODY" | grep -o '"processed":[0-9]*' | cut -d: -f2 || echo "0")
+        CLOSED=$(echo "$RESPONSE_BODY" | grep -o '"closed":[0-9]*' | cut -d: -f2 || echo "0")
+        IN_PROGRESS=$(echo "$RESPONSE_BODY" | grep -o '"inProgress":[0-9]*' | cut -d: -f2 || echo "0")
+
+        if [ "$PROCESSED" != "0" ]; then
+            echo "[PUNT] Updated $PROCESSED ticket(s): $CLOSED closed, $IN_PROGRESS in progress"
+        fi
+    fi
+elif [ "$HTTP_CODE" = "401" ]; then
+    if [ -z "$PUNT_HOOK_QUIET" ]; then
+        echo "[PUNT] Error: Invalid API key"
+    fi
+elif [ "$HTTP_CODE" = "000" ]; then
+    if [ -z "$PUNT_HOOK_QUIET" ]; then
+        echo "[PUNT] Warning: Could not connect to PUNT server at $PUNT_BASE_URL"
+    fi
+else
+    if [ "$PUNT_HOOK_DEBUG" = "1" ]; then
+        echo "[PUNT] Error: HTTP $HTTP_CODE"
+        echo "[PUNT] Response: $RESPONSE_BODY"
+    elif [ -z "$PUNT_HOOK_QUIET" ]; then
+        echo "[PUNT] Warning: Unexpected response (HTTP $HTTP_CODE)"
+    fi
+fi
+
+# Always exit successfully to not block the commit
+exit 0

--- a/src/app/api/integrations/git-hook/route.ts
+++ b/src/app/api/integrations/git-hook/route.ts
@@ -1,0 +1,442 @@
+import { headers } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { handleApiError, validationError } from '@/lib/api-utils'
+import { db } from '@/lib/db'
+import { projectEvents } from '@/lib/events'
+import { parseCommitMessage, type TicketAction } from '@/lib/git-hooks'
+import { isCompletedColumn } from '@/lib/sprint-utils'
+
+/**
+ * Git Hook Integration API
+ *
+ * This endpoint processes git commit information and updates tickets based on
+ * commit message patterns. Authentication is via API key (same as MCP).
+ *
+ * Supported actions:
+ * - "close": Move ticket to Done column and set resolution
+ * - "reference": Add commit info to ticket (future: comments)
+ * - "in_progress": Move ticket to In Progress column
+ */
+
+const commitSchema = z.object({
+  message: z.string().min(1),
+  sha: z.string().optional(),
+  author: z.string().optional(),
+  timestamp: z.string().optional(),
+  branch: z.string().optional(),
+})
+
+const gitHookSchema = z.object({
+  commits: z.array(commitSchema).min(1),
+  // Optional: specify which projects to process (default: all referenced)
+  projectKeys: z.array(z.string()).optional(),
+  // Dry run mode: parse and return what would happen without making changes
+  dryRun: z.boolean().optional().default(false),
+})
+
+interface TicketUpdate {
+  ticketKey: string
+  action: TicketAction
+  success: boolean
+  message: string
+  ticketId?: string
+}
+
+/**
+ * Authenticate via API key (same as MCP).
+ * Returns the user if authenticated, null otherwise.
+ */
+async function authenticateApiKey() {
+  const headersList = await headers()
+  const apiKey = headersList.get('X-API-Key') || headersList.get('X-MCP-API-Key')
+
+  if (!apiKey) {
+    return null
+  }
+
+  const user = await db.user.findUnique({
+    where: { mcpApiKey: apiKey },
+    select: {
+      id: true,
+      name: true,
+      isActive: true,
+    },
+  })
+
+  if (user?.isActive) {
+    return user
+  }
+
+  return null
+}
+
+/**
+ * Find the "Done" column for a project.
+ */
+async function findDoneColumn(projectId: string) {
+  const columns = await db.column.findMany({
+    where: { projectId },
+    orderBy: { order: 'asc' },
+    select: { id: true, name: true },
+  })
+
+  return columns.find((col) => isCompletedColumn(col.name))
+}
+
+/**
+ * Find the "In Progress" column for a project.
+ */
+async function findInProgressColumn(projectId: string) {
+  const columns = await db.column.findMany({
+    where: { projectId },
+    orderBy: { order: 'asc' },
+    select: { id: true, name: true },
+  })
+
+  // Look for common "in progress" column names
+  const inProgressPatterns = ['in progress', 'in-progress', 'doing', 'working', 'active']
+  return columns.find((col) => inProgressPatterns.includes(col.name.toLowerCase()))
+}
+
+/**
+ * Process a single ticket action.
+ */
+async function processTicketAction(
+  ticketKey: string,
+  action: TicketAction,
+  userId: string,
+  commit: { sha?: string; author?: string; branch?: string },
+  dryRun: boolean,
+): Promise<TicketUpdate> {
+  // Parse ticket key
+  const [projectKey, ticketNumberStr] = ticketKey.split('-')
+  const ticketNumber = parseInt(ticketNumberStr, 10)
+
+  if (!projectKey || Number.isNaN(ticketNumber)) {
+    return {
+      ticketKey,
+      action,
+      success: false,
+      message: 'Invalid ticket key format',
+    }
+  }
+
+  // Find the project
+  const project = await db.project.findUnique({
+    where: { key: projectKey.toUpperCase() },
+    select: { id: true },
+  })
+
+  if (!project) {
+    return {
+      ticketKey,
+      action,
+      success: false,
+      message: `Project ${projectKey} not found`,
+    }
+  }
+
+  // Check if user is a member of the project
+  const membership = await db.projectMember.findUnique({
+    where: { userId_projectId: { userId, projectId: project.id } },
+  })
+
+  // Also check if user is a system admin
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { isSystemAdmin: true },
+  })
+
+  if (!membership && !user?.isSystemAdmin) {
+    return {
+      ticketKey,
+      action,
+      success: false,
+      message: `Not a member of project ${projectKey}`,
+    }
+  }
+
+  // Find the ticket
+  const ticket = await db.ticket.findUnique({
+    where: { projectId_number: { projectId: project.id, number: ticketNumber } },
+    select: {
+      id: true,
+      columnId: true,
+      column: { select: { name: true } },
+      resolution: true,
+    },
+  })
+
+  if (!ticket) {
+    return {
+      ticketKey,
+      action,
+      success: false,
+      message: `Ticket ${ticketKey} not found`,
+    }
+  }
+
+  if (dryRun) {
+    return {
+      ticketKey,
+      action,
+      success: true,
+      message: `Would ${action} ticket`,
+      ticketId: ticket.id,
+    }
+  }
+
+  // Process based on action
+  switch (action) {
+    case 'close': {
+      // Move to Done column and set resolution
+      const doneColumn = await findDoneColumn(project.id)
+      if (!doneColumn) {
+        return {
+          ticketKey,
+          action,
+          success: false,
+          message: 'No Done column found in project',
+          ticketId: ticket.id,
+        }
+      }
+
+      // Only update if not already done
+      if (!isCompletedColumn(ticket.column.name)) {
+        await db.ticket.update({
+          where: { id: ticket.id },
+          data: {
+            columnId: doneColumn.id,
+            resolution: 'Done',
+            resolvedAt: new Date(),
+          },
+        })
+
+        // Emit SSE event
+        projectEvents.emitTicketEvent({
+          type: 'ticket.moved',
+          projectId: project.id,
+          ticketId: ticket.id,
+          userId,
+          timestamp: Date.now(),
+        })
+      }
+
+      return {
+        ticketKey,
+        action,
+        success: true,
+        message: `Ticket moved to Done${commit.sha ? ` (commit: ${commit.sha.substring(0, 7)})` : ''}`,
+        ticketId: ticket.id,
+      }
+    }
+
+    case 'in_progress': {
+      // Move to In Progress column
+      const inProgressColumn = await findInProgressColumn(project.id)
+      if (!inProgressColumn) {
+        return {
+          ticketKey,
+          action,
+          success: false,
+          message: 'No In Progress column found in project',
+          ticketId: ticket.id,
+        }
+      }
+
+      // Only update if not already in progress or done
+      const currentColName = ticket.column.name.toLowerCase()
+      const isAlreadyInProgress =
+        currentColName === 'in progress' ||
+        currentColName === 'in-progress' ||
+        currentColName === 'doing'
+
+      if (!isAlreadyInProgress && !isCompletedColumn(ticket.column.name)) {
+        await db.ticket.update({
+          where: { id: ticket.id },
+          data: {
+            columnId: inProgressColumn.id,
+            // Clear resolution if moving back to in progress
+            resolution: null,
+            resolvedAt: null,
+          },
+        })
+
+        // Emit SSE event
+        projectEvents.emitTicketEvent({
+          type: 'ticket.moved',
+          projectId: project.id,
+          ticketId: ticket.id,
+          userId,
+          timestamp: Date.now(),
+        })
+      }
+
+      return {
+        ticketKey,
+        action,
+        success: true,
+        message: `Ticket marked as in progress${commit.sha ? ` (commit: ${commit.sha.substring(0, 7)})` : ''}`,
+        ticketId: ticket.id,
+      }
+    }
+
+    case 'reference': {
+      // For now, just acknowledge the reference
+      // Future: Add comment with commit info
+      return {
+        ticketKey,
+        action,
+        success: true,
+        message: `Ticket referenced${commit.sha ? ` in commit ${commit.sha.substring(0, 7)}` : ''}`,
+        ticketId: ticket.id,
+      }
+    }
+
+    default:
+      return {
+        ticketKey,
+        action,
+        success: false,
+        message: `Unknown action: ${action}`,
+        ticketId: ticket.id,
+      }
+  }
+}
+
+/**
+ * POST /api/integrations/git-hook - Process git commits and update tickets
+ *
+ * Requires API key authentication (X-API-Key or X-MCP-API-Key header).
+ */
+export async function POST(request: Request) {
+  try {
+    // Authenticate
+    const user = await authenticateApiKey()
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Provide X-API-Key header.' },
+        { status: 401 },
+      )
+    }
+
+    // Parse request body
+    const body = await request.json()
+    const parsed = gitHookSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return validationError(parsed)
+    }
+
+    const { commits, projectKeys, dryRun } = parsed.data
+
+    // Parse all commits and extract ticket references
+    const allUpdates: TicketUpdate[] = []
+
+    for (const commit of commits) {
+      const parsedCommit = parseCommitMessage(commit.message)
+
+      for (const ticket of parsedCommit.tickets) {
+        // Filter by project keys if specified
+        if (projectKeys && !projectKeys.includes(ticket.projectKey)) {
+          continue
+        }
+
+        // Skip if already processed (use most significant action)
+        // Priority: close > in_progress > reference
+        const existingUpdate = allUpdates.find((u) => u.ticketKey === ticket.ticketKey)
+        if (existingUpdate) {
+          const actionPriority = { close: 3, in_progress: 2, reference: 1 }
+          if (actionPriority[ticket.action] <= actionPriority[existingUpdate.action]) {
+            continue
+          }
+          // Remove the existing update to replace with higher priority
+          const idx = allUpdates.findIndex((u) => u.ticketKey === ticket.ticketKey)
+          if (idx >= 0) {
+            allUpdates.splice(idx, 1)
+          }
+        }
+
+        // Process the ticket action
+        const update = await processTicketAction(
+          ticket.ticketKey,
+          ticket.action,
+          user.id,
+          commit,
+          dryRun ?? false,
+        )
+
+        allUpdates.push(update)
+      }
+    }
+
+    // Prepare response
+    const response = {
+      success: true,
+      dryRun: dryRun ?? false,
+      processed: allUpdates.length,
+      updates: allUpdates,
+      summary: {
+        closed: allUpdates.filter((u) => u.action === 'close' && u.success).length,
+        inProgress: allUpdates.filter((u) => u.action === 'in_progress' && u.success).length,
+        referenced: allUpdates.filter((u) => u.action === 'reference' && u.success).length,
+        failed: allUpdates.filter((u) => !u.success).length,
+      },
+    }
+
+    return NextResponse.json(response)
+  } catch (error) {
+    return handleApiError(error, 'process git hook')
+  }
+}
+
+/**
+ * GET /api/integrations/git-hook - Get hook installation instructions
+ */
+export async function GET() {
+  return NextResponse.json({
+    description: 'Git Hook Integration API for PUNT',
+    version: '1.0.0',
+    endpoints: {
+      POST: {
+        description: 'Process git commits and update tickets based on commit messages',
+        authentication: 'API key via X-API-Key or X-MCP-API-Key header',
+        body: {
+          commits: [
+            {
+              message: 'Commit message (required)',
+              sha: 'Commit SHA (optional)',
+              author: 'Author name (optional)',
+              timestamp: 'ISO timestamp (optional)',
+              branch: 'Branch name (optional)',
+            },
+          ],
+          projectKeys: 'Array of project keys to filter (optional)',
+          dryRun: 'If true, only parse and report what would happen (optional)',
+        },
+      },
+    },
+    patterns: {
+      close: [
+        'fix PUNT-123',
+        'fixes PUNT-123',
+        'close PUNT-123',
+        'closes PUNT-123',
+        'resolve PUNT-123',
+        'resolves PUNT-123',
+      ],
+      in_progress: ['wip PUNT-123', 'working on PUNT-123', 'started PUNT-123'],
+      reference: ['PUNT-123 (standalone mention)', 'ref PUNT-123', 'refs PUNT-123', 'see PUNT-123'],
+    },
+    installation: {
+      instructions: 'See /scripts/git-hooks/README.md for installation instructions',
+      quickStart: [
+        '1. Generate an API key in PUNT: Profile > API Key',
+        '2. Copy scripts/git-hooks/post-commit to your repo .git/hooks/',
+        '3. Set PUNT_API_KEY environment variable',
+        '4. Set PUNT_BASE_URL if not using localhost:3000',
+      ],
+    },
+  })
+}

--- a/src/lib/git-hooks/__tests__/commit-parser.test.ts
+++ b/src/lib/git-hooks/__tests__/commit-parser.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractTicketKeys,
+  getTicketAction,
+  parseCommitMessage,
+  parseCommits,
+  referencesTicket,
+} from '../commit-parser'
+
+describe('commit-parser', () => {
+  describe('parseCommitMessage', () => {
+    it('parses standalone ticket references', () => {
+      const result = parseCommitMessage('Add feature for PUNT-123')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0]).toEqual({
+        projectKey: 'PUNT',
+        ticketNumber: 123,
+        ticketKey: 'PUNT-123',
+        action: 'reference',
+      })
+    })
+
+    it('parses multiple ticket references', () => {
+      const result = parseCommitMessage('PUNT-1 and PROJ-42 and BUG-999')
+
+      expect(result.tickets).toHaveLength(3)
+      expect(result.tickets.map((t) => t.ticketKey)).toEqual(['PUNT-1', 'PROJ-42', 'BUG-999'])
+    })
+
+    it('parses "fixes" pattern as close action', () => {
+      const result = parseCommitMessage('fixes PUNT-123: resolve null pointer')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('close')
+      expect(result.tickets[0].ticketKey).toBe('PUNT-123')
+    })
+
+    it('parses "closes" pattern as close action', () => {
+      const result = parseCommitMessage('Feature complete, closes PUNT-456')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('close')
+    })
+
+    it('parses "resolves" pattern as close action', () => {
+      const result = parseCommitMessage('resolves PUNT-789')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('close')
+    })
+
+    it('parses "wip" pattern as in_progress action', () => {
+      const result = parseCommitMessage('wip PUNT-100: initial implementation')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('in_progress')
+    })
+
+    it('parses "working on" pattern as in_progress action', () => {
+      const result = parseCommitMessage('working on PUNT-200')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('in_progress')
+    })
+
+    it('parses "refs" pattern as reference action', () => {
+      const result = parseCommitMessage('refs PUNT-50')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('reference')
+    })
+
+    it('handles case insensitive keywords', () => {
+      const result = parseCommitMessage('FIXES PUNT-1, Closes PUNT-2')
+
+      expect(result.tickets).toHaveLength(2)
+      expect(result.tickets[0].action).toBe('close')
+      expect(result.tickets[1].action).toBe('close')
+    })
+
+    it('normalizes ticket keys to uppercase', () => {
+      const result = parseCommitMessage('fixes punt-123')
+
+      expect(result.tickets[0].ticketKey).toBe('PUNT-123')
+      expect(result.tickets[0].projectKey).toBe('PUNT')
+    })
+
+    it('deduplicates ticket references', () => {
+      const result = parseCommitMessage('PUNT-1 mentioned, then PUNT-1 again')
+
+      expect(result.tickets).toHaveLength(1)
+    })
+
+    it('prioritizes action keywords over standalone mentions', () => {
+      const result = parseCommitMessage('Working on PUNT-1, also PUNT-1 mentioned')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('in_progress')
+    })
+
+    it('handles empty messages', () => {
+      const result = parseCommitMessage('')
+
+      expect(result.tickets).toHaveLength(0)
+    })
+
+    it('handles messages without tickets', () => {
+      const result = parseCommitMessage('Just a regular commit message')
+
+      expect(result.tickets).toHaveLength(0)
+    })
+
+    it('handles project keys with varying lengths', () => {
+      const result = parseCommitMessage('AB-1 and ABCDEFGHIJ-999')
+
+      expect(result.tickets).toHaveLength(2)
+      expect(result.tickets[0].projectKey).toBe('AB')
+      expect(result.tickets[1].projectKey).toBe('ABCDEFGHIJ')
+    })
+
+    it('does not match single-letter project keys', () => {
+      const result = parseCommitMessage('X-123 is not valid')
+
+      expect(result.tickets).toHaveLength(0)
+    })
+
+    it('preserves original message', () => {
+      const message = 'Original message with PUNT-1'
+      const result = parseCommitMessage(message)
+
+      expect(result.message).toBe(message)
+    })
+
+    it('handles multiline commit messages', () => {
+      const message = `feat: add new feature
+
+This commit fixes PUNT-123 and refs PUNT-456.
+
+Also working on PUNT-789.`
+
+      const result = parseCommitMessage(message)
+
+      expect(result.tickets).toHaveLength(3)
+      expect(result.tickets.find((t) => t.ticketKey === 'PUNT-123')?.action).toBe('close')
+      expect(result.tickets.find((t) => t.ticketKey === 'PUNT-456')?.action).toBe('reference')
+      expect(result.tickets.find((t) => t.ticketKey === 'PUNT-789')?.action).toBe('in_progress')
+    })
+
+    it('handles colon-prefixed keywords', () => {
+      const result = parseCommitMessage('fix:fixes PUNT-123')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('close')
+    })
+
+    it('parses "completed" as close action', () => {
+      const result = parseCommitMessage('completed PUNT-42')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('close')
+    })
+
+    it('parses "started" as in_progress action', () => {
+      const result = parseCommitMessage('started PUNT-99')
+
+      expect(result.tickets).toHaveLength(1)
+      expect(result.tickets[0].action).toBe('in_progress')
+    })
+  })
+
+  describe('parseCommits', () => {
+    it('parses multiple commits', () => {
+      const commits = [
+        { message: 'fixes PUNT-1', sha: 'abc123' },
+        { message: 'PUNT-2 mentioned', sha: 'def456' },
+      ]
+
+      const results = parseCommits(commits)
+
+      expect(results).toHaveLength(2)
+      expect(results[0].sha).toBe('abc123')
+      expect(results[0].tickets[0].ticketKey).toBe('PUNT-1')
+      expect(results[1].sha).toBe('def456')
+    })
+
+    it('preserves commit metadata', () => {
+      const commits = [
+        {
+          message: 'PUNT-1',
+          sha: 'abc123',
+          author: 'Jane',
+          timestamp: '2024-01-15T10:00:00Z',
+          branch: 'main',
+        },
+      ]
+
+      const results = parseCommits(commits)
+
+      expect(results[0].sha).toBe('abc123')
+      expect(results[0].author).toBe('Jane')
+      expect(results[0].timestamp).toBe('2024-01-15T10:00:00Z')
+      expect(results[0].branch).toBe('main')
+    })
+  })
+
+  describe('extractTicketKeys', () => {
+    it('extracts ticket keys from message', () => {
+      const keys = extractTicketKeys('PUNT-1 and PROJ-2')
+
+      expect(keys).toEqual(['PUNT-1', 'PROJ-2'])
+    })
+
+    it('returns empty array for no tickets', () => {
+      const keys = extractTicketKeys('No tickets here')
+
+      expect(keys).toEqual([])
+    })
+  })
+
+  describe('referencesTicket', () => {
+    it('returns true when ticket is referenced', () => {
+      expect(referencesTicket('fixes PUNT-123', 'PUNT-123')).toBe(true)
+    })
+
+    it('returns false when ticket is not referenced', () => {
+      expect(referencesTicket('fixes PUNT-123', 'PUNT-456')).toBe(false)
+    })
+
+    it('handles case insensitive matching', () => {
+      expect(referencesTicket('fixes punt-123', 'PUNT-123')).toBe(true)
+    })
+  })
+
+  describe('getTicketAction', () => {
+    it('returns the action for a referenced ticket', () => {
+      expect(getTicketAction('fixes PUNT-123', 'PUNT-123')).toBe('close')
+      expect(getTicketAction('wip PUNT-456', 'PUNT-456')).toBe('in_progress')
+      expect(getTicketAction('PUNT-789 mentioned', 'PUNT-789')).toBe('reference')
+    })
+
+    it('returns null for unreferenced ticket', () => {
+      expect(getTicketAction('fixes PUNT-123', 'PUNT-999')).toBe(null)
+    })
+  })
+})

--- a/src/lib/git-hooks/commit-parser.ts
+++ b/src/lib/git-hooks/commit-parser.ts
@@ -1,0 +1,248 @@
+/**
+ * Git commit message parser for ticket references.
+ *
+ * Parses commit messages to extract ticket references and actions.
+ * Supports patterns like:
+ * - "PUNT-123" - simple mention
+ * - "fixes PUNT-123" or "closes PUNT-123" - close action
+ * - "refs PUNT-123" or "references PUNT-123" - reference action
+ * - "wip PUNT-123" or "working on PUNT-123" - in progress action
+ */
+
+export type TicketAction = 'close' | 'reference' | 'in_progress'
+
+export interface TicketReference {
+  /** Project key (e.g., "PUNT") */
+  projectKey: string
+  /** Ticket number (e.g., 123) */
+  ticketNumber: number
+  /** Full ticket key (e.g., "PUNT-123") */
+  ticketKey: string
+  /** Action to perform on the ticket */
+  action: TicketAction
+}
+
+export interface ParsedCommit {
+  /** Original commit message */
+  message: string
+  /** Extracted ticket references */
+  tickets: TicketReference[]
+  /** Commit SHA (if provided) */
+  sha?: string
+  /** Commit author (if provided) */
+  author?: string
+  /** Commit timestamp (if provided) */
+  timestamp?: string
+  /** Branch name (if provided) */
+  branch?: string
+}
+
+// Patterns that indicate closing a ticket
+const CLOSE_PATTERNS = [
+  'fix',
+  'fixes',
+  'fixed',
+  'close',
+  'closes',
+  'closed',
+  'resolve',
+  'resolves',
+  'resolved',
+  'complete',
+  'completes',
+  'completed',
+  'done',
+]
+
+// Patterns that indicate work in progress
+const WIP_PATTERNS = [
+  'wip',
+  'working on',
+  'work on',
+  'started',
+  'starting',
+  'begin',
+  'begins',
+  'beginning',
+  'progress',
+  'in progress',
+]
+
+// Patterns that indicate a simple reference
+const REFERENCE_PATTERNS = ['ref', 'refs', 'reference', 'references', 'see', 'related to', 're']
+
+/**
+ * Builds a regex pattern for matching action keywords followed by ticket references.
+ * Pattern: (action_word)\s+(PROJECT-123)
+ */
+function buildActionPattern(keywords: string[]): RegExp {
+  const keywordPattern = keywords.map((k) => k.replace(/\s+/g, '\\s+')).join('|')
+  // Match: action_keyword whitespace PROJECT-NUMBER
+  // PROJECT is 2-10 uppercase letters, NUMBER is 1+ digits
+  return new RegExp(`(?:^|\\s|:)(${keywordPattern})\\s+([A-Z]{2,10}-\\d+)`, 'gi')
+}
+
+/**
+ * Builds a regex pattern for matching standalone ticket references.
+ * Pattern: PROJECT-123 (not preceded by an action word)
+ */
+function buildStandaloneTicketPattern(): RegExp {
+  // Match PROJECT-NUMBER that's not preceded by action words
+  return /\b([A-Z]{2,10})-(\d+)\b/g
+}
+
+/**
+ * Helper to extract all matches from a regex pattern.
+ */
+function getAllMatches(pattern: RegExp, text: string): RegExpExecArray[] {
+  const matches: RegExpExecArray[] = []
+  let match = pattern.exec(text)
+  while (match !== null) {
+    matches.push(match)
+    match = pattern.exec(text)
+  }
+  return matches
+}
+
+/**
+ * Parse a commit message to extract ticket references.
+ *
+ * @param message - The commit message to parse
+ * @returns ParsedCommit object with extracted ticket references
+ */
+export function parseCommitMessage(message: string): ParsedCommit {
+  const tickets: TicketReference[] = []
+  const seenTickets = new Set<string>()
+
+  // First, find all action-based references (these take precedence)
+  const closePattern = buildActionPattern(CLOSE_PATTERNS)
+  const wipPattern = buildActionPattern(WIP_PATTERNS)
+  const refPattern = buildActionPattern(REFERENCE_PATTERNS)
+
+  // Process close actions
+  for (const match of getAllMatches(closePattern, message)) {
+    const ticketKey = match[2].toUpperCase()
+    if (!seenTickets.has(ticketKey)) {
+      seenTickets.add(ticketKey)
+      const [projectKey, numberStr] = ticketKey.split('-')
+      tickets.push({
+        projectKey,
+        ticketNumber: parseInt(numberStr, 10),
+        ticketKey,
+        action: 'close',
+      })
+    }
+  }
+
+  // Process WIP actions
+  for (const match of getAllMatches(wipPattern, message)) {
+    const ticketKey = match[2].toUpperCase()
+    if (!seenTickets.has(ticketKey)) {
+      seenTickets.add(ticketKey)
+      const [projectKey, numberStr] = ticketKey.split('-')
+      tickets.push({
+        projectKey,
+        ticketNumber: parseInt(numberStr, 10),
+        ticketKey,
+        action: 'in_progress',
+      })
+    }
+  }
+
+  // Process reference actions
+  for (const match of getAllMatches(refPattern, message)) {
+    const ticketKey = match[2].toUpperCase()
+    if (!seenTickets.has(ticketKey)) {
+      seenTickets.add(ticketKey)
+      const [projectKey, numberStr] = ticketKey.split('-')
+      tickets.push({
+        projectKey,
+        ticketNumber: parseInt(numberStr, 10),
+        ticketKey,
+        action: 'reference',
+      })
+    }
+  }
+
+  // Finally, find standalone ticket references (default to 'reference' action)
+  const standalonePattern = buildStandaloneTicketPattern()
+  for (const match of getAllMatches(standalonePattern, message)) {
+    const ticketKey = `${match[1].toUpperCase()}-${match[2]}`
+    if (!seenTickets.has(ticketKey)) {
+      seenTickets.add(ticketKey)
+      tickets.push({
+        projectKey: match[1].toUpperCase(),
+        ticketNumber: parseInt(match[2], 10),
+        ticketKey,
+        action: 'reference',
+      })
+    }
+  }
+
+  return {
+    message,
+    tickets,
+  }
+}
+
+/**
+ * Parse multiple commit messages.
+ *
+ * @param commits - Array of commit objects with message and optional metadata
+ * @returns Array of ParsedCommit objects
+ */
+export function parseCommits(
+  commits: Array<{
+    message: string
+    sha?: string
+    author?: string
+    timestamp?: string
+    branch?: string
+  }>,
+): ParsedCommit[] {
+  return commits.map((commit) => ({
+    ...parseCommitMessage(commit.message),
+    sha: commit.sha,
+    author: commit.author,
+    timestamp: commit.timestamp,
+    branch: commit.branch,
+  }))
+}
+
+/**
+ * Extract unique ticket keys from a commit message.
+ *
+ * @param message - The commit message to parse
+ * @returns Array of unique ticket keys (e.g., ["PUNT-123", "PUNT-456"])
+ */
+export function extractTicketKeys(message: string): string[] {
+  const parsed = parseCommitMessage(message)
+  return parsed.tickets.map((t) => t.ticketKey)
+}
+
+/**
+ * Check if a commit message references a specific ticket.
+ *
+ * @param message - The commit message to check
+ * @param ticketKey - The ticket key to look for (e.g., "PUNT-123")
+ * @returns True if the ticket is referenced
+ */
+export function referencesTicket(message: string, ticketKey: string): boolean {
+  const parsed = parseCommitMessage(message)
+  const normalizedKey = ticketKey.toUpperCase()
+  return parsed.tickets.some((t) => t.ticketKey === normalizedKey)
+}
+
+/**
+ * Get the action for a specific ticket from a commit message.
+ *
+ * @param message - The commit message to parse
+ * @param ticketKey - The ticket key to find (e.g., "PUNT-123")
+ * @returns The action for the ticket, or null if not found
+ */
+export function getTicketAction(message: string, ticketKey: string): TicketAction | null {
+  const parsed = parseCommitMessage(message)
+  const normalizedKey = ticketKey.toUpperCase()
+  const ref = parsed.tickets.find((t) => t.ticketKey === normalizedKey)
+  return ref?.action ?? null
+}

--- a/src/lib/git-hooks/index.ts
+++ b/src/lib/git-hooks/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Git hooks integration module.
+ *
+ * Provides utilities for parsing commit messages and extracting ticket references.
+ */
+
+export {
+  extractTicketKeys,
+  getTicketAction,
+  type ParsedCommit,
+  parseCommitMessage,
+  parseCommits,
+  referencesTicket,
+  type TicketAction,
+  type TicketReference,
+} from './commit-parser'


### PR DESCRIPTION
## Summary

- Add new API endpoint (`POST /api/integrations/git-hook`) that processes git commits and updates tickets based on commit message patterns
- Implement commit message parser that extracts ticket references (e.g., `PUNT-123`) and determines actions (`close`, `in_progress`, `reference`)
- Include shell scripts for `post-commit` (sends commit info to API) and `commit-msg` (validates ticket references) hooks
- Provide installer script and comprehensive documentation

## Features

**Supported Patterns:**
| Pattern | Action |
|---------|--------|
| `fixes PUNT-123`, `closes PUNT-123`, `resolves PUNT-123` | Move to Done |
| `wip PUNT-123`, `working on PUNT-123` | Move to In Progress |
| `PUNT-123` (standalone) | Log reference |

**Files Added:**
- `src/app/api/integrations/git-hook/route.ts` - API endpoint
- `src/lib/git-hooks/commit-parser.ts` - Commit message parsing utility
- `scripts/git-hooks/post-commit` - Post-commit hook script
- `scripts/git-hooks/commit-msg` - Commit message validation hook
- `scripts/git-hooks/install.sh` - Hook installer
- `scripts/git-hooks/README.md` - Documentation

## Test plan

- [x] Run unit tests for commit parser (`pnpm test -- src/lib/git-hooks`)
- [x] Verify lint passes (`pnpm lint`)
- [ ] Test API endpoint with sample commit payloads
- [ ] Test hooks in a sample repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)