### PR TITLE
feat(ui): rework toast notification system for consistency (PUNT-25)

### DIFF
--- a/src/app/(app)/admin/users/[username]/page.tsx
+++ b/src/app/(app)/admin/users/[username]/page.tsx
@@ -17,7 +17,6 @@ import {
 import Link from 'next/link'
 import { useParams, useSearchParams } from 'next/navigation'
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -32,6 +31,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useIsSystemAdmin } from '@/hooks/use-current-user'
 import { getTabId } from '@/hooks/use-realtime'
+import { showToast } from '@/lib/toast'
 import { cn, getAvatarColor, getInitials } from '@/lib/utils'
 import { useAdminUndoStore } from '@/stores/admin-undo-store'
 
@@ -250,7 +250,7 @@ function AdminUserProfileContent() {
       // Invalidate the cache to get fresh data
       queryClient.invalidateQueries({ queryKey: ['admin', 'user', username] })
 
-      toast.success(isUndo ? `Role reverted to ${roleName}` : `Role updated to ${roleName}`)
+      showToast.success(isUndo ? `Role reverted to ${roleName}` : `Role updated to ${roleName}`)
     },
     [queryClient, username],
   )
@@ -270,7 +270,7 @@ function AdminUserProfileContent() {
           true,
         )
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Failed to undo')
+        showToast.error(err instanceof Error ? err.message : 'Failed to undo')
         // Re-push the action since undo failed
         pushMemberRoleChange(action.member)
       }
@@ -292,7 +292,7 @@ function AdminUserProfileContent() {
           false,
         )
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Failed to redo')
+        showToast.error(err instanceof Error ? err.message : 'Failed to redo')
       }
     }
   }, [redo, performRoleChange])
@@ -357,11 +357,11 @@ function AdminUserProfileContent() {
         },
       )
 
-      toast.success(
+      showToast.success(
         newValue ? `${user.name} is now an admin` : `${user.name} is no longer an admin`,
       )
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to update user')
+      showToast.error(err instanceof Error ? err.message : 'Failed to update user')
     }
   }
 
@@ -402,9 +402,11 @@ function AdminUserProfileContent() {
         },
       )
 
-      toast.success(newValue ? `${user.name} has been enabled` : `${user.name} has been disabled`)
+      showToast.success(
+        newValue ? `${user.name} has been enabled` : `${user.name} has been disabled`,
+      )
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to update user')
+      showToast.error(err instanceof Error ? err.message : 'Failed to update user')
     }
   }
 
@@ -465,14 +467,14 @@ function AdminUserProfileContent() {
         newRoleName,
       })
 
-      toast.success(`Role updated to ${newRoleName}`, {
+      showToast.success(`Role updated to ${newRoleName}`, {
         action: {
           label: 'Undo',
           onClick: handleUndo,
         },
       })
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to update role')
+      showToast.error(err instanceof Error ? err.message : 'Failed to update role')
     }
   }
 

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -4,12 +4,12 @@ import { useQuery } from '@tanstack/react-query'
 import { ArrowRight, CheckCircle2, Clock, FolderKanban, Layers, Plus } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useMemo, useRef } from 'react'
-import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useProjects } from '@/hooks/queries/use-projects'
 import { demoStorage, isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
 import { useProjectsStore } from '@/stores/projects-store'
 import { useUIStore } from '@/stores/ui-store'
 
@@ -114,7 +114,7 @@ export default function DashboardPage() {
 
     if (invalidPath && !hasShownRedirectToast.current) {
       hasShownRedirectToast.current = true
-      toast.error('404 - Page Not Found', {
+      showToast.error('404 - Page Not Found', {
         description: `The page "${invalidPath}" doesn't exist. You've been redirected to the dashboard.`,
         duration: 5000,
       })

--- a/src/components/admin/create-user-dialog.tsx
+++ b/src/components/admin/create-user-dialog.tsx
@@ -3,8 +3,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { AlertTriangle, Eye, EyeOff, Loader2, UserPlus } from 'lucide-react'
 import { useState } from 'react'
-import { toast } from 'sonner'
-
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -19,6 +17,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
 
 export function CreateUserDialog() {
   const [open, setOpen] = useState(false)
@@ -36,7 +35,7 @@ export function CreateUserDialog() {
     mutationFn: async () => {
       // Demo mode: show info toast and don't submit
       if (isDemoMode()) {
-        toast.info('User creation is disabled in demo mode')
+        showToast.info('User creation is disabled in demo mode')
         return { demo: true }
       }
 
@@ -64,11 +63,11 @@ export function CreateUserDialog() {
         return
       }
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })
-      toast.success('User created successfully')
+      showToast.success('User created successfully')
       handleClose()
     },
     onError: (error) => {
-      toast.error(error.message)
+      showToast.error(error.message)
     },
   })
 

--- a/src/components/admin/database-wipe-projects-dialog.tsx
+++ b/src/components/admin/database-wipe-projects-dialog.tsx
@@ -2,7 +2,6 @@
 
 import { AlertTriangle, Eye, EyeOff, FolderX, Loader2, Lock, Shield } from 'lucide-react'
 import { useState } from 'react'
-import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -14,6 +13,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useWipeProjects } from '@/hooks/queries/use-database-backup'
+import { showToast } from '@/lib/toast'
 
 interface DatabaseWipeProjectsDialogProps {
   open: boolean
@@ -63,7 +63,7 @@ export function DatabaseWipeProjectsDialog({
       })
       setResult({ projects: res.counts.projects, tickets: res.counts.tickets })
       setStep('success')
-      toast.success('All projects wiped successfully')
+      showToast.success('All projects wiped successfully')
     } catch {
       // Error shown via toast, return to confirm step
       setStep('confirm')

--- a/src/components/admin/role-permissions-form.tsx
+++ b/src/components/admin/role-permissions-form.tsx
@@ -17,7 +17,6 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Copy, GitCompare, Loader2, Plus, RotateCcw, Shield, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
 import { RoleCompareDialog } from '@/components/projects/permissions/role-compare-dialog'
 import { RoleEditorPanel } from '@/components/projects/permissions/role-editor-panel'
 import {
@@ -38,6 +37,7 @@ import {
   ROLE_POSITIONS,
   ROLE_PRESETS,
 } from '@/lib/permissions/presets'
+import { showToast } from '@/lib/toast'
 import type { RoleWithPermissions } from '@/types'
 
 interface RoleConfig {
@@ -144,12 +144,12 @@ export function RolePermissionsForm() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'settings', 'roles'] })
-      toast.success('Role settings saved')
+      showToast.success('Role settings saved')
       setHasChanges(false)
       setIsCreating(false)
     },
     onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Failed to save')
+      showToast.error(err instanceof Error ? err.message : 'Failed to save')
     },
   })
 
@@ -164,14 +164,14 @@ export function RolePermissionsForm() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'settings', 'roles'] })
-      toast.success('Role settings reset to defaults')
+      showToast.success('Role settings reset to defaults')
       setHasChanges(false)
       setCustomRoles([])
       setIsCreating(false)
       setSelectedId('Owner')
     },
     onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Failed to reset')
+      showToast.error(err instanceof Error ? err.message : 'Failed to reset')
     },
   })
 
@@ -313,7 +313,7 @@ export function RolePermissionsForm() {
       setCustomRoles((prev) => [...prev, newRole])
       setSelectedId(id)
       setIsCreating(false)
-      toast.success(`Cloned "${source.name}"`)
+      showToast.success(`Cloned "${source.name}"`)
     },
     [localSettings, customRoles],
   )
@@ -326,7 +326,7 @@ export function RolePermissionsForm() {
       if (selectedId === roleId) {
         setSelectedId('Owner')
       }
-      if (role) toast.success(`Removed "${role.name}"`)
+      if (role) showToast.success(`Removed "${role.name}"`)
     },
     [customRoles, selectedId],
   )
@@ -425,7 +425,7 @@ export function RolePermissionsForm() {
 
   const handleCreateRole = () => {
     if (!editName.trim()) {
-      toast.error('Role name is required')
+      showToast.error('Role name is required')
       return
     }
     const id = `custom-${Date.now()}-${nextCustomId++}`

--- a/src/components/admin/user-list.tsx
+++ b/src/components/admin/user-list.tsx
@@ -24,8 +24,6 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
-import { toast } from 'sonner'
-
 import { PageHeader } from '@/components/common'
 import {
   AlertDialog,
@@ -72,6 +70,7 @@ import {
 import { useCurrentUser } from '@/hooks/use-current-user'
 import { getTabId } from '@/hooks/use-realtime'
 import { demoStorage, isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
 import { useAdminUndoStore } from '@/stores/admin-undo-store'
 import { CreateUserDialog } from './create-user-dialog'
 
@@ -219,7 +218,7 @@ export function UserList() {
     }) => {
       if (isDemoMode()) {
         // Demo mode: simulate success
-        toast.info('User management is read-only in demo mode')
+        showToast.info('User management is read-only in demo mode')
         return { user: { username, ...updates }, updates, previousUser }
       }
       const res = await fetch(`/api/admin/users/${username}`, {
@@ -251,22 +250,22 @@ export function UserList() {
 
         if (updates.isSystemAdmin) {
           pushUserMakeAdmin([userSnapshot])
-          toast.success(`${user.name} is now an admin (Ctrl+Z to undo)`)
+          showToast.success(`${user.name} is now an admin (Ctrl+Z to undo)`)
         } else {
           pushUserRemoveAdmin([userSnapshot])
-          toast.success(`${user.name} is no longer an admin (Ctrl+Z to undo)`)
+          showToast.success(`${user.name} is no longer an admin (Ctrl+Z to undo)`)
         }
       }
     },
     onError: (error) => {
-      toast.error(error.message)
+      showToast.error(error.message)
     },
   })
 
   const deleteUser = useMutation({
     mutationFn: async ({ username, permanent }: { username: string; permanent: boolean }) => {
       if (isDemoMode()) {
-        toast.info('User management is read-only in demo mode')
+        showToast.info('User management is read-only in demo mode')
         return { action: 'demo' }
       }
       const url = permanent
@@ -282,11 +281,11 @@ export function UserList() {
     onSuccess: (data) => {
       if (data.action === 'demo') return
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })
-      toast.success(data.action === 'deleted' ? 'User permanently deleted' : 'User disabled')
+      showToast.success(data.action === 'deleted' ? 'User permanently deleted' : 'User disabled')
       setDeleteUsername(null)
     },
     onError: (error) => {
-      toast.error(error.message)
+      showToast.error(error.message)
     },
   })
 
@@ -356,7 +355,7 @@ export function UserList() {
               ? 'admins'
               : 'non-admins'
             : 'in that state'
-        toast.info(
+        showToast.info(
           `All ${skipped} selected user${skipped !== 1 ? 's were' : ' was'} already ${state}`,
         )
         setSelectedIds(new Set())
@@ -379,15 +378,15 @@ export function UserList() {
           : ''
 
       if (failed === 0) {
-        toast.success(`${message}${extra} (Ctrl+Z to undo)`)
+        showToast.success(`${message}${extra} (Ctrl+Z to undo)`)
       } else {
-        toast.warning(`${message}, failed ${failed}`)
+        showToast.warning(`${message}, failed ${failed}`)
       }
       setSelectedIds(new Set())
       setBulkAction(null)
     },
     onError: () => {
-      toast.error('Bulk update failed')
+      showToast.error('Bulk update failed')
       setBulkAction(null)
     },
   })
@@ -436,21 +435,21 @@ export function UserList() {
       }
 
       if (succeeded === 0 && skipped > 0) {
-        toast.info(
+        showToast.info(
           `All ${skipped} selected user${skipped !== 1 ? 's were' : ' was'} already disabled`,
         )
       } else if (failed === 0) {
         const msg = `Disabled ${succeeded} user${succeeded !== 1 ? 's' : ''}`
         const extra = skipped > 0 ? ` (${skipped} already disabled)` : ''
-        toast.success(`${msg}${extra} (Ctrl+Z to undo)`)
+        showToast.success(`${msg}${extra} (Ctrl+Z to undo)`)
       } else {
-        toast.warning(`Disabled ${succeeded}, failed ${failed}`)
+        showToast.warning(`Disabled ${succeeded}, failed ${failed}`)
       }
       setSelectedIds(new Set())
       setBulkAction(null)
     },
     onError: () => {
-      toast.error('Bulk disable failed')
+      showToast.error('Bulk disable failed')
       setBulkAction(null)
     },
   })
@@ -499,21 +498,21 @@ export function UserList() {
       }
 
       if (succeeded === 0 && skipped > 0) {
-        toast.info(
+        showToast.info(
           `All ${skipped} selected user${skipped !== 1 ? 's were' : ' was'} already enabled`,
         )
       } else if (failed === 0) {
         const msg = `Enabled ${succeeded} user${succeeded !== 1 ? 's' : ''}`
         const extra = skipped > 0 ? ` (${skipped} already enabled)` : ''
-        toast.success(`${msg}${extra} (Ctrl+Z to undo)`)
+        showToast.success(`${msg}${extra} (Ctrl+Z to undo)`)
       } else {
-        toast.warning(`Enabled ${succeeded}, failed ${failed}`)
+        showToast.warning(`Enabled ${succeeded}, failed ${failed}`)
       }
       setSelectedIds(new Set())
       setBulkAction(null)
     },
     onError: () => {
-      toast.error('Bulk enable failed')
+      showToast.error('Bulk enable failed')
       setBulkAction(null)
     },
   })
@@ -560,9 +559,9 @@ export function UserList() {
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })
 
       if (failed === 0) {
-        toast.success(`Permanently deleted ${succeeded} user${succeeded !== 1 ? 's' : ''}`)
+        showToast.success(`Permanently deleted ${succeeded} user${succeeded !== 1 ? 's' : ''}`)
       } else {
-        toast.warning(`Deleted ${succeeded}, failed ${failed}`)
+        showToast.warning(`Deleted ${succeeded}, failed ${failed}`)
       }
       setSelectedIds(new Set())
       closeBulkDeleteDialog()
@@ -634,11 +633,11 @@ export function UserList() {
       )
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })
 
-      toast.success(
+      showToast.success(
         `${verb} ${action.users.length} user${action.users.length !== 1 ? 's' : ''} (Ctrl+Y to redo)`,
       )
     } catch {
-      toast.error('Failed to undo')
+      showToast.error('Failed to undo')
     }
   }, [undo, queryClient, tabId])
 
@@ -691,11 +690,11 @@ export function UserList() {
       )
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })
 
-      toast.success(
+      showToast.success(
         `${verb} ${action.users.length} user${action.users.length !== 1 ? 's' : ''} (Ctrl+Z to undo)`,
       )
     } catch {
-      toast.error('Failed to redo')
+      showToast.error('Failed to redo')
     }
   }, [redo, queryClient, tabId])
 

--- a/src/components/board/add-column-button.tsx
+++ b/src/components/board/add-column-button.tsx
@@ -3,7 +3,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { Plus, X } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
-import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -20,6 +19,7 @@ import { columnKeys } from '@/hooks/queries/use-tickets'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { getTabId } from '@/hooks/use-realtime'
 import { PERMISSIONS } from '@/lib/permissions'
+import { showToast } from '@/lib/toast'
 import { showUndoRedoToast } from '@/lib/undo-toast'
 import { useBoardStore } from '@/stores/board-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -137,7 +137,7 @@ export function AddColumnButton({ projectId, projectKey }: AddColumnButtonProps)
             queryClient.invalidateQueries({ queryKey: columnKeys.byProject(projectId) })
           } catch (err) {
             console.error('Failed to undo column create:', err)
-            toast.error('Failed to undo column creation')
+            showToast.error('Failed to undo column creation')
           } finally {
             useUndoStore.getState().setProcessing(false)
           }
@@ -170,7 +170,7 @@ export function AddColumnButton({ projectId, projectKey }: AddColumnButtonProps)
             queryClient.invalidateQueries({ queryKey: columnKeys.byProject(projectId) })
           } catch (err) {
             console.error('Failed to redo column create:', err)
-            toast.error('Failed to redo column creation')
+            showToast.error('Failed to redo column creation')
           } finally {
             useUndoStore.getState().setProcessing(false)
           }
@@ -186,7 +186,7 @@ export function AddColumnButton({ projectId, projectKey }: AddColumnButtonProps)
       setDialogOpen(false)
       setColumnName('')
     } catch (error) {
-      toast.error('Failed to create column', {
+      showToast.error('Failed to create column', {
         description: error instanceof Error ? error.message : 'An error occurred',
       })
     } finally {

--- a/src/components/board/column-menu.tsx
+++ b/src/components/board/column-menu.tsx
@@ -11,7 +11,6 @@ import {
   Trash2,
 } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
-import { toast } from 'sonner'
 import { ColorPickerBody } from '@/components/tickets/label-select'
 import {
   AlertDialog,
@@ -58,6 +57,7 @@ import {
   resolveColumnColor,
   resolveColumnIconName,
 } from '@/lib/status-icons'
+import { showToast } from '@/lib/toast'
 import { showUndoRedoToast } from '@/lib/undo-toast'
 import { cn } from '@/lib/utils'
 import { useBoardStore } from '@/stores/board-store'
@@ -165,11 +165,11 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
         // Invalidate column queries to refresh data
         queryClient.invalidateQueries({ queryKey: columnKeys.byProject(projectId) })
 
-        toast.success('Column moved', {
+        showToast.success('Column moved', {
           description: `"${column.name}" moved ${direction}`,
         })
       } catch (error) {
-        toast.error('Failed to move column', {
+        showToast.error('Failed to move column', {
           description: error instanceof Error ? error.message : 'An error occurred',
         })
       } finally {
@@ -284,7 +284,7 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
             queryClient.invalidateQueries({ queryKey: columnKeys.byProject(projectId) })
           } catch (err) {
             console.error('Failed to undo column rename:', err)
-            toast.error('Failed to undo column update')
+            showToast.error('Failed to undo column update')
           } finally {
             useUndoStore.getState().setProcessing(false)
           }
@@ -315,7 +315,7 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
             queryClient.invalidateQueries({ queryKey: columnKeys.byProject(projectId) })
           } catch (err) {
             console.error('Failed to redo column rename:', err)
-            toast.error('Failed to redo column update')
+            showToast.error('Failed to redo column update')
           } finally {
             useUndoStore.getState().setProcessing(false)
           }
@@ -342,7 +342,7 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
 
       setRenameOpen(false)
     } catch (error) {
-      toast.error('Failed to update column', {
+      showToast.error('Failed to update column', {
         description: error instanceof Error ? error.message : 'An error occurred',
       })
     } finally {
@@ -523,7 +523,7 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
             queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
           } catch (err) {
             console.error('Failed to undo column delete:', err)
-            toast.error('Failed to undo column deletion')
+            showToast.error('Failed to undo column deletion')
           } finally {
             useUndoStore.getState().setProcessing(false)
           }
@@ -573,7 +573,7 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
             queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
           } catch (err) {
             console.error('Failed to redo column delete:', err)
-            toast.error('Failed to redo column deletion')
+            showToast.error('Failed to redo column deletion')
           } finally {
             useUndoStore.getState().setProcessing(false)
           }
@@ -588,7 +588,7 @@ export function ColumnMenu({ column, projectId, projectKey, allColumns }: Column
 
       setDeleteOpen(false)
     } catch (error) {
-      toast.error('Failed to delete column', {
+      showToast.error('Failed to delete column', {
         description: error instanceof Error ? error.message : 'An error occurred',
       })
     } finally {

--- a/src/components/board/ticket-context-menu.tsx
+++ b/src/components/board/ticket-context-menu.tsx
@@ -27,7 +27,6 @@ import {
   useState,
 } from 'react'
 import { createPortal } from 'react-dom'
-import { toast } from 'sonner'
 import { PriorityBadge } from '@/components/common/priority-badge'
 import { resolutionConfig } from '@/components/common/resolution-badge'
 import { MoveToProjectDialog } from '@/components/tickets/move-to-project-dialog'
@@ -50,6 +49,7 @@ import { deleteTickets } from '@/lib/actions/delete-tickets'
 import { isCompletedColumn } from '@/lib/sprint-utils'
 import { getStatusIcon } from '@/lib/status-icons'
 import { formatTicketIds } from '@/lib/ticket-format'
+import { rawToast, showToast } from '@/lib/toast'
 import { showUndoRedoToast } from '@/lib/undo-toast'
 import { cn, getAvatarColor, getInitials } from '@/lib/utils'
 import { useBoardStore } from '@/stores/board-store'
@@ -244,9 +244,9 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
     const ids = getIds()
     const ticketKeys = formatTicketIds(columns, ids)
     const count = ids.length
-    toast.success(count === 1 ? 'Ticket copied' : `${count} tickets copied`, {
+    showToast.success(count === 1 ? 'Ticket copied' : `${count} tickets copied`, {
       description: ticketKeys.length === 1 ? ticketKeys[0] : ticketKeys.join(', '),
-      duration: 2000,
+      duration: showToast.DURATION.SHORT,
     })
     setOpen(false)
     setSubmenu(null)
@@ -448,7 +448,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
       updates.map((u) => u.ticketId),
     )
 
-    const toastId = toast.success(
+    const toastId = rawToast.success(
       updates.length === 1 ? 'Priority updated' : `${updates.length} priorities updated`,
       { description: updates.length === 1 ? ticketKeys[0] : ticketKeys.join(', '), duration: 3000 },
     )
@@ -515,7 +515,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
           ? `${updates.length} tickets set to ${resolution}`
           : `Resolution cleared from ${updates.length} tickets`
 
-    const toastId = toast.success(msg, {
+    const toastId = rawToast.success(msg, {
       description: updates.length === 1 ? ticketKeys[0] : ticketKeys.join(', '),
       duration: 3000,
     })
@@ -571,7 +571,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
           ? `Assigned ${updates.length} tickets to ${user.name}`
           : `Unassigned ${updates.length} tickets`
 
-    const toastId = toast.success(msg, {
+    const toastId = rawToast.success(msg, {
       description: updates.length === 1 ? ticketKeys[0] : ticketKeys.join(', '),
       duration: 3000,
     })
@@ -625,7 +625,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
           ? `Set ${updates.length} tickets to ${points} point${points === 1 ? '' : 's'}`
           : `Cleared points from ${updates.length} tickets`
 
-    const toastId = toast.success(msg, {
+    const toastId = rawToast.success(msg, {
       description: updates.length === 1 ? ticketKeys[0] : ticketKeys.join(', '),
       duration: 3000,
     })

--- a/src/components/common/email-verification-banner.tsx
+++ b/src/components/common/email-verification-banner.tsx
@@ -3,10 +3,10 @@
 import { AlertTriangle, Loader2, Mail, X } from 'lucide-react'
 import { useSession } from 'next-auth/react'
 import { useState } from 'react'
-import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { useEmailVerificationStatus } from '@/hooks/queries/use-email-verification'
 import { isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
 
 /**
  * Wrapper that skips email verification banner in demo mode
@@ -57,20 +57,20 @@ function EmailVerificationBannerInner() {
 
       if (!res.ok) {
         if (res.status === 429) {
-          toast.error('Too many requests. Please try again later.')
+          showToast.error('Too many requests. Please try again later.')
         } else {
-          toast.error(data.error || 'Failed to send verification email')
+          showToast.error(data.error || 'Failed to send verification email')
         }
         return
       }
 
       if (data.alreadyVerified) {
-        toast.success('Email is already verified')
+        showToast.success('Email is already verified')
       } else {
-        toast.success('Verification email sent!')
+        showToast.success('Verification email sent!')
       }
     } catch {
-      toast.error('Failed to send verification email')
+      showToast.error('Failed to send verification email')
     } finally {
       setIsSending(false)
     }

--- a/src/components/profile/integrations-tab.tsx
+++ b/src/components/profile/integrations-tab.tsx
@@ -2,7 +2,6 @@
 
 import { Bot, Check, Copy, Eye, EyeOff, KeyRound, Terminal, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { toast } from 'sonner'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,6 +16,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
+import { showToast } from '@/lib/toast'
 
 interface IntegrationsTabProps {
   isDemo: boolean
@@ -92,9 +92,9 @@ export function IntegrationsTab({ isDemo }: IntegrationsTabProps) {
       setMcpKeyVisible(true)
       setMcpHasKey(true)
       setMcpKeyHint(data.apiKey.slice(-4))
-      toast.success('MCP API key generated')
+      showToast.success('MCP API key generated')
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to generate API key')
+      showToast.error(error instanceof Error ? error.message : 'Failed to generate API key')
     } finally {
       setMcpKeyLoading(false)
     }
@@ -110,9 +110,9 @@ export function IntegrationsTab({ isDemo }: IntegrationsTabProps) {
       setMcpKeyHint(null)
       setMcpNewKey(null)
       setMcpKeyVisible(false)
-      toast.success('MCP API key revoked')
+      showToast.success('MCP API key revoked')
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to revoke API key')
+      showToast.error(error instanceof Error ? error.message : 'Failed to revoke API key')
     } finally {
       setMcpKeyLoading(false)
     }
@@ -125,9 +125,9 @@ export function IntegrationsTab({ isDemo }: IntegrationsTabProps) {
       setMcpKeyCopied(true)
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current)
       copyTimeoutRef.current = setTimeout(() => setMcpKeyCopied(false), 2000)
-      toast.success('API key copied to clipboard')
+      showToast.success('API key copied to clipboard')
     } catch {
-      toast.error('Failed to copy to clipboard')
+      showToast.error('Failed to copy to clipboard')
     }
   }, [mcpNewKey])
 

--- a/src/components/profile/profile-tab.tsx
+++ b/src/components/profile/profile-tab.tsx
@@ -2,7 +2,6 @@
 
 import { Camera, Palette, Shield, User } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { toast } from 'sonner'
 import { ImageCropDialog, resizeImageForCropper } from '@/components/profile/image-crop-dialog'
 import { ColorPickerBody } from '@/components/tickets/label-select'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -11,6 +10,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { getTabId } from '@/hooks/use-realtime'
+import { showToast } from '@/lib/toast'
 import { getAvatarColor, getInitials } from '@/lib/utils'
 
 interface UserData {
@@ -106,9 +106,9 @@ export function ProfileTab({
 
       onUserUpdate({ name })
       await onSessionUpdate()
-      toast.success('Display name updated')
+      showToast.success('Display name updated')
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to update profile')
+      showToast.error(error instanceof Error ? error.message : 'Failed to update profile')
     } finally {
       setProfileLoading(false)
     }
@@ -127,7 +127,7 @@ export function ProfileTab({
       setCropDialogOpen(true)
     } catch (error) {
       console.error('Failed to load image:', error)
-      toast.error('Failed to load image')
+      showToast.error('Failed to load image')
     }
   }
 
@@ -178,13 +178,13 @@ export function ProfileTab({
       }
 
       await onSessionUpdate()
-      toast.success('Avatar updated')
+      showToast.success('Avatar updated')
     } catch (error) {
       if (blobUrlRef.current) {
         URL.revokeObjectURL(blobUrlRef.current)
         blobUrlRef.current = null
       }
-      toast.error(error instanceof Error ? error.message : 'Failed to upload avatar')
+      showToast.error(error instanceof Error ? error.message : 'Failed to upload avatar')
     } finally {
       setAvatarLoading(false)
       selectedFileRef.current = null
@@ -222,9 +222,9 @@ export function ProfileTab({
 
       setOptimisticAvatar(null)
       await onSessionUpdate()
-      toast.success('Avatar removed')
+      showToast.success('Avatar removed')
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to remove avatar')
+      showToast.error(error instanceof Error ? error.message : 'Failed to remove avatar')
     } finally {
       setAvatarLoading(false)
     }
@@ -253,9 +253,9 @@ export function ProfileTab({
       }
 
       await onSessionUpdate()
-      toast.success(color ? 'Avatar color updated' : 'Avatar color reset to default')
+      showToast.success(color ? 'Avatar color updated' : 'Avatar color reset to default')
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to update avatar color')
+      showToast.error(error instanceof Error ? error.message : 'Failed to update avatar color')
     } finally {
       setAvatarColorLoading(false)
     }

--- a/src/components/profile/security-tab.tsx
+++ b/src/components/profile/security-tab.tsx
@@ -3,7 +3,6 @@
 import { KeyRound, Mail, Trash2 } from 'lucide-react'
 import { signOut } from 'next-auth/react'
 import { useState } from 'react'
-import { toast } from 'sonner'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -20,6 +19,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { getTabId } from '@/hooks/use-realtime'
+import { showToast } from '@/lib/toast'
 
 interface UserData {
   id: string
@@ -78,9 +78,9 @@ export function SecurityTab({ user, isDemo, onUserUpdate, onSessionUpdate }: Sec
       await onSessionUpdate()
       setNewEmail('')
       setEmailPassword('')
-      toast.success('Email address updated')
+      showToast.success('Email address updated')
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to change email')
+      showToast.error(error instanceof Error ? error.message : 'Failed to change email')
     } finally {
       setEmailLoading(false)
     }
@@ -90,7 +90,7 @@ export function SecurityTab({ user, isDemo, onUserUpdate, onSessionUpdate }: Sec
     e.preventDefault()
 
     if (newPassword !== confirmPassword) {
-      toast.error('New passwords do not match')
+      showToast.error('New passwords do not match')
       return
     }
 
@@ -112,9 +112,9 @@ export function SecurityTab({ user, isDemo, onUserUpdate, onSessionUpdate }: Sec
       setCurrentPassword('')
       setNewPassword('')
       setConfirmPassword('')
-      toast.success('Password changed successfully')
+      showToast.success('Password changed successfully')
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to change password')
+      showToast.error(error instanceof Error ? error.message : 'Failed to change password')
     } finally {
       setPasswordLoading(false)
     }
@@ -122,12 +122,12 @@ export function SecurityTab({ user, isDemo, onUserUpdate, onSessionUpdate }: Sec
 
   const handleDeleteAccount = async () => {
     if (isDemo) {
-      toast.error('Account deletion is not available in demo mode')
+      showToast.error('Account deletion is not available in demo mode')
       return
     }
 
     if (deleteConfirmation !== 'DELETE MY ACCOUNT') {
-      toast.error('Please type "DELETE MY ACCOUNT" to confirm')
+      showToast.error('Please type "DELETE MY ACCOUNT" to confirm')
       return
     }
 
@@ -149,10 +149,10 @@ export function SecurityTab({ user, isDemo, onUserUpdate, onSessionUpdate }: Sec
         throw new Error(data.error || 'Failed to delete account')
       }
 
-      toast.success('Account deleted. Signing out...')
+      showToast.success('Account deleted. Signing out...')
       await signOut({ callbackUrl: '/login' })
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to delete account')
+      showToast.error(error instanceof Error ? error.message : 'Failed to delete account')
       setDeleteLoading(false)
     }
   }

--- a/src/components/projects/edit-project-dialog.tsx
+++ b/src/components/projects/edit-project-dialog.tsx
@@ -2,7 +2,6 @@
 
 import { AlertTriangle, Loader2, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
-import { toast } from 'sonner'
 import { ColorPickerBody } from '@/components/tickets/label-select'
 import {
   AlertDialog,
@@ -28,6 +27,7 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { useDeleteProject, useUpdateProject } from '@/hooks/queries/use-projects'
 import { LABEL_COLORS } from '@/lib/constants'
+import { showToast } from '@/lib/toast'
 import { useProjectsStore } from '@/stores/projects-store'
 import { useUIStore } from '@/stores/ui-store'
 
@@ -103,14 +103,14 @@ export function EditProjectDialog() {
       {
         onSuccess: () => {
           const newKey = keyChanged ? formData.key.toUpperCase() : originalKey
-          toast.success('Project updated', {
+          showToast.success('Project updated', {
             description: `${formData.name.trim()} (${newKey})`,
             duration: 4000,
           })
           handleClose()
         },
         onError: (error) => {
-          toast.error('Failed to update project', {
+          showToast.error('Failed to update project', {
             description: error.message,
           })
         },
@@ -127,7 +127,7 @@ export function EditProjectDialog() {
 
     deleteProject.mutate(editProjectId, {
       onSuccess: () => {
-        toast.success('Project deleted', {
+        showToast.success('Project deleted', {
           description: project.name,
           duration: 4000,
         })
@@ -135,7 +135,7 @@ export function EditProjectDialog() {
         handleClose()
       },
       onError: (error) => {
-        toast.error('Failed to delete project', {
+        showToast.error('Failed to delete project', {
           description: error.message,
         })
         setShowDeleteConfirm(false)

--- a/src/components/projects/permissions/add-member-dialog.tsx
+++ b/src/components/projects/permissions/add-member-dialog.tsx
@@ -3,7 +3,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { Check, ChevronsUpDown, Loader2, UserPlus, Users, X } from 'lucide-react'
 import { useCallback, useState } from 'react'
-import { toast } from 'sonner'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import {
@@ -36,6 +35,7 @@ import {
 import { availableUserKeys, memberKeys, useAvailableUsers } from '@/hooks/queries/use-members'
 import { useProjectRoles } from '@/hooks/queries/use-roles'
 import { getTabId } from '@/hooks/use-realtime'
+import { showToast } from '@/lib/toast'
 import { cn, getAvatarColor } from '@/lib/utils'
 import { type MemberSnapshot, useAdminUndoStore } from '@/stores/admin-undo-store'
 
@@ -162,10 +162,10 @@ export function AddMemberDialog({ projectId, trigger }: AddMemberDialogProps) {
       pushMemberAdd(projectId, memberSnapshots)
 
       // Single toast for all members
-      toast.success(`Added ${count} member${count !== 1 ? 's' : ''} (Ctrl+Z to undo)`)
+      showToast.success(`Added ${count} member${count !== 1 ? 's' : ''} (Ctrl+Z to undo)`)
       handleOpenChange(false)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to add members')
+      showToast.error(err instanceof Error ? err.message : 'Failed to add members')
     } finally {
       setIsSubmitting(false)
     }

--- a/src/components/projects/permissions/members-tab.tsx
+++ b/src/components/projects/permissions/members-tab.tsx
@@ -14,7 +14,6 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
 import { AddMemberDialog } from '@/components/projects/permissions/add-member-dialog'
 import {
   AlertDialog,
@@ -50,6 +49,7 @@ import { useCurrentUser } from '@/hooks/use-current-user'
 import { useHasPermission, useIsSystemAdmin } from '@/hooks/use-permissions'
 import { getTabId } from '@/hooks/use-realtime'
 import { PERMISSIONS } from '@/lib/permissions'
+import { showToast } from '@/lib/toast'
 import { cn, getAvatarColor } from '@/lib/utils'
 import {
   type BulkMemberRoleSnapshot,
@@ -211,9 +211,9 @@ export function MembersTab({ projectId, projectKey }: MembersTabProps) {
       // Push to undo stack
       pushMemberRemove(projectId, [memberSnapshot])
 
-      toast.success('Member removed (Ctrl+Z to undo)')
+      showToast.success('Member removed (Ctrl+Z to undo)')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to remove member')
+      showToast.error(err instanceof Error ? err.message : 'Failed to remove member')
     }
     setRemovingMember(null)
   }
@@ -260,10 +260,10 @@ export function MembersTab({ projectId, projectKey }: MembersTabProps) {
       // Push to undo stack
       pushMemberRemove(projectId, removedMembers)
 
-      toast.success(`Removed ${count} member${count !== 1 ? 's' : ''} (Ctrl+Z to undo)`)
+      showToast.success(`Removed ${count} member${count !== 1 ? 's' : ''} (Ctrl+Z to undo)`)
       setSelectedIds(new Set())
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to remove members')
+      showToast.error(err instanceof Error ? err.message : 'Failed to remove members')
     } finally {
       setIsRemoving(false)
       setShowBulkRemoveDialog(false)
@@ -318,10 +318,12 @@ export function MembersTab({ projectId, projectKey }: MembersTabProps) {
       // Push to undo stack
       pushBulkMemberRoleChange(projectId, roleChanges)
 
-      toast.success(`Set ${count} member${count !== 1 ? 's' : ''} to ${roleName} (Ctrl+Z to undo)`)
+      showToast.success(
+        `Set ${count} member${count !== 1 ? 's' : ''} to ${roleName} (Ctrl+Z to undo)`,
+      )
       setSelectedIds(new Set())
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to update roles')
+      showToast.error(err instanceof Error ? err.message : 'Failed to update roles')
     } finally {
       setIsChangingRole(false)
     }
@@ -357,11 +359,11 @@ export function MembersTab({ projectId, projectKey }: MembersTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Restored ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to restore members')
+        showToast.error('Failed to restore members')
       }
     } else if (action.type === 'memberAdd' && action.projectId === projectId) {
       // Remove re-added members
@@ -380,11 +382,11 @@ export function MembersTab({ projectId, projectKey }: MembersTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Removed ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to remove members')
+        showToast.error('Failed to remove members')
       }
     } else if (action.type === 'bulkMemberRoleChange' && action.projectId === projectId) {
       // Restore previous roles
@@ -403,11 +405,11 @@ export function MembersTab({ projectId, projectKey }: MembersTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Restored roles for ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to restore roles')
+        showToast.error('Failed to restore roles')
       }
     }
   }, [undo, projectId, members, invalidateMemberQueries])
@@ -434,11 +436,11 @@ export function MembersTab({ projectId, projectKey }: MembersTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Removed ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to remove members')
+        showToast.error('Failed to remove members')
       }
     } else if (action.type === 'memberAdd' && action.projectId === projectId) {
       // Re-add members
@@ -457,11 +459,11 @@ export function MembersTab({ projectId, projectKey }: MembersTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Added ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to add members')
+        showToast.error('Failed to add members')
       }
     } else if (action.type === 'bulkMemberRoleChange' && action.projectId === projectId) {
       // Re-apply new roles
@@ -480,11 +482,11 @@ export function MembersTab({ projectId, projectKey }: MembersTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Updated roles for ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to update roles')
+        showToast.error('Failed to update roles')
       }
     }
   }, [redo, projectId, members, invalidateMemberQueries])

--- a/src/components/projects/permissions/roles-tab.tsx
+++ b/src/components/projects/permissions/roles-tab.tsx
@@ -33,7 +33,6 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -85,6 +84,7 @@ import { getTabId } from '@/hooks/use-realtime'
 import { LABEL_COLORS } from '@/lib/constants'
 import { PERMISSIONS } from '@/lib/permissions'
 import { type DefaultRoleName, ROLE_POSITIONS, ROLE_PRESETS } from '@/lib/permissions/presets'
+import { showToast } from '@/lib/toast'
 import { cn, getAvatarColor, getInitials } from '@/lib/utils'
 import {
   type BulkMemberRoleSnapshot,
@@ -358,9 +358,9 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
           roleName,
         }
         pushMemberAdd(projectId, [snapshot])
-        toast.success(`Added ${userName} as ${roleName} (Ctrl+Z to undo)`)
+        showToast.success(`Added ${userName} as ${roleName} (Ctrl+Z to undo)`)
       } catch {
-        toast.error('Failed to add member')
+        showToast.error('Failed to add member')
       }
     },
     [projectId, roles, invalidateMemberQueries, pushMemberAdd],
@@ -398,9 +398,9 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
           newRoleName,
         }
         pushBulkMemberRoleChange(projectId, [snapshot])
-        toast.success(`Changed ${userName} to ${newRoleName} (Ctrl+Z to undo)`)
+        showToast.success(`Changed ${userName} to ${newRoleName} (Ctrl+Z to undo)`)
       } catch {
-        toast.error('Failed to update role')
+        showToast.error('Failed to update role')
       }
     },
     [projectId, roles, invalidateMemberQueries, pushBulkMemberRoleChange],
@@ -426,9 +426,9 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
           roleName,
         }
         pushMemberRemove(projectId, [snapshot])
-        toast.success(`Removed ${userName} (Ctrl+Z to undo)`)
+        showToast.success(`Removed ${userName} (Ctrl+Z to undo)`)
       } catch {
-        toast.error('Failed to remove member')
+        showToast.error('Failed to remove member')
       }
     },
     [projectId, roles, invalidateMemberQueries, pushMemberRemove],
@@ -483,12 +483,12 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
         // Push to undo stack
         pushBulkMemberRoleChange(projectId, roleChanges)
 
-        toast.success(
+        showToast.success(
           `Moved ${count} member${count !== 1 ? 's' : ''} to ${newRoleName} (Ctrl+Z to undo)`,
         )
         setMemberSelectedIds(new Set())
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Failed to update roles')
+        showToast.error(err instanceof Error ? err.message : 'Failed to update roles')
       } finally {
         setIsChangingBulkRole(false)
       }
@@ -546,10 +546,10 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
       // Push to undo stack
       pushMemberRemove(projectId, removedMembers)
 
-      toast.success(`Removed ${count} member${count !== 1 ? 's' : ''} (Ctrl+Z to undo)`)
+      showToast.success(`Removed ${count} member${count !== 1 ? 's' : ''} (Ctrl+Z to undo)`)
       setMemberSelectedIds(new Set())
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to remove members')
+      showToast.error(err instanceof Error ? err.message : 'Failed to remove members')
     } finally {
       setIsRemovingBulk(false)
       setShowBulkRemoveDialog(false)
@@ -585,11 +585,11 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Restored ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to restore members')
+        showToast.error('Failed to restore members')
       }
     } else if (action.type === 'memberAdd' && action.projectId === projectId) {
       try {
@@ -606,11 +606,11 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Removed ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to remove members')
+        showToast.error('Failed to remove members')
       }
     } else if (action.type === 'bulkMemberRoleChange' && action.projectId === projectId) {
       try {
@@ -628,11 +628,11 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Restored roles for ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to restore roles')
+        showToast.error('Failed to restore roles')
       }
     }
   }, [undo, projectId, members, invalidateMemberQueries])
@@ -657,11 +657,11 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Removed ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to remove members')
+        showToast.error('Failed to remove members')
       }
     } else if (action.type === 'memberAdd' && action.projectId === projectId) {
       try {
@@ -679,11 +679,11 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Added ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to add members')
+        showToast.error('Failed to add members')
       }
     } else if (action.type === 'bulkMemberRoleChange' && action.projectId === projectId) {
       try {
@@ -701,11 +701,11 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
           }),
         )
         invalidateMemberQueries()
-        toast.success(
+        showToast.success(
           `Updated roles for ${action.members.length} member${action.members.length !== 1 ? 's' : ''}`,
         )
       } catch {
-        toast.error('Failed to update roles')
+        showToast.error('Failed to update roles')
       }
     }
   }, [redo, projectId, members, invalidateMemberQueries])
@@ -895,7 +895,7 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
   // Save the role
   const handleSave = async () => {
     if (!editName.trim()) {
-      toast.error('Role name is required')
+      showToast.error('Role name is required')
       return
     }
 
@@ -949,7 +949,7 @@ export function RolesTab({ projectId, projectKey }: RolesTabProps) {
       setSelectedRoleId(newRole.id)
       setIsCreating(false)
       loadRoleData(newRole)
-      toast.success(`Cloned role "${role.name}"`)
+      showToast.success(`Cloned role "${role.name}"`)
     } catch {
       // Error handled by mutation
     }

--- a/src/components/projects/settings/general-tab.tsx
+++ b/src/components/projects/settings/general-tab.tsx
@@ -3,7 +3,6 @@
 import { AlertTriangle, Loader2, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
-import { toast } from 'sonner'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -23,6 +22,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { useDeleteProject, useProjectDetail, useUpdateProject } from '@/hooks/queries/use-projects'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { PERMISSIONS } from '@/lib/permissions'
+import { showToast } from '@/lib/toast'
 
 type AddColumnVisibility = 'inherit' | 'show' | 'hide'
 
@@ -148,13 +148,13 @@ export function GeneralTab({ projectId, project }: GeneralTabProps) {
 
     deleteProject.mutate(project.id, {
       onSuccess: () => {
-        toast.success('Project deleted', {
+        showToast.success('Project deleted', {
           description: project.name,
         })
         router.push('/')
       },
       onError: (error) => {
-        toast.error('Failed to delete project', {
+        showToast.error('Failed to delete project', {
           description: error.message,
         })
       },

--- a/src/components/projects/settings/labels-tab.tsx
+++ b/src/components/projects/settings/labels-tab.tsx
@@ -12,7 +12,6 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { toast } from 'sonner'
 import { ColorPickerBody } from '@/components/tickets/label-select'
 import {
   AlertDialog,
@@ -41,6 +40,7 @@ import {
 import { useHasPermission } from '@/hooks/use-permissions'
 import { LABEL_COLORS } from '@/lib/constants'
 import { PERMISSIONS } from '@/lib/permissions'
+import { showToast } from '@/lib/toast'
 import { cn, getLabelStyles } from '@/lib/utils'
 
 /**
@@ -240,7 +240,7 @@ export function LabelsTab({ projectId }: LabelsTabProps) {
   const handleSave = useCallback(async () => {
     const name = editName.trim()
     if (!name) {
-      toast.error('Label name is required')
+      showToast.error('Label name is required')
       return
     }
 
@@ -249,7 +249,7 @@ export function LabelsTab({ projectId }: LabelsTabProps) {
         { name, color: editColor },
         {
           onSuccess: (newLabel) => {
-            toast.success('Label created')
+            showToast.success('Label created')
             setIsCreating(false)
             setSelectedLabelId(newLabel.id)
             setHasChanges(false)

--- a/src/components/tickets/label-select.tsx
+++ b/src/components/tickets/label-select.tsx
@@ -3,7 +3,6 @@
 import { Check, ChevronsUpDown, Palette, Plus, Trash2, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { HexColorPicker } from 'react-colorful'
-import { toast } from 'sonner'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -27,6 +26,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { LABEL_COLORS } from '@/lib/constants'
+import { showToast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { LabelSummary } from '@/types'
@@ -488,7 +488,7 @@ export function ColorPickerBody({
       if (hideColorRemovalWarning) {
         // Skip modal, remove directly
         removeCustomColor(color)
-        toast.success('Color removed from swatches')
+        showToast.success('Color removed from swatches')
       } else {
         // Show confirmation modal
         setColorToRemove(color)
@@ -508,7 +508,7 @@ export function ColorPickerBody({
 
     removeCustomColor(colorToRemove)
     setColorToRemove(null)
-    toast.success('Color removed from swatches')
+    showToast.success('Color removed from swatches')
   }, [colorToRemove, dontShowAgain, removeCustomColor, setHideColorRemovalWarning])
 
   // Merge extra presets (deduplicated) with standard label colors

--- a/src/components/tickets/move-to-project-dialog.tsx
+++ b/src/components/tickets/move-to-project-dialog.tsx
@@ -2,7 +2,6 @@
 
 import { FolderOpen } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -14,6 +13,7 @@ import {
 } from '@/components/ui/dialog'
 import { useProjects } from '@/hooks/queries/use-projects'
 import { getTabId } from '@/hooks/use-realtime'
+import { showToast } from '@/lib/toast'
 import { useBoardStore } from '@/stores/board-store'
 import type { TicketWithRelations } from '@/types'
 
@@ -70,7 +70,7 @@ export function MoveToProjectDialog({
       // Remove ticket from current project's board
       removeTicket(projectId, ticket.id)
 
-      toast.success('Ticket moved', {
+      showToast.success('Ticket moved', {
         description: `${projectKey}-${ticket.number} moved to ${selectedProjectKey}-${data.ticket.number}`,
         duration: 5000,
       })
@@ -78,7 +78,7 @@ export function MoveToProjectDialog({
       onOpenChange(false)
       setSelectedProjectKey(null)
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to move ticket')
+      showToast.error(error instanceof Error ? error.message : 'Failed to move ticket')
     } finally {
       setIsMoving(false)
     }

--- a/src/components/tickets/ticket-detail-drawer.tsx
+++ b/src/components/tickets/ticket-detail-drawer.tsx
@@ -20,7 +20,6 @@ import {
 } from 'lucide-react'
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { toast } from 'sonner'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -80,6 +79,7 @@ import { PERMISSIONS } from '@/lib/permissions'
 import { isCompletedColumn } from '@/lib/sprint-utils'
 import { getStatusIcon } from '@/lib/status-icons'
 import { formatTicketId } from '@/lib/ticket-format'
+import { showToast } from '@/lib/toast'
 import { cn, getAvatarColor, getInitials } from '@/lib/utils'
 import { useBoardStore } from '@/stores/board-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -847,7 +847,7 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
                 onClick={() => {
                   const url = `${window.location.origin}${window.location.pathname}?ticket=${ticketKey}`
                   navigator.clipboard.writeText(url)
-                  toast.success('Link copied to clipboard', {
+                  showToast.success('Link copied to clipboard', {
                     description: ticketKey,
                   })
                 }}

--- a/src/hooks/queries/use-attachments.ts
+++ b/src/hooks/queries/use-attachments.ts
@@ -1,8 +1,8 @@
 'use client'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import { getTabId } from '@/hooks/use-realtime'
+import { showToast } from '@/lib/toast'
 import type { AttachmentInfo } from '@/types'
 
 export const attachmentKeys = {
@@ -103,7 +103,7 @@ export function useAddAttachments() {
       })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -166,7 +166,7 @@ export function useRemoveAttachment() {
           context.previousAttachments,
         )
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSettled: (_, __, { projectId, ticketId }) => {
       queryClient.invalidateQueries({

--- a/src/hooks/queries/use-database-backup.ts
+++ b/src/hooks/queries/use-database-backup.ts
@@ -2,11 +2,11 @@
 
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { signOut } from 'next-auth/react'
-import { toast } from 'sonner'
 import type { ImportPreview } from '@/app/api/admin/database/preview/route'
 import type { DatabaseStats } from '@/app/api/admin/database/stats/route'
 import type { ImportResult } from '@/lib/database-import'
 import { isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
 
 export type { ImportPreview, DatabaseStats }
 
@@ -55,7 +55,7 @@ export function useExportDatabase() {
   return useMutation({
     mutationFn: async (options: ExportOptions) => {
       if (isDemoMode()) {
-        toast.info('Database export is disabled in demo mode')
+        showToast.info('Database export is disabled in demo mode')
         return null
       }
 
@@ -112,10 +112,10 @@ export function useExportDatabase() {
       document.body.removeChild(link)
       URL.revokeObjectURL(url)
 
-      toast.success('Database exported successfully')
+      showToast.success('Database exported successfully')
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -132,7 +132,7 @@ export function usePreviewDatabase() {
   return useMutation({
     mutationFn: async (params: PreviewDatabaseParams): Promise<ImportPreview> => {
       if (isDemoMode()) {
-        toast.info('Database preview is disabled in demo mode')
+        showToast.info('Database preview is disabled in demo mode')
         throw new Error('Demo mode')
       }
 
@@ -174,7 +174,7 @@ export function useImportDatabase() {
   return useMutation({
     mutationFn: async (params: ImportDatabaseParams): Promise<ImportResult> => {
       if (isDemoMode()) {
-        toast.info('Database import is disabled in demo mode')
+        showToast.info('Database import is disabled in demo mode')
         throw new Error('Demo mode')
       }
 
@@ -199,11 +199,11 @@ export function useImportDatabase() {
         result.files.attachmentsRestored + result.files.avatarsRestored > 0
           ? `, ${result.files.attachmentsRestored + result.files.avatarsRestored} files`
           : ''
-      toast.success(`Database imported successfully (${total} records${fileInfo})`)
+      showToast.success(`Database imported successfully (${total} records${fileInfo})`)
     },
     onError: (err) => {
       if (err.message !== 'Demo mode') {
-        toast.error(err.message)
+        showToast.error(err.message)
       }
     },
   })
@@ -271,7 +271,7 @@ export function useWipeProjects() {
   return useMutation({
     mutationFn: async (params: WipeProjectsParams): Promise<WipeProjectsResult> => {
       if (isDemoMode()) {
-        toast.info('Project wipe is disabled in demo mode')
+        showToast.info('Project wipe is disabled in demo mode')
         throw new Error('Demo mode')
       }
 
@@ -292,7 +292,7 @@ export function useWipeProjects() {
     },
     onError: (err) => {
       if (err.message !== 'Demo mode') {
-        toast.error(err.message)
+        showToast.error(err.message)
       }
     },
   })
@@ -312,7 +312,7 @@ export function useWipeDatabase() {
   return useMutation({
     mutationFn: async (params: WipeDatabaseParams) => {
       if (isDemoMode()) {
-        toast.info('Database wipe is disabled in demo mode')
+        showToast.info('Database wipe is disabled in demo mode')
         throw new Error('Demo mode')
       }
 
@@ -332,7 +332,7 @@ export function useWipeDatabase() {
       return res.json()
     },
     onSuccess: () => {
-      toast.success('Database wiped successfully. Redirecting to login...')
+      showToast.success('Database wiped successfully. Redirecting to login...')
       // Sign out to clear the session cookie, then redirect to login
       setTimeout(() => {
         signOut({ callbackUrl: '/login' })
@@ -340,7 +340,7 @@ export function useWipeDatabase() {
     },
     onError: (err) => {
       if (err.message !== 'Demo mode') {
-        toast.error(err.message)
+        showToast.error(err.message)
       }
     },
   })

--- a/src/hooks/queries/use-labels.ts
+++ b/src/hooks/queries/use-labels.ts
@@ -1,10 +1,10 @@
 'use client'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import { getTabId } from '@/hooks/use-realtime'
 import { getDataProvider } from '@/lib/data-provider'
 import { demoStorage, isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
 import type { LabelSummary } from '@/types'
 
 // Label with ticket count for management views
@@ -101,7 +101,7 @@ export function useCreateLabel(projectId: string) {
       queryClient.invalidateQueries({ queryKey: labelKeys.byProjectWithCounts(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -125,12 +125,12 @@ export function useUpdateLabel(projectId: string) {
       return provider.updateLabel(projectId, labelId, data)
     },
     onSuccess: () => {
-      toast.success('Label updated')
+      showToast.success('Label updated')
       queryClient.invalidateQueries({ queryKey: labelKeys.byProject(projectId) })
       queryClient.invalidateQueries({ queryKey: labelKeys.byProjectWithCounts(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -148,12 +148,12 @@ export function useDeleteLabel(projectId: string) {
       return { success: true }
     },
     onSuccess: () => {
-      toast.success('Label deleted')
+      showToast.success('Label deleted')
       queryClient.invalidateQueries({ queryKey: labelKeys.byProject(projectId) })
       queryClient.invalidateQueries({ queryKey: labelKeys.byProjectWithCounts(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }

--- a/src/hooks/queries/use-members.ts
+++ b/src/hooks/queries/use-members.ts
@@ -1,9 +1,9 @@
 'use client'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import { getTabId } from '@/hooks/use-realtime'
 import { demoStorage, isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
 import type { Permission, ProjectMemberWithRole } from '@/types'
 
 // Query keys for members
@@ -116,7 +116,7 @@ export function useUpdateMember(projectId: string) {
       return res.json() as Promise<MemberDetails>
     },
     onSuccess: (_data, variables) => {
-      toast.success('Member updated')
+      showToast.success('Member updated')
       queryClient.invalidateQueries({ queryKey: memberKeys.byProject(projectId) })
       queryClient.invalidateQueries({
         queryKey: memberKeys.single(projectId, variables.memberId),
@@ -125,7 +125,7 @@ export function useUpdateMember(projectId: string) {
       queryClient.invalidateQueries({ queryKey: ['roles', 'project', projectId] })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -151,7 +151,7 @@ export function useRemoveMember(projectId: string) {
       return res.json()
     },
     onSuccess: () => {
-      toast.success('Member removed')
+      showToast.success('Member removed')
       queryClient.invalidateQueries({ queryKey: memberKeys.byProject(projectId) })
       // Also invalidate roles to update member counts
       queryClient.invalidateQueries({ queryKey: ['roles', 'project', projectId] })
@@ -159,7 +159,7 @@ export function useRemoveMember(projectId: string) {
       queryClient.invalidateQueries({ queryKey: availableUserKeys.byProject(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -198,7 +198,7 @@ export function useAddMember(projectId: string) {
       return res.json() as Promise<ProjectMemberWithRole>
     },
     onSuccess: () => {
-      toast.success('Member added')
+      showToast.success('Member added')
       queryClient.invalidateQueries({ queryKey: memberKeys.byProject(projectId) })
       // Also invalidate roles to update member counts
       queryClient.invalidateQueries({ queryKey: ['roles', 'project', projectId] })
@@ -206,7 +206,7 @@ export function useAddMember(projectId: string) {
       queryClient.invalidateQueries({ queryKey: availableUserKeys.byProject(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }

--- a/src/hooks/queries/use-projects.ts
+++ b/src/hooks/queries/use-projects.ts
@@ -2,9 +2,9 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
-import { toast } from 'sonner'
 import { getTabId } from '@/hooks/use-realtime'
 import { getDataProvider, type ProjectSummary as ProviderProjectSummary } from '@/lib/data-provider'
+import { showToast } from '@/lib/toast'
 import { type ProjectSummary, useProjectsStore } from '@/stores/projects-store'
 
 export const projectKeys = {
@@ -119,7 +119,7 @@ export function useCreateProject() {
       if (context?.tempProject) {
         removeProject(context.tempProject.id)
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSuccess: (newProject, _, context) => {
       // Replace temp project with real one
@@ -127,7 +127,7 @@ export function useCreateProject() {
         removeProject(context.tempProject.id)
         addProject(newProject as ProjectSummary)
       }
-      toast.success('Project created')
+      showToast.success('Project created')
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: projectKeys.all })
@@ -171,10 +171,10 @@ export function useUpdateProject() {
       if (context?.previousProjects) {
         queryClient.setQueryData(projectKeys.all, context.previousProjects)
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSuccess: () => {
-      toast.success('Project updated')
+      showToast.success('Project updated')
     },
     onSettled: (_, __, variables) => {
       queryClient.invalidateQueries({ queryKey: projectKeys.all })
@@ -214,10 +214,10 @@ export function useDeleteProject() {
       if (context?.previousProjects) {
         queryClient.setQueryData(projectKeys.all, context.previousProjects)
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSuccess: () => {
-      toast.success('Project deleted')
+      showToast.success('Project deleted')
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: projectKeys.all })

--- a/src/hooks/queries/use-roles.ts
+++ b/src/hooks/queries/use-roles.ts
@@ -1,8 +1,8 @@
 'use client'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import { demoStorage, isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
 import type { Permission, RoleWithPermissions } from '@/types'
 
 // Query keys for roles
@@ -102,11 +102,11 @@ export function useCreateRole(projectId: string) {
       return res.json() as Promise<RoleWithPermissions>
     },
     onSuccess: () => {
-      toast.success('Role created')
+      showToast.success('Role created')
       queryClient.invalidateQueries({ queryKey: roleKeys.byProject(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -141,7 +141,7 @@ export function useUpdateRole(projectId: string) {
       return res.json() as Promise<RoleWithPermissions>
     },
     onSuccess: (_data, variables) => {
-      toast.success('Role updated')
+      showToast.success('Role updated')
       queryClient.invalidateQueries({ queryKey: roleKeys.byProject(projectId) })
       queryClient.invalidateQueries({
         queryKey: roleKeys.single(projectId, variables.roleId),
@@ -150,7 +150,7 @@ export function useUpdateRole(projectId: string) {
       queryClient.invalidateQueries({ queryKey: ['members', 'project', projectId] })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -173,11 +173,11 @@ export function useDeleteRole(projectId: string) {
       return res.json()
     },
     onSuccess: () => {
-      toast.success('Role deleted')
+      showToast.success('Role deleted')
       queryClient.invalidateQueries({ queryKey: roleKeys.byProject(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -208,7 +208,7 @@ export function useReorderRoles(projectId: string) {
       queryClient.setQueryData(roleKeys.byProject(projectId), data)
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
       // Refetch to restore correct order
       queryClient.invalidateQueries({ queryKey: roleKeys.byProject(projectId) })
     },

--- a/src/hooks/queries/use-sprints.ts
+++ b/src/hooks/queries/use-sprints.ts
@@ -1,10 +1,10 @@
 'use client'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import { ticketKeys } from '@/hooks/queries/use-tickets'
 import { getTabId } from '@/hooks/use-realtime'
 import { getDataProvider } from '@/lib/data-provider'
+import { showToast } from '@/lib/toast'
 import type {
   ProjectSprintSettingsData,
   SprintCompletionOptions,
@@ -111,12 +111,12 @@ export function useCreateSprint(projectId: string) {
       }) as Promise<SprintWithMetrics>
     },
     onSuccess: () => {
-      toast.success('Sprint created')
+      showToast.success('Sprint created')
       // Invalidate all sprint-related queries (broader invalidation to ensure UI updates)
       queryClient.invalidateQueries({ queryKey: ['sprints'] })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -150,13 +150,13 @@ export function useUpdateSprint(projectId: string) {
       }) as Promise<SprintWithMetrics>
     },
     onSuccess: (_, { sprintId }) => {
-      toast.success('Sprint updated')
+      showToast.success('Sprint updated')
       queryClient.invalidateQueries({ queryKey: sprintKeys.byProject(projectId) })
       queryClient.invalidateQueries({ queryKey: sprintKeys.detail(projectId, sprintId) })
       queryClient.invalidateQueries({ queryKey: sprintKeys.active(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -174,11 +174,11 @@ export function useDeleteSprint(projectId: string) {
       return { success: true }
     },
     onSuccess: () => {
-      toast.success('Sprint deleted')
+      showToast.success('Sprint deleted')
       queryClient.invalidateQueries({ queryKey: sprintKeys.byProject(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -207,12 +207,12 @@ export function useStartSprint(projectId: string) {
       }) as Promise<SprintWithMetrics>
     },
     onSuccess: () => {
-      toast.success('Sprint started')
+      showToast.success('Sprint started')
       queryClient.invalidateQueries({ queryKey: sprintKeys.byProject(projectId) })
       queryClient.invalidateQueries({ queryKey: sprintKeys.active(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -264,14 +264,14 @@ export function useCompleteSprint(projectId: string) {
         message += ` ${completed} completed.`
       }
 
-      toast.success(message)
+      showToast.success(message)
       queryClient.invalidateQueries({ queryKey: sprintKeys.byProject(projectId) })
       queryClient.invalidateQueries({ queryKey: sprintKeys.active(projectId) })
       // Also invalidate tickets as they may have been moved
       queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -311,12 +311,12 @@ export function useExtendSprint(projectId: string) {
     },
     onSuccess: (result) => {
       const endDateStr = result.endDate ? new Date(result.endDate).toLocaleDateString() : 'unknown'
-      toast.success(`Sprint extended until ${endDateStr}`)
+      showToast.success(`Sprint extended until ${endDateStr}`)
       queryClient.invalidateQueries({ queryKey: sprintKeys.byProject(projectId) })
       queryClient.invalidateQueries({ queryKey: sprintKeys.active(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -364,11 +364,11 @@ export function useUpdateSprintSettings(projectId: string) {
       return provider.updateSprintSettings(projectId, data)
     },
     onSuccess: () => {
-      toast.success('Sprint settings updated')
+      showToast.success('Sprint settings updated')
       queryClient.invalidateQueries({ queryKey: sprintKeys.settings(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }

--- a/src/hooks/queries/use-system-settings.ts
+++ b/src/hooks/queries/use-system-settings.ts
@@ -1,10 +1,10 @@
 'use client'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import { isDemoMode } from '@/lib/demo'
 import type { EmailProviderType, EmailSettings } from '@/lib/email/types'
 import type { RepoHostingProvider, SystemSettings } from '@/lib/system-settings'
+import { showToast } from '@/lib/toast'
 import { brandingKeys } from './use-branding'
 
 // Combined settings type that includes both upload and email settings
@@ -135,7 +135,7 @@ export function useUpdateSystemSettings() {
     mutationFn: async (data: UpdateSystemSettingsParams) => {
       // Demo mode: show info toast and return current settings
       if (isDemoMode()) {
-        toast.info('Settings are read-only in demo mode')
+        showToast.info('Settings are read-only in demo mode')
         return { ...DEMO_SYSTEM_SETTINGS, ...data }
       }
 
@@ -175,11 +175,11 @@ export function useUpdateSystemSettings() {
       if (context?.previousSettings) {
         queryClient.setQueryData(systemSettingsKeys.all, context.previousSettings)
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSuccess: () => {
       if (!isDemoMode()) {
-        toast.success('Settings updated')
+        showToast.success('Settings updated')
       }
     },
     onSettled: () => {
@@ -202,7 +202,7 @@ export function useUploadLogo() {
     mutationFn: async (file: File) => {
       // Demo mode: show info toast
       if (isDemoMode()) {
-        toast.info('Logo upload is disabled in demo mode')
+        showToast.info('Logo upload is disabled in demo mode')
         return { success: false, logoUrl: '' }
       }
 
@@ -232,10 +232,10 @@ export function useUploadLogo() {
           logoUrl: data.logoUrl,
         })
       }
-      toast.success('Logo uploaded')
+      showToast.success('Logo uploaded')
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSettled: () => {
       if (!isDemoMode()) {
@@ -256,7 +256,7 @@ export function useDeleteLogo() {
     mutationFn: async () => {
       // Demo mode: show info toast
       if (isDemoMode()) {
-        toast.info('Logo deletion is disabled in demo mode')
+        showToast.info('Logo deletion is disabled in demo mode')
         return { success: false }
       }
 
@@ -282,10 +282,10 @@ export function useDeleteLogo() {
           logoUrl: null,
         })
       }
-      toast.success('Logo removed')
+      showToast.success('Logo removed')
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSettled: () => {
       if (!isDemoMode()) {
@@ -304,7 +304,7 @@ export function useSendTestEmail() {
     mutationFn: async (email: string) => {
       // Demo mode: show info toast
       if (isDemoMode()) {
-        toast.info('Test email is disabled in demo mode')
+        showToast.info('Test email is disabled in demo mode')
         return { success: false }
       }
 
@@ -323,11 +323,11 @@ export function useSendTestEmail() {
     },
     onSuccess: (data) => {
       if (!isDemoMode() && data.success !== false) {
-        toast.success('Test email sent successfully')
+        showToast.success('Test email sent successfully')
       }
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }

--- a/src/hooks/queries/use-ticket-links.ts
+++ b/src/hooks/queries/use-ticket-links.ts
@@ -1,8 +1,8 @@
 'use client'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import { getTabId } from '@/hooks/use-realtime'
+import { showToast } from '@/lib/toast'
 import type { LinkType, TicketLinkSummary } from '@/types'
 import { ticketKeys } from './use-tickets'
 
@@ -82,10 +82,10 @@ export function useCreateTicketLink() {
         queryKey: ticketLinkKeys.byTicket(projectId, targetTicketId),
       })
       queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
-      toast.success('Link created successfully')
+      showToast.success('Link created')
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -130,10 +130,10 @@ export function useDeleteTicketLink() {
         queryKey: ticketLinkKeys.byTicket(projectId, targetTicketId),
       })
       queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
-      toast.success('Link removed')
+      showToast.success('Link removed')
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }

--- a/src/hooks/queries/use-tickets.ts
+++ b/src/hooks/queries/use-tickets.ts
@@ -2,10 +2,10 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
-import { toast } from 'sonner'
 import { getTabId } from '@/hooks/use-realtime'
 import type { CreateTicketInput, UpdateTicketInput } from '@/lib/data-provider'
 import { getDataProvider } from '@/lib/data-provider'
+import { showToast } from '@/lib/toast'
 import { useBoardStore } from '@/stores/board-store'
 import type { Column, ColumnWithTickets, TicketFormData, TicketWithRelations } from '@/types'
 
@@ -152,7 +152,7 @@ export function useCreateTicket() {
       if (context?.tempTicket) {
         removeTicket(projectId, context.tempTicket.id)
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSuccess: (newTicket, { projectId }, context) => {
       // Replace temp ticket with real one from server
@@ -233,7 +233,7 @@ export function useUpdateTicket() {
       if (context?.previousColumns) {
         useBoardStore.getState().setColumns(projectId, context.previousColumns)
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSettled: (_data, _error, { projectId }) => {
       queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
@@ -275,7 +275,7 @@ export function useDeleteTicket() {
       if (context?.deletedTicket && context?.columnId) {
         addTicket(projectId, context.columnId, context.deletedTicket)
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSettled: (_data, _error, { projectId }) => {
       queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
@@ -316,7 +316,7 @@ export function useMoveTicket() {
       if (previousColumns) {
         useBoardStore.getState().setColumns(projectId, previousColumns)
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSettled: (_data, _error, { projectId }) => {
       queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
@@ -514,7 +514,7 @@ export function useMoveTickets() {
       if (previousColumns) {
         useBoardStore.getState().setColumns(projectId, previousColumns)
       }
-      toast.error(err.message)
+      showToast.error(err.message)
     },
     onSettled: (_data, _error, { projectId }) => {
       queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
@@ -593,7 +593,7 @@ export function useCreateLabel() {
       queryClient.invalidateQueries({ queryKey: labelKeys.byProject(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -623,7 +623,7 @@ export function useDeleteLabel() {
       queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }
@@ -652,7 +652,7 @@ export function useUpdateLabel() {
       queryClient.invalidateQueries({ queryKey: ticketKeys.byProject(projectId) })
     },
     onError: (err) => {
-      toast.error(err.message)
+      showToast.error(err.message)
     },
   })
 }

--- a/src/lib/actions/delete-tickets.ts
+++ b/src/lib/actions/delete-tickets.ts
@@ -3,8 +3,8 @@
  * This module consolidates the delete logic used by context menu and keyboard shortcuts.
  */
 
-import { toast } from 'sonner'
 import { formatTicketId } from '@/lib/ticket-format'
+import { showToast } from '@/lib/toast'
 import { showUndoRedoToast } from '@/lib/undo-toast'
 import { useBoardStore } from '@/stores/board-store'
 import { useSelectionStore } from '@/stores/selection-store'
@@ -68,7 +68,7 @@ export async function deleteTickets(params: DeleteTicketsParams): Promise<Delete
     for (const { ticket, columnId } of tickets) {
       boardStore.addTicket(projectId, columnId, ticket)
     }
-    toast.error('Failed to delete ticket(s)')
+    showToast.error('Failed to delete ticket(s)')
     onComplete?.()
     return { success: false, deletedTickets: [], error: 'API error' }
   }
@@ -127,7 +127,7 @@ export async function deleteTickets(params: DeleteTicketsParams): Promise<Delete
           )
         } catch (err) {
           console.error('Failed to restore deleted tickets via API:', err)
-          toast.error('Failed to restore tickets')
+          showToast.error('Failed to restore tickets')
         }
       }
     },

--- a/src/lib/actions/paste-tickets.ts
+++ b/src/lib/actions/paste-tickets.ts
@@ -3,9 +3,9 @@
  * This module consolidates the paste logic used by context menu and keyboard shortcuts.
  */
 
-import { toast } from 'sonner'
 import { batchCreateTicketsAPI, batchDeleteTicketsAPI } from '@/hooks/queries/use-tickets'
 import { formatTicketId } from '@/lib/ticket-format'
+import { showToast } from '@/lib/toast'
 import { showUndoRedoToast } from '@/lib/undo-toast'
 import { useBoardStore } from '@/stores/board-store'
 import { useSelectionStore } from '@/stores/selection-store'
@@ -166,7 +166,7 @@ export function pasteTickets(params: PasteTicketsParams): PasteResult {
       for (const { ticket } of newTickets) {
         currentBoardState.removeTicket(projectId, ticket.id)
       }
-      toast.error('Failed to paste tickets')
+      showToast.error('Failed to paste tickets')
     }
   })()
 

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,301 @@
+/**
+ * Centralized toast notification system.
+ *
+ * This module provides consistent toast notifications across the app with:
+ * - Standardized durations
+ * - Consistent styling and messaging patterns
+ * - Built-in undo/redo support
+ * - Loading state helpers
+ *
+ * Usage:
+ *   import { showToast } from '@/lib/toast'
+ *
+ *   showToast.success('Project created')
+ *   showToast.error('Failed to delete ticket')
+ *   showToast.info('Settings are read-only in demo mode')
+ *   showToast.warning('This action cannot be undone')
+ *   showToast.withUndo('Ticket deleted', { onUndo: () => restore() })
+ *   showToast.loading('Saving...', async () => saveData())
+ */
+
+import { toast } from 'sonner'
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/**
+ * Standard toast durations in milliseconds.
+ * Keep these consistent across the app.
+ */
+export const TOAST_DURATION = {
+  /** Quick feedback (2s) - for confirmations, minor actions */
+  SHORT: 2000,
+  /** Standard feedback (4s) - default for most notifications */
+  DEFAULT: 4000,
+  /** Extended feedback (5s) - for undo-able actions */
+  WITH_ACTION: 5000,
+  /** Longer visibility (6s) - for important messages users need to read */
+  LONG: 6000,
+} as const
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type ToastId = string | number
+
+interface ToastOptions {
+  /** Optional description below the title */
+  description?: string
+  /** Custom duration in ms (use TOAST_DURATION constants) */
+  duration?: number
+  /** Toast ID for programmatic control */
+  id?: ToastId
+}
+
+interface UndoToastOptions extends Omit<ToastOptions, 'duration'> {
+  /** Called when user clicks Undo */
+  onUndo: () => void | Promise<void>
+  /** Custom undo button label (default: "Undo") */
+  undoLabel?: string
+  /** Duration before toast auto-dismisses (default: WITH_ACTION) */
+  duration?: number
+}
+
+interface LoadingToastOptions {
+  /** Loading message (default: "Loading...") */
+  loadingMessage?: string
+  /** Success message after promise resolves */
+  successMessage?: string | ((data: unknown) => string)
+  /** Error message after promise rejects (default: shows error.message) */
+  errorMessage?: string | ((error: Error) => string)
+  /** Description for loading state */
+  description?: string
+}
+
+// =============================================================================
+// Core Toast Functions
+// =============================================================================
+
+/**
+ * Show a success toast.
+ * Use for completed actions: creation, updates, deletions, etc.
+ */
+function success(message: string, options?: ToastOptions): ToastId {
+  return toast.success(message, {
+    description: options?.description,
+    duration: options?.duration ?? TOAST_DURATION.DEFAULT,
+    id: options?.id,
+  })
+}
+
+/**
+ * Show an error toast.
+ * Use for failed operations, validation errors, etc.
+ */
+function error(message: string, options?: ToastOptions): ToastId {
+  return toast.error(message, {
+    description: options?.description,
+    duration: options?.duration ?? TOAST_DURATION.DEFAULT,
+    id: options?.id,
+  })
+}
+
+/**
+ * Show an info toast.
+ * Use for informational messages, demo mode notices, etc.
+ */
+function info(message: string, options?: ToastOptions): ToastId {
+  return toast.info(message, {
+    description: options?.description,
+    duration: options?.duration ?? TOAST_DURATION.DEFAULT,
+    id: options?.id,
+  })
+}
+
+/**
+ * Show a warning toast.
+ * Use for cautions, partial successes, etc.
+ */
+function warning(message: string, options?: ToastOptions): ToastId {
+  return toast.warning(message, {
+    description: options?.description,
+    duration: options?.duration ?? TOAST_DURATION.DEFAULT,
+    id: options?.id,
+  })
+}
+
+/**
+ * Show a success toast with an Undo button.
+ * Use for reversible actions like delete, move, update.
+ */
+function withUndo(message: string, options: UndoToastOptions): ToastId {
+  return toast.success(message, {
+    description: options.description,
+    duration: options.duration ?? TOAST_DURATION.WITH_ACTION,
+    id: options.id,
+    action: {
+      label: options.undoLabel ?? 'Undo',
+      onClick: () => {
+        void options.onUndo()
+      },
+    },
+  })
+}
+
+/**
+ * Show an error toast with an Undo button (for undo-able failures).
+ * Use when showing deleted/removed state that can be restored.
+ */
+function errorWithUndo(message: string, options: UndoToastOptions): ToastId {
+  return toast.error(message, {
+    description: options.description,
+    duration: options.duration ?? TOAST_DURATION.WITH_ACTION,
+    id: options.id,
+    action: {
+      label: options.undoLabel ?? 'Undo',
+      onClick: () => {
+        void options.onUndo()
+      },
+    },
+  })
+}
+
+/**
+ * Show a loading toast that transitions to success/error.
+ * Use for async operations where you want to show progress.
+ *
+ * @example
+ * showToast.loading(saveProject(), {
+ *   loadingMessage: 'Saving project...',
+ *   successMessage: 'Project saved',
+ *   errorMessage: 'Failed to save project'
+ * })
+ */
+function loading<T>(promise: Promise<T>, options?: LoadingToastOptions): Promise<T> {
+  const loadingMessage = options?.loadingMessage ?? 'Loading...'
+  const successMessage = options?.successMessage ?? 'Done'
+  const errorMessage = options?.errorMessage ?? ((err: Error) => err.message || 'An error occurred')
+
+  toast.promise(promise, {
+    loading: loadingMessage,
+    success: (data) => {
+      if (typeof successMessage === 'function') {
+        return successMessage(data)
+      }
+      return successMessage
+    },
+    error: (err) => {
+      if (typeof errorMessage === 'function') {
+        return errorMessage(err as Error)
+      }
+      return errorMessage
+    },
+    description: options?.description,
+  })
+
+  return promise
+}
+
+/**
+ * Dismiss a toast by ID.
+ */
+function dismiss(toastId?: ToastId): void {
+  toast.dismiss(toastId)
+}
+
+/**
+ * Dismiss all toasts.
+ */
+function dismissAll(): void {
+  toast.dismiss()
+}
+
+// =============================================================================
+// Specialized Toast Helpers
+// =============================================================================
+
+/**
+ * Show a "copied to clipboard" toast.
+ */
+function copied(item?: string): ToastId {
+  const message = item ? `${item} copied to clipboard` : 'Copied to clipboard'
+  return success(message, { duration: TOAST_DURATION.SHORT })
+}
+
+/**
+ * Show a demo mode notice.
+ */
+function demoModeNotice(feature: string): ToastId {
+  return info(`${feature} is disabled in demo mode`, { duration: TOAST_DURATION.DEFAULT })
+}
+
+/**
+ * Show an action with keyboard shortcut hint.
+ */
+function actionWithHint(message: string, hint: string, options?: ToastOptions): ToastId {
+  return success(message, {
+    ...options,
+    description: options?.description ? `${options.description} (${hint})` : hint,
+    duration: options?.duration ?? TOAST_DURATION.DEFAULT,
+  })
+}
+
+// =============================================================================
+// Export
+// =============================================================================
+
+/**
+ * Centralized toast notification system.
+ *
+ * @example
+ * // Basic toasts
+ * showToast.success('Ticket created')
+ * showToast.error('Failed to save')
+ * showToast.info('Demo mode active')
+ * showToast.warning('Large file detected')
+ *
+ * // With undo action
+ * showToast.withUndo('Ticket deleted', {
+ *   description: 'PUNT-42',
+ *   onUndo: () => restoreTicket(id)
+ * })
+ *
+ * // Loading state
+ * showToast.loading(saveProject(), {
+ *   loadingMessage: 'Saving...',
+ *   successMessage: 'Saved!',
+ * })
+ *
+ * // Quick helpers
+ * showToast.copied('API key')
+ * showToast.demoModeNotice('File uploads')
+ */
+export const showToast = {
+  // Core
+  success,
+  error,
+  info,
+  warning,
+
+  // With actions
+  withUndo,
+  errorWithUndo,
+  loading,
+
+  // Control
+  dismiss,
+  dismissAll,
+
+  // Helpers
+  copied,
+  demoModeNotice,
+  actionWithHint,
+
+  // Duration constants for custom use
+  DURATION: TOAST_DURATION,
+} as const
+
+// Re-export the raw toast for edge cases where direct access is needed
+export { toast as rawToast }

--- a/src/lib/undo-toast.ts
+++ b/src/lib/undo-toast.ts
@@ -1,4 +1,4 @@
-import { toast } from 'sonner'
+import { rawToast as toast } from '@/lib/toast'
 
 type ToastKind = 'success' | 'error'
 


### PR DESCRIPTION
## Summary
- Create centralized toast utility (`src/lib/toast.ts`) with standardized durations and unified API
- Replace all direct sonner imports across 36 files with consistent `showToast` patterns
- Add specialized toast methods: `copied`, `demoModeNotice`, `actionWithHint`, `withUndo`, `errorWithUndo`
- Export `rawToast` for complex undo/redo chains that need direct toast access

## Changes
**New file:**
- `src/lib/toast.ts` - Centralized toast notification system

**Toast Duration Constants:**
- `SHORT`: 2000ms (quick confirmations)
- `DEFAULT`: 4000ms (standard notifications)
- `WITH_ACTION`: 5000ms (toasts with undo buttons)
- `LONG`: 6000ms (important messages)

**Updated files (36 total):**
- All hooks/queries files (`use-tickets.ts`, `use-sprints.ts`, etc.)
- Admin components (`user-list.tsx`, `create-user-dialog.tsx`, etc.)
- Board components (`column-menu.tsx`, `ticket-context-menu.tsx`, etc.)
- Profile components (`profile-tab.tsx`, `security-tab.tsx`, etc.)
- Project components (permissions, settings)
- Action modules (`paste-tickets.ts`, `delete-tickets.ts`)

## Test plan
- [x] Lint passes (`pnpm lint`)
- [x] Build passes
- [x] Verify toast notifications work correctly for:
  - Success operations (create, update, delete)
  - Error handling
  - Undo/redo actions
  - Loading states
  - Copy to clipboard
  - Demo mode notices

🤖 Generated with [Claude Code](https://claude.com/claude-code)