### PR TITLE
feat(chat): add embedded Claude Chat panel for conversational ticket management (PUNT-140)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release": "node scripts/release.js"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.74.0",
     "@auth/prisma-adapter": "^2.11.1",
     "@codemirror/commands": "^6.10.2",
     "@codemirror/language-data": "^6.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.74.0
+        version: 0.74.0(zod@4.3.6)
       '@auth/prisma-adapter':
         specifier: ^2.11.1
         version: 2.11.1(@prisma/client@6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3))(nodemailer@7.0.13)
@@ -265,6 +268,15 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.74.0':
+    resolution: {integrity: sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@4.1.1':
     resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
@@ -3579,6 +3591,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -4593,6 +4609,9 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4909,6 +4928,12 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.74.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@asamuzakjp/css-color@4.1.1':
     dependencies:
@@ -8383,6 +8408,11 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -9687,6 +9717,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,9 @@ model User {
   // MCP API access
   mcpApiKey String? @unique // API key for MCP authentication
 
+  // Claude Chat API access
+  anthropicApiKey String? // User's own Anthropic API key for embedded chat
+
   // Ticket relations
   assignedTickets  Ticket[]        @relation("Assignee")
   createdTickets   Ticket[]        @relation("Creator")

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { ChatFAB, ChatPanel } from '@/components/chat'
 import { EmailVerificationBanner } from '@/components/common/email-verification-banner'
 import { Dialogs } from '@/components/dialogs'
 import { KeyboardShortcuts } from '@/components/keyboard-shortcuts'
@@ -20,6 +21,8 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       <MobileNotice />
       <Dialogs />
       <KeyboardShortcuts />
+      <ChatPanel />
+      <ChatFAB />
     </div>
   )
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,197 @@
+/**
+ * POST /api/chat - Streaming chat endpoint with Claude
+ * Proxies requests to Anthropic API using user's API key
+ */
+
+import Anthropic from '@anthropic-ai/sdk'
+import { z } from 'zod/v4'
+import { requireAuth } from '@/lib/auth-helpers'
+import { buildSystemPrompt } from '@/lib/chat/context'
+import { executeTool } from '@/lib/chat/executor'
+import { type ChatToolName, chatTools } from '@/lib/chat/tools'
+import { db } from '@/lib/db'
+
+const chatRequestSchema = z.object({
+  messages: z.array(
+    z.object({
+      role: z.enum(['user', 'assistant']),
+      content: z.string(),
+    }),
+  ),
+  context: z
+    .object({
+      projectId: z.string().optional(),
+      ticketKey: z.string().optional(),
+    })
+    .optional(),
+})
+
+export async function POST(request: Request) {
+  try {
+    const currentUser = await requireAuth()
+
+    // Get user's Anthropic API key
+    const user = await db.user.findUnique({
+      where: { id: currentUser.id },
+      select: { anthropicApiKey: true },
+    })
+
+    if (!user?.anthropicApiKey) {
+      return new Response(
+        JSON.stringify({
+          error: 'No Anthropic API key configured. Add your key in Profile > Integrations.',
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    const body = await request.json()
+    const result = chatRequestSchema.safeParse(body)
+
+    if (!result.success) {
+      return new Response(JSON.stringify({ error: 'Invalid request format' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const { messages, context } = result.data
+
+    // Build system prompt with context
+    const systemPrompt = await buildSystemPrompt(context ?? {})
+
+    // Initialize Anthropic client with user's API key
+    const anthropic = new Anthropic({
+      apiKey: user.anthropicApiKey,
+    })
+
+    // Create a readable stream for the response
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream({
+      async start(controller) {
+        try {
+          // Convert messages to Anthropic format
+          // Use Anthropic.Messages.MessageParam type to allow both text and tool results
+          let currentMessages: Anthropic.Messages.MessageParam[] = messages.map((m) => ({
+            role: m.role as 'user' | 'assistant',
+            content: m.content,
+          }))
+
+          // Run conversation loop (handles tool calls)
+          let continueLoop = true
+
+          while (continueLoop) {
+            const response = await anthropic.messages.create({
+              model: 'claude-sonnet-4-20250514',
+              max_tokens: 4096,
+              system: systemPrompt,
+              tools: chatTools,
+              messages: currentMessages,
+            })
+
+            // Process response content
+            let hasToolUse = false
+            const toolResults: Array<{
+              type: 'tool_result'
+              tool_use_id: string
+              content: string
+            }> = []
+
+            for (const block of response.content) {
+              if (block.type === 'text') {
+                // Stream text to client
+                const data = JSON.stringify({ type: 'text', content: block.text })
+                controller.enqueue(encoder.encode(`data: ${data}\n\n`))
+              } else if (block.type === 'tool_use') {
+                hasToolUse = true
+
+                // Notify client about tool execution
+                const toolStart = JSON.stringify({
+                  type: 'tool_start',
+                  name: block.name,
+                  input: block.input,
+                })
+                controller.enqueue(encoder.encode(`data: ${toolStart}\n\n`))
+
+                // Execute the tool
+                const toolResult = await executeTool(
+                  block.name as ChatToolName,
+                  block.input as Record<string, unknown>,
+                  currentUser.id,
+                )
+
+                // Notify client about tool result
+                const toolEnd = JSON.stringify({
+                  type: 'tool_end',
+                  name: block.name,
+                  result: toolResult.result,
+                  success: toolResult.success,
+                })
+                controller.enqueue(encoder.encode(`data: ${toolEnd}\n\n`))
+
+                toolResults.push({
+                  type: 'tool_result',
+                  tool_use_id: block.id,
+                  content: toolResult.result,
+                })
+              }
+            }
+
+            // If there were tool calls, continue the conversation
+            if (hasToolUse && response.stop_reason === 'tool_use') {
+              // Add assistant response and tool results to messages
+              currentMessages = [
+                ...currentMessages,
+                { role: 'assistant' as const, content: response.content },
+                { role: 'user' as const, content: toolResults },
+              ]
+            } else {
+              continueLoop = false
+            }
+          }
+
+          // Send done signal
+          controller.enqueue(encoder.encode('data: {"type":"done"}\n\n'))
+          controller.close()
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'An error occurred'
+
+          // Check for specific Anthropic errors
+          let userMessage = errorMessage
+          if (errorMessage.includes('Invalid API Key')) {
+            userMessage =
+              'Invalid Anthropic API key. Please check your key in Profile > Integrations.'
+          } else if (errorMessage.includes('rate_limit')) {
+            userMessage = 'Rate limit exceeded. Please wait a moment and try again.'
+          }
+
+          const errorData = JSON.stringify({ type: 'error', error: userMessage })
+          controller.enqueue(encoder.encode(`data: ${errorData}\n\n`))
+          controller.close()
+        }
+      },
+    })
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    })
+  } catch (error) {
+    // Handle auth errors
+    if (error instanceof Error && error.message === 'Not authenticated') {
+      return new Response(JSON.stringify({ error: 'Not authenticated' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/src/app/api/me/anthropic-key/route.ts
+++ b/src/app/api/me/anthropic-key/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod/v4'
+import { badRequestError, handleApiError, validationError } from '@/lib/api-utils'
+import { requireAuth } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+
+const storeKeySchema = z.object({
+  apiKey: z
+    .string()
+    .min(1, 'API key is required')
+    .regex(/^sk-ant-/, 'Invalid Anthropic API key format (should start with sk-ant-)'),
+})
+
+/**
+ * GET /api/me/anthropic-key - Get Anthropic API key status
+ * Returns whether user has a key and a hint (last 4 chars) for identification
+ */
+export async function GET() {
+  try {
+    const currentUser = await requireAuth()
+
+    const user = await db.user.findUnique({
+      where: { id: currentUser.id },
+      select: { anthropicApiKey: true },
+    })
+
+    return NextResponse.json({
+      hasKey: !!user?.anthropicApiKey,
+      keyHint: user?.anthropicApiKey ? user.anthropicApiKey.slice(-4) : null,
+    })
+  } catch (error) {
+    return handleApiError(error, 'get Anthropic key status')
+  }
+}
+
+/**
+ * POST /api/me/anthropic-key - Store user's Anthropic API key
+ * User provides their own key (not generated)
+ */
+export async function POST(request: Request) {
+  try {
+    const currentUser = await requireAuth()
+    const body = await request.json()
+
+    const result = storeKeySchema.safeParse(body)
+    if (!result.success) {
+      return validationError(result)
+    }
+
+    const { apiKey } = result.data
+
+    // Validate the key format more thoroughly
+    if (!apiKey.startsWith('sk-ant-')) {
+      return badRequestError('Invalid Anthropic API key format')
+    }
+
+    await db.user.update({
+      where: { id: currentUser.id },
+      data: { anthropicApiKey: apiKey },
+    })
+
+    return NextResponse.json({
+      success: true,
+      message: 'Anthropic API key saved',
+      keyHint: apiKey.slice(-4),
+    })
+  } catch (error) {
+    return handleApiError(error, 'store Anthropic key')
+  }
+}
+
+/**
+ * DELETE /api/me/anthropic-key - Remove Anthropic API key
+ */
+export async function DELETE() {
+  try {
+    const currentUser = await requireAuth()
+
+    await db.user.update({
+      where: { id: currentUser.id },
+      data: { anthropicApiKey: null },
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return handleApiError(error, 'remove Anthropic key')
+  }
+}

--- a/src/components/chat/chat-fab.tsx
+++ b/src/components/chat/chat-fab.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { MessageSquareIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useUIStore } from '@/stores/ui-store'
+
+export function ChatFAB() {
+  const { chatPanelOpen, toggleChatPanel } = useUIStore()
+
+  return (
+    <button
+      type="button"
+      onClick={toggleChatPanel}
+      className={cn(
+        'fixed bottom-6 right-6 z-40 flex h-14 w-14 items-center justify-center',
+        'rounded-full bg-purple-600 shadow-lg transition-all',
+        'hover:bg-purple-700 hover:scale-105',
+        'focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-zinc-900',
+        chatPanelOpen && 'opacity-0 pointer-events-none',
+      )}
+      aria-label="Open Claude Chat"
+    >
+      <MessageSquareIcon className="h-6 w-6 text-white" />
+    </button>
+  )
+}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { SendIcon } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface ChatInputProps {
+  onSend: (message: string) => void
+  disabled?: boolean
+  placeholder?: string
+}
+
+export function ChatInput({
+  onSend,
+  disabled,
+  placeholder = 'Ask me about your tickets...',
+}: ChatInputProps) {
+  const [value, setValue] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Auto-resize textarea when value changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we need to resize when value changes
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = 'auto'
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`
+    }
+  }, [value])
+
+  const handleSubmit = () => {
+    const trimmed = value.trim()
+    if (trimmed && !disabled) {
+      onSend(trimmed)
+      setValue('')
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  return (
+    <div className="flex items-end gap-2 border-t border-zinc-800 bg-zinc-900 p-4">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={1}
+        className={cn(
+          'flex-1 resize-none rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm',
+          'text-zinc-100 placeholder:text-zinc-500',
+          'focus:border-purple-500 focus:outline-none focus:ring-1 focus:ring-purple-500',
+          'disabled:opacity-50 disabled:cursor-not-allowed',
+        )}
+      />
+      <Button
+        onClick={handleSubmit}
+        disabled={disabled || !value.trim()}
+        size="icon"
+        className="shrink-0 bg-purple-600 hover:bg-purple-700 disabled:opacity-50"
+      >
+        <SendIcon className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { BotIcon, CheckCircleIcon, UserIcon, WrenchIcon, XCircleIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface ChatMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  toolCalls?: ToolCall[]
+}
+
+export interface ToolCall {
+  name: string
+  input: Record<string, unknown>
+  result?: string
+  success?: boolean
+  status: 'pending' | 'running' | 'completed'
+}
+
+interface ChatMessageProps {
+  message: ChatMessage
+}
+
+export function ChatMessageComponent({ message }: ChatMessageProps) {
+  const isUser = message.role === 'user'
+
+  return (
+    <div className={cn('flex gap-3', isUser ? 'flex-row-reverse' : 'flex-row')}>
+      {/* Avatar */}
+      <div
+        className={cn(
+          'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+          isUser ? 'bg-blue-600' : 'bg-purple-600',
+        )}
+      >
+        {isUser ? (
+          <UserIcon className="h-4 w-4 text-white" />
+        ) : (
+          <BotIcon className="h-4 w-4 text-white" />
+        )}
+      </div>
+
+      {/* Message content */}
+      <div
+        className={cn(
+          'flex max-w-[80%] flex-col gap-2 rounded-lg px-4 py-2',
+          isUser ? 'bg-blue-600 text-white' : 'bg-zinc-800 text-zinc-100',
+        )}
+      >
+        {/* Tool calls */}
+        {message.toolCalls && message.toolCalls.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            {message.toolCalls.map((tool, index) => (
+              <ToolCallBadge key={index} tool={tool} />
+            ))}
+          </div>
+        )}
+
+        {/* Text content */}
+        {message.content && <div className="whitespace-pre-wrap text-sm">{message.content}</div>}
+      </div>
+    </div>
+  )
+}
+
+function ToolCallBadge({ tool }: { tool: ToolCall }) {
+  return (
+    <div className="flex items-center gap-2 rounded-md bg-zinc-900/50 px-2 py-1.5 text-xs">
+      <WrenchIcon className="h-3 w-3 text-zinc-400" />
+      <span className="font-medium text-zinc-300">{formatToolName(tool.name)}</span>
+      {tool.status === 'running' && (
+        <span className="ml-auto animate-pulse text-yellow-400">Running...</span>
+      )}
+      {tool.status === 'completed' &&
+        (tool.success ? (
+          <CheckCircleIcon className="ml-auto h-3 w-3 text-green-400" />
+        ) : (
+          <XCircleIcon className="ml-auto h-3 w-3 text-red-400" />
+        ))}
+    </div>
+  )
+}
+
+function formatToolName(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -1,0 +1,288 @@
+'use client'
+
+import { BotIcon, KeyIcon, Loader2Icon } from 'lucide-react'
+import Link from 'next/link'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { useUIStore } from '@/stores/ui-store'
+import { ChatInput } from './chat-input'
+import { type ChatMessage, ChatMessageComponent } from './chat-message'
+
+interface StreamEvent {
+  type: 'text' | 'tool_start' | 'tool_end' | 'done' | 'error'
+  content?: string
+  name?: string
+  input?: Record<string, unknown>
+  result?: string
+  success?: boolean
+  error?: string
+}
+
+export function ChatPanel() {
+  const { chatPanelOpen, setChatPanelOpen, chatContext } = useUIStore()
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasApiKey, setHasApiKey] = useState<boolean | null>(null)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  // Check if user has API key
+  useEffect(() => {
+    if (chatPanelOpen && hasApiKey === null) {
+      fetch('/api/me/anthropic-key')
+        .then((res) => res.json())
+        .then((data) => setHasApiKey(data.hasKey))
+        .catch(() => setHasApiKey(false))
+    }
+  }, [chatPanelOpen, hasApiKey])
+
+  // Scroll to bottom on new messages
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we need to scroll when messages change
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const handleStreamEvent = useCallback((messageId: string, event: StreamEvent) => {
+    setMessages((prev) =>
+      prev.map((m) => {
+        if (m.id !== messageId) return m
+
+        switch (event.type) {
+          case 'text':
+            return { ...m, content: m.content + (event.content || '') }
+
+          case 'tool_start':
+            return {
+              ...m,
+              toolCalls: [
+                ...(m.toolCalls || []),
+                {
+                  name: event.name || 'unknown',
+                  input: event.input || {},
+                  status: 'running' as const,
+                },
+              ],
+            }
+
+          case 'tool_end':
+            return {
+              ...m,
+              toolCalls: m.toolCalls?.map((t) =>
+                t.name === event.name && t.status === 'running'
+                  ? {
+                      ...t,
+                      status: 'completed' as const,
+                      result: event.result,
+                      success: event.success,
+                    }
+                  : t,
+              ),
+            }
+
+          case 'error':
+            return { ...m, content: `${m.content}\n\nError: ${event.error}` }
+
+          default:
+            return m
+        }
+      }),
+    )
+  }, [])
+
+  const sendMessage = useCallback(
+    async (content: string) => {
+      if (!content.trim() || isLoading) return
+
+      // Add user message
+      const userMessage: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: 'user',
+        content,
+      }
+      setMessages((prev) => [...prev, userMessage])
+      setIsLoading(true)
+
+      // Create assistant message placeholder
+      const assistantId = crypto.randomUUID()
+      const assistantMessage: ChatMessage = {
+        id: assistantId,
+        role: 'assistant',
+        content: '',
+        toolCalls: [],
+      }
+      setMessages((prev) => [...prev, assistantMessage])
+
+      try {
+        // Build message history for API
+        const apiMessages = [...messages, userMessage].map((m) => ({
+          role: m.role,
+          content: m.content,
+        }))
+
+        const response = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            messages: apiMessages,
+            context: chatContext,
+          }),
+        })
+
+        if (!response.ok) {
+          const data = await response.json()
+          throw new Error(data.error || 'Failed to send message')
+        }
+
+        if (!response.body) {
+          throw new Error('No response body')
+        }
+
+        // Process SSE stream
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split('\n')
+          buffer = lines.pop() || ''
+
+          for (const line of lines) {
+            if (line.startsWith('data: ')) {
+              const data = line.slice(6)
+              try {
+                const event: StreamEvent = JSON.parse(data)
+                handleStreamEvent(assistantId, event)
+              } catch {
+                // Ignore parse errors
+              }
+            }
+          }
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'An error occurred'
+        setMessages((prev) =>
+          prev.map((m) => (m.id === assistantId ? { ...m, content: `Error: ${errorMessage}` } : m)),
+        )
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [messages, chatContext, isLoading, handleStreamEvent],
+  )
+
+  const clearChat = () => {
+    setMessages([])
+  }
+
+  return (
+    <Sheet open={chatPanelOpen} onOpenChange={setChatPanelOpen}>
+      <SheetContent side="right" className="flex w-full flex-col p-0 sm:max-w-md">
+        <SheetHeader className="border-b border-zinc-800 px-4 py-3">
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-purple-600">
+              <BotIcon className="h-4 w-4 text-white" />
+            </div>
+            <div className="flex-1">
+              <SheetTitle className="text-base">Claude Chat</SheetTitle>
+              <SheetDescription className="text-xs">
+                Manage tickets with natural language
+              </SheetDescription>
+            </div>
+            {messages.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={clearChat}
+                className="text-xs text-zinc-400 hover:text-zinc-100"
+              >
+                Clear
+              </Button>
+            )}
+          </div>
+        </SheetHeader>
+
+        {/* Messages area */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {hasApiKey === false ? (
+            <NoApiKeyMessage />
+          ) : messages.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <div className="flex flex-col gap-4">
+              {messages.map((message) => (
+                <ChatMessageComponent key={message.id} message={message} />
+              ))}
+              {isLoading && messages[messages.length - 1]?.content === '' && (
+                <div className="flex items-center gap-2 text-sm text-zinc-400">
+                  <Loader2Icon className="h-4 w-4 animate-spin" />
+                  Thinking...
+                </div>
+              )}
+              <div ref={messagesEndRef} />
+            </div>
+          )}
+        </div>
+
+        {/* Input area */}
+        {hasApiKey !== false && (
+          <ChatInput onSend={sendMessage} disabled={isLoading || hasApiKey === null} />
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function NoApiKeyMessage() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-yellow-500/20">
+        <KeyIcon className="h-6 w-6 text-yellow-400" />
+      </div>
+      <div>
+        <p className="font-medium text-zinc-100">API Key Required</p>
+        <p className="mt-1 text-sm text-zinc-400">Add your Anthropic API key to use Claude Chat</p>
+      </div>
+      <Button asChild className="bg-purple-600 hover:bg-purple-700">
+        <Link href="/profile">Go to Settings</Link>
+      </Button>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-purple-600/20">
+        <BotIcon className="h-6 w-6 text-purple-400" />
+      </div>
+      <div>
+        <p className="font-medium text-zinc-100">How can I help?</p>
+        <p className="mt-1 text-sm text-zinc-400">
+          Ask me to list tickets, create issues, or check on sprints
+        </p>
+      </div>
+      <div className="flex flex-wrap justify-center gap-2 text-xs">
+        {[
+          'List my open tickets',
+          'Create a bug for login issue',
+          'Show sprint status',
+          'What tickets are high priority?',
+        ].map((suggestion) => (
+          <span key={suggestion} className="rounded-full bg-zinc-800 px-3 py-1.5 text-zinc-300">
+            {suggestion}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/index.ts
+++ b/src/components/chat/index.ts
@@ -1,0 +1,4 @@
+export { ChatFAB } from './chat-fab'
+export { ChatInput } from './chat-input'
+export { type ChatMessage, ChatMessageComponent, type ToolCall } from './chat-message'
+export { ChatPanel } from './chat-panel'

--- a/src/components/keyboard-shortcuts.tsx
+++ b/src/components/keyboard-shortcuts.tsx
@@ -699,6 +699,13 @@ export function KeyboardShortcuts() {
         return
       }
 
+      // Ctrl/Cmd + I: Toggle Claude Chat panel
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'i' || e.key === 'I')) {
+        e.preventDefault()
+        useUIStore.getState().toggleChatPanel()
+        return
+      }
+
       // Check for Ctrl/Cmd + Z (Undo) - must check before redo to avoid conflicts
       if ((e.ctrlKey || e.metaKey) && (e.key === 'z' || e.key === 'Z') && !e.shiftKey) {
         e.preventDefault()
@@ -2777,6 +2784,12 @@ export function KeyboardShortcuts() {
                   <span>Paste copied tickets</span>
                   <kbd className="px-2 py-1 text-xs font-semibold text-zinc-300 bg-zinc-800 border border-zinc-700 rounded">
                     Ctrl / Cmd + V
+                  </kbd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Open Claude Chat</span>
+                  <kbd className="px-2 py-1 text-xs font-semibold text-zinc-300 bg-zinc-800 border border-zinc-700 rounded">
+                    Ctrl / Cmd + I
                   </kbd>
                 </div>
                 <div className="flex items-center justify-between">

--- a/src/components/profile/integrations-tab.tsx
+++ b/src/components/profile/integrations-tab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Check, Copy, Eye, EyeOff, KeyRound, Terminal, Trash2 } from 'lucide-react'
+import { Bot, Check, Copy, Eye, EyeOff, KeyRound, Terminal, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -32,6 +32,14 @@ export function IntegrationsTab({ isDemo }: IntegrationsTabProps) {
   const [mcpKeyCopied, setMcpKeyCopied] = useState(false)
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Anthropic API key state
+  const [anthropicKeyLoading, setAnthropicKeyLoading] = useState(false)
+  const [anthropicHasKey, setAnthropicHasKey] = useState(false)
+  const [anthropicKeyHint, setAnthropicKeyHint] = useState<string | null>(null)
+  const [anthropicKeyInput, setAnthropicKeyInput] = useState('')
+  const [anthropicKeyVisible, setAnthropicKeyVisible] = useState(false)
+  const [anthropicKeyFetched, setAnthropicKeyFetched] = useState(false)
+
   useEffect(() => {
     return () => {
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current)
@@ -55,6 +63,24 @@ export function IntegrationsTab({ isDemo }: IntegrationsTabProps) {
     }
     fetchMcpKeyStatus()
   }, [isDemo, mcpKeyFetched])
+
+  useEffect(() => {
+    if (isDemo || anthropicKeyFetched) return
+    const fetchAnthropicKeyStatus = async () => {
+      try {
+        const res = await fetch('/api/me/anthropic-key')
+        if (res.ok) {
+          const data = await res.json()
+          setAnthropicHasKey(data.hasKey)
+          setAnthropicKeyHint(data.keyHint)
+          setAnthropicKeyFetched(true)
+        }
+      } catch {
+        // Silently fail
+      }
+    }
+    fetchAnthropicKeyStatus()
+  }, [isDemo, anthropicKeyFetched])
 
   const handleGenerateMcpKey = async () => {
     setMcpKeyLoading(true)
@@ -105,6 +131,52 @@ export function IntegrationsTab({ isDemo }: IntegrationsTabProps) {
     }
   }, [mcpNewKey])
 
+  const handleSaveAnthropicKey = async () => {
+    if (!anthropicKeyInput.trim()) {
+      toast.error('Please enter an API key')
+      return
+    }
+    if (!anthropicKeyInput.startsWith('sk-ant-')) {
+      toast.error('Invalid key format (should start with sk-ant-)')
+      return
+    }
+    setAnthropicKeyLoading(true)
+    try {
+      const res = await fetch('/api/me/anthropic-key', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey: anthropicKeyInput }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to save API key')
+      setAnthropicHasKey(true)
+      setAnthropicKeyHint(data.keyHint)
+      setAnthropicKeyInput('')
+      setAnthropicKeyVisible(false)
+      toast.success('Anthropic API key saved')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save API key')
+    } finally {
+      setAnthropicKeyLoading(false)
+    }
+  }
+
+  const handleRemoveAnthropicKey = async () => {
+    setAnthropicKeyLoading(true)
+    try {
+      const res = await fetch('/api/me/anthropic-key', { method: 'DELETE' })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to remove API key')
+      setAnthropicHasKey(false)
+      setAnthropicKeyHint(null)
+      toast.success('Anthropic API key removed')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to remove API key')
+    } finally {
+      setAnthropicKeyLoading(false)
+    }
+  }
+
   if (isDemo) {
     return (
       <div className="space-y-6">
@@ -123,6 +195,27 @@ export function IntegrationsTab({ isDemo }: IntegrationsTabProps) {
               <Terminal className="h-12 w-12 mx-auto mb-3 text-zinc-600" />
               <p className="text-sm">
                 MCP API keys are only available when running the full PUNT application.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-zinc-800 bg-zinc-900/50">
+          <CardHeader className="pb-4">
+            <div className="flex items-center gap-2">
+              <Bot className="h-5 w-5 text-violet-500" />
+              <CardTitle className="text-zinc-100">Claude Chat</CardTitle>
+            </div>
+            <CardDescription className="text-zinc-500">
+              AI chat is not available in demo mode
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="px-4 py-6 text-center text-zinc-500 bg-zinc-800/30 rounded-lg border border-zinc-700/50">
+              <Bot className="h-12 w-12 mx-auto mb-3 text-zinc-600" />
+              <p className="text-sm">
+                Claude Chat requires an Anthropic API key and is only available when running the
+                full PUNT application.
               </p>
             </div>
           </CardContent>
@@ -280,6 +373,120 @@ export function IntegrationsTab({ isDemo }: IntegrationsTabProps) {
             <p>
               Add the key to your <code className="text-amber-400">.mcp.json</code> file in the
               project root.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-zinc-800 bg-zinc-900/50">
+        <CardHeader className="pb-4">
+          <div className="flex items-center gap-2">
+            <Bot className="h-5 w-5 text-violet-500" />
+            <CardTitle className="text-zinc-100">Claude Chat</CardTitle>
+          </div>
+          <CardDescription className="text-zinc-500">
+            Add your Anthropic API key to enable the embedded Claude chat for conversational ticket
+            management
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {anthropicHasKey ? (
+            <>
+              <div className="flex items-center gap-3 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg">
+                <KeyRound className="h-4 w-4 text-emerald-500 shrink-0" />
+                <p className="text-sm text-zinc-300">
+                  Active key ending in{' '}
+                  <code className="text-violet-400 font-mono">...{anthropicKeyHint}</code>
+                </p>
+              </div>
+
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-zinc-400 hover:text-red-400"
+                    disabled={anthropicKeyLoading}
+                  >
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    Remove Key
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent className="bg-zinc-900 border-zinc-800">
+                  <AlertDialogHeader>
+                    <AlertDialogTitle className="text-zinc-100">
+                      Remove Anthropic API Key?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription className="text-zinc-400">
+                      This will disable Claude Chat until you add a new key.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel className="border-zinc-700 text-zinc-300 hover:bg-zinc-800">
+                      Cancel
+                    </AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={handleRemoveAnthropicKey}
+                      className="bg-red-600 hover:bg-red-700 text-white"
+                    >
+                      Remove Key
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </>
+          ) : (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <div className="flex-1 relative">
+                  <Input
+                    type={anthropicKeyVisible ? 'text' : 'password'}
+                    value={anthropicKeyInput}
+                    onChange={(e) => setAnthropicKeyInput(e.target.value)}
+                    placeholder="sk-ant-..."
+                    className="bg-zinc-900 border-zinc-700 font-mono text-sm pr-10"
+                  />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7 p-0 text-zinc-400 hover:text-zinc-200"
+                    onClick={() => setAnthropicKeyVisible(!anthropicKeyVisible)}
+                  >
+                    {anthropicKeyVisible ? (
+                      <EyeOff className="h-3.5 w-3.5" />
+                    ) : (
+                      <Eye className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                </div>
+                <Button
+                  onClick={handleSaveAnthropicKey}
+                  disabled={anthropicKeyLoading || !anthropicKeyInput.trim()}
+                  className="bg-violet-600 hover:bg-violet-700 text-white"
+                >
+                  Save Key
+                </Button>
+              </div>
+              <p className="text-xs text-zinc-500">
+                Get your API key from{' '}
+                <a
+                  href="https://console.anthropic.com/settings/keys"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-violet-400 hover:underline"
+                >
+                  console.anthropic.com
+                </a>
+              </p>
+            </div>
+          )}
+
+          <div className="bg-zinc-800/50 rounded-lg p-3 text-xs text-zinc-400 space-y-2">
+            <p className="font-medium text-zinc-300">About Claude Chat</p>
+            <p>
+              Open the chat panel with{' '}
+              <kbd className="px-1.5 py-0.5 bg-zinc-700 rounded text-zinc-300">Cmd+I</kbd> or the
+              floating button. Claude can create tickets, manage sprints, and more.
             </p>
           </div>
         </CardContent>

--- a/src/lib/chat/context.ts
+++ b/src/lib/chat/context.ts
@@ -1,0 +1,186 @@
+/**
+ * Context building utilities for Claude Chat
+ * Builds system prompts with relevant project/ticket context
+ */
+
+import { db } from '@/lib/db'
+
+interface ChatContext {
+  projectId?: string
+  ticketKey?: string
+}
+
+interface ProjectContext {
+  key: string
+  name: string
+  description: string | null
+  columns: string[]
+  labels: string[]
+  activeSprint: string | null
+  memberCount: number
+  ticketCount: number
+}
+
+interface TicketContext {
+  key: string
+  title: string
+  description: string | null
+  type: string
+  priority: string
+  status: string
+  assignee: string | null
+  sprint: string | null
+  storyPoints: number | null
+  labels: string[]
+}
+
+/**
+ * Build system prompt with context about the current project/ticket
+ */
+export async function buildSystemPrompt(context: ChatContext): Promise<string> {
+  const parts: string[] = []
+
+  // Base system prompt
+  parts.push(`You are a helpful assistant integrated into PUNT, a project management and issue tracking system.
+You can help users manage their tickets, sprints, and projects through natural conversation.
+
+When users ask you to do something, use the available tools to accomplish it. Be concise but helpful.
+
+Key capabilities:
+- List, create, and update tickets
+- View project details and sprints
+- Search for tickets by various criteria
+- Help with sprint planning and ticket organization`)
+
+  // Add project context if available
+  if (context.projectId) {
+    const projectCtx = await getProjectContext(context.projectId)
+    if (projectCtx) {
+      parts.push('')
+      parts.push('## Current Project Context')
+      parts.push(`You are viewing project **${projectCtx.key}** (${projectCtx.name}).`)
+      if (projectCtx.description) {
+        parts.push(`Description: ${projectCtx.description}`)
+      }
+      parts.push(`Columns: ${projectCtx.columns.join(', ')}`)
+      if (projectCtx.labels.length > 0) {
+        parts.push(`Labels: ${projectCtx.labels.join(', ')}`)
+      }
+      if (projectCtx.activeSprint) {
+        parts.push(`Active sprint: ${projectCtx.activeSprint}`)
+      }
+      parts.push(`${projectCtx.ticketCount} tickets, ${projectCtx.memberCount} members`)
+    }
+  }
+
+  // Add ticket context if available
+  if (context.ticketKey) {
+    const ticketCtx = await getTicketContext(context.ticketKey)
+    if (ticketCtx) {
+      parts.push('')
+      parts.push('## Current Ticket Context')
+      parts.push(`User is viewing ticket **${ticketCtx.key}**: ${ticketCtx.title}`)
+      parts.push(
+        `Type: ${ticketCtx.type}, Priority: ${ticketCtx.priority}, Status: ${ticketCtx.status}`,
+      )
+      if (ticketCtx.assignee) parts.push(`Assignee: ${ticketCtx.assignee}`)
+      if (ticketCtx.sprint) parts.push(`Sprint: ${ticketCtx.sprint}`)
+      if (ticketCtx.storyPoints !== null) parts.push(`Story points: ${ticketCtx.storyPoints}`)
+      if (ticketCtx.labels.length > 0) parts.push(`Labels: ${ticketCtx.labels.join(', ')}`)
+      if (ticketCtx.description) {
+        parts.push(
+          `Description: ${ticketCtx.description.slice(0, 500)}${ticketCtx.description.length > 500 ? '...' : ''}`,
+        )
+      }
+    }
+  }
+
+  return parts.join('\n')
+}
+
+async function getProjectContext(projectId: string): Promise<ProjectContext | null> {
+  try {
+    const project = await db.project.findUnique({
+      where: { id: projectId },
+      include: {
+        columns: {
+          orderBy: { order: 'asc' },
+          select: { name: true },
+        },
+        labels: {
+          select: { name: true },
+        },
+        sprints: {
+          where: { status: 'active' },
+          select: { name: true },
+          take: 1,
+        },
+        _count: {
+          select: {
+            tickets: true,
+            members: true,
+          },
+        },
+      },
+    })
+
+    if (!project) return null
+
+    return {
+      key: project.key,
+      name: project.name,
+      description: project.description,
+      columns: project.columns.map((c) => c.name),
+      labels: project.labels.map((l) => l.name),
+      activeSprint: project.sprints[0]?.name ?? null,
+      memberCount: project._count.members,
+      ticketCount: project._count.tickets,
+    }
+  } catch {
+    return null
+  }
+}
+
+async function getTicketContext(ticketKey: string): Promise<TicketContext | null> {
+  try {
+    // Parse ticket key (e.g., "PUNT-123")
+    const match = ticketKey.match(/^([A-Z]+)-(\d+)$/i)
+    if (!match) return null
+
+    const [, projectKey, numberStr] = match
+    const number = parseInt(numberStr, 10)
+
+    const ticket = await db.ticket.findFirst({
+      where: {
+        number,
+        project: {
+          key: projectKey.toUpperCase(),
+        },
+      },
+      include: {
+        project: { select: { key: true } },
+        column: { select: { name: true } },
+        assignee: { select: { name: true } },
+        sprint: { select: { name: true } },
+        labels: { select: { name: true } },
+      },
+    })
+
+    if (!ticket) return null
+
+    return {
+      key: `${ticket.project.key}-${ticket.number}`,
+      title: ticket.title,
+      description: ticket.description,
+      type: ticket.type,
+      priority: ticket.priority,
+      status: ticket.column.name,
+      assignee: ticket.assignee?.name ?? null,
+      sprint: ticket.sprint?.name ?? null,
+      storyPoints: ticket.storyPoints,
+      labels: ticket.labels.map((l) => l.name),
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/chat/executor.ts
+++ b/src/lib/chat/executor.ts
@@ -1,0 +1,566 @@
+/**
+ * Tool executor for Claude Chat
+ * Executes tool calls against PUNT's internal API
+ */
+
+import { db } from '@/lib/db'
+import type { ChatToolName } from './tools'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ToolInput = Record<string, any>
+
+interface ToolResult {
+  success: boolean
+  result: string
+}
+
+/**
+ * Execute a tool call and return the result
+ */
+export async function executeTool(
+  toolName: ChatToolName,
+  input: ToolInput,
+  userId: string,
+): Promise<ToolResult> {
+  try {
+    switch (toolName) {
+      case 'list_tickets':
+        return await listTickets(input, userId)
+      case 'get_ticket':
+        return await getTicket(input, userId)
+      case 'create_ticket':
+        return await createTicket(input, userId)
+      case 'update_ticket':
+        return await updateTicket(input, userId)
+      case 'list_projects':
+        return await listProjects(userId)
+      case 'get_project':
+        return await getProject(input, userId)
+      case 'list_sprints':
+        return await listSprints(input, userId)
+      case 'list_labels':
+        return await listLabels(input, userId)
+      default:
+        return { success: false, result: `Unknown tool: ${toolName}` }
+    }
+  } catch (error) {
+    return {
+      success: false,
+      result: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    }
+  }
+}
+
+async function listTickets(input: ToolInput, userId: string): Promise<ToolResult> {
+  const {
+    projectKey,
+    column,
+    type,
+    priority,
+    assignee,
+    sprint,
+    resolution,
+    search,
+    limit = 20,
+  } = input
+
+  // Verify user has access to project
+  const project = await db.project.findFirst({
+    where: {
+      key: projectKey.toUpperCase(),
+      members: { some: { userId } },
+    },
+  })
+
+  if (!project) {
+    return { success: false, result: `Project ${projectKey} not found or access denied` }
+  }
+
+  // Build where clause
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const where: any = { projectId: project.id }
+
+  if (type) where.type = type
+  if (priority) where.priority = priority
+  if (resolution === 'resolved') {
+    where.resolution = { not: null }
+  } else if (resolution === 'unresolved') {
+    where.resolution = null
+  } else if (resolution) {
+    where.resolution = resolution
+  }
+
+  let tickets = await db.ticket.findMany({
+    where,
+    include: {
+      column: { select: { name: true } },
+      assignee: { select: { name: true } },
+      sprint: { select: { name: true } },
+    },
+    orderBy: { updatedAt: 'desc' },
+  })
+
+  // Apply case-insensitive filters in memory
+  if (column) {
+    const columnLower = column.toLowerCase()
+    tickets = tickets.filter((t) => t.column.name.toLowerCase().includes(columnLower))
+  }
+  if (assignee) {
+    const assigneeLower = assignee.toLowerCase()
+    tickets = tickets.filter((t) => t.assignee?.name.toLowerCase().includes(assigneeLower))
+  }
+  if (sprint) {
+    const sprintLower = sprint.toLowerCase()
+    tickets = tickets.filter((t) => t.sprint?.name.toLowerCase().includes(sprintLower))
+  }
+  if (search) {
+    const searchLower = search.toLowerCase()
+    tickets = tickets.filter(
+      (t) =>
+        t.title.toLowerCase().includes(searchLower) ||
+        t.description?.toLowerCase().includes(searchLower),
+    )
+  }
+
+  // Apply limit after filtering
+  tickets = tickets.slice(0, Math.min(limit, 100))
+
+  if (tickets.length === 0) {
+    return { success: true, result: 'No tickets found matching the criteria' }
+  }
+
+  const lines = tickets.map((t) => {
+    const key = `${project.key}-${t.number}`
+    const parts = [key, t.title, `[${t.column.name}]`, t.priority]
+    if (t.assignee) parts.push(`→ ${t.assignee.name}`)
+    if (t.storyPoints !== null) parts.push(`${t.storyPoints}pt`)
+    return parts.join(' | ')
+  })
+
+  return {
+    success: true,
+    result: `Found ${tickets.length} ticket(s):\n${lines.join('\n')}`,
+  }
+}
+
+async function getTicket(input: ToolInput, userId: string): Promise<ToolResult> {
+  const { key } = input
+  const match = key.match(/^([A-Z]+)-(\d+)$/i)
+  if (!match) {
+    return { success: false, result: 'Invalid ticket key format' }
+  }
+
+  const [, projectKey, numberStr] = match
+  const number = parseInt(numberStr, 10)
+
+  const ticket = await db.ticket.findFirst({
+    where: {
+      number,
+      project: {
+        key: projectKey.toUpperCase(),
+        members: { some: { userId } },
+      },
+    },
+    include: {
+      project: { select: { key: true } },
+      column: { select: { name: true } },
+      assignee: { select: { name: true } },
+      sprint: { select: { name: true } },
+      labels: { select: { name: true } },
+      parent: { select: { number: true, title: true } },
+    },
+  })
+
+  if (!ticket) {
+    return { success: false, result: `Ticket ${key} not found or access denied` }
+  }
+
+  const lines = [
+    `**${ticket.project.key}-${ticket.number}**: ${ticket.title}`,
+    `Type: ${ticket.type} | Priority: ${ticket.priority} | Status: ${ticket.column.name}`,
+  ]
+
+  if (ticket.assignee) lines.push(`Assignee: ${ticket.assignee.name}`)
+  if (ticket.sprint) lines.push(`Sprint: ${ticket.sprint.name}`)
+  if (ticket.storyPoints !== null) lines.push(`Story Points: ${ticket.storyPoints}`)
+  if (ticket.labels.length > 0) lines.push(`Labels: ${ticket.labels.map((l) => l.name).join(', ')}`)
+  if (ticket.resolution) lines.push(`Resolution: ${ticket.resolution}`)
+  if (ticket.parent)
+    lines.push(`Parent: ${ticket.project.key}-${ticket.parent.number} (${ticket.parent.title})`)
+  if (ticket.description) lines.push(`\nDescription:\n${ticket.description}`)
+
+  return { success: true, result: lines.join('\n') }
+}
+
+async function createTicket(input: ToolInput, userId: string): Promise<ToolResult> {
+  const {
+    projectKey,
+    title,
+    description,
+    type = 'task',
+    priority = 'medium',
+    assignee,
+    storyPoints,
+    sprint,
+    labels,
+    parent,
+  } = input
+
+  // Get project and verify access
+  const project = await db.project.findFirst({
+    where: {
+      key: projectKey.toUpperCase(),
+      members: { some: { userId } },
+    },
+    include: {
+      columns: { orderBy: { order: 'asc' }, take: 1 },
+    },
+  })
+
+  if (!project) {
+    return { success: false, result: `Project ${projectKey} not found or access denied` }
+  }
+
+  if (project.columns.length === 0) {
+    return { success: false, result: 'Project has no columns configured' }
+  }
+
+  // Get next ticket number
+  const maxTicket = await db.ticket.findFirst({
+    where: { projectId: project.id },
+    orderBy: { number: 'desc' },
+    select: { number: true },
+  })
+  const nextNumber = (maxTicket?.number ?? 0) + 1
+
+  // Build create data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = {
+    title,
+    description,
+    type,
+    priority,
+    number: nextNumber,
+    order: Date.now(),
+    project: { connect: { id: project.id } },
+    column: { connect: { id: project.columns[0].id } },
+    creator: { connect: { id: userId } },
+  }
+
+  if (storyPoints !== undefined) data.storyPoints = storyPoints
+
+  // Handle assignee
+  if (assignee) {
+    const projectMembers = await db.projectMember.findMany({
+      where: { projectId: project.id },
+      include: { user: { select: { id: true, name: true } } },
+    })
+    const assigneeLower = assignee.toLowerCase()
+    const assigneeUser = projectMembers.find((m) =>
+      m.user.name.toLowerCase().includes(assigneeLower),
+    )?.user
+    if (assigneeUser) {
+      data.assignee = { connect: { id: assigneeUser.id } }
+    }
+  }
+
+  // Handle sprint
+  if (sprint) {
+    const sprints = await db.sprint.findMany({
+      where: { projectId: project.id },
+    })
+    const sprintLower = sprint.toLowerCase()
+    const sprintObj = sprints.find((s) => s.name.toLowerCase() === sprintLower)
+    if (sprintObj) {
+      data.sprint = { connect: { id: sprintObj.id } }
+    }
+  }
+
+  // Handle labels
+  if (labels && labels.length > 0) {
+    const allLabels = await db.label.findMany({
+      where: { projectId: project.id },
+    })
+    const labelsLower = labels.map((l: string) => l.toLowerCase())
+    const labelObjs = allLabels.filter((l) => labelsLower.includes(l.name.toLowerCase()))
+    if (labelObjs.length > 0) {
+      data.labels = { connect: labelObjs.map((l) => ({ id: l.id })) }
+    }
+  }
+
+  // Handle parent
+  if (parent) {
+    const parentMatch = parent.match(/^([A-Z]+)-(\d+)$/i)
+    if (parentMatch) {
+      const parentTicket = await db.ticket.findFirst({
+        where: {
+          number: parseInt(parentMatch[2], 10),
+          project: { key: parentMatch[1].toUpperCase() },
+        },
+      })
+      if (parentTicket) {
+        data.parent = { connect: { id: parentTicket.id } }
+      }
+    }
+  }
+
+  const ticket = await db.ticket.create({ data })
+  const key = `${project.key}-${ticket.number}`
+
+  return { success: true, result: `Created ticket ${key}: ${title}` }
+}
+
+async function updateTicket(input: ToolInput, userId: string): Promise<ToolResult> {
+  const { key, ...updates } = input
+  const match = key.match(/^([A-Z]+)-(\d+)$/i)
+  if (!match) {
+    return { success: false, result: 'Invalid ticket key format' }
+  }
+
+  const [, projectKey, numberStr] = match
+  const number = parseInt(numberStr, 10)
+
+  const ticket = await db.ticket.findFirst({
+    where: {
+      number,
+      project: {
+        key: projectKey.toUpperCase(),
+        members: { some: { userId } },
+      },
+    },
+    include: { project: true },
+  })
+
+  if (!ticket) {
+    return { success: false, result: `Ticket ${key} not found or access denied` }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = {}
+  const changes: string[] = []
+
+  if (updates.title) {
+    data.title = updates.title
+    changes.push(`title → "${updates.title}"`)
+  }
+  if (updates.description !== undefined) {
+    data.description = updates.description
+    changes.push('description updated')
+  }
+  if (updates.type) {
+    data.type = updates.type
+    changes.push(`type → ${updates.type}`)
+  }
+  if (updates.priority) {
+    data.priority = updates.priority
+    changes.push(`priority → ${updates.priority}`)
+  }
+  if (updates.storyPoints !== undefined) {
+    data.storyPoints = updates.storyPoints
+    changes.push(`points → ${updates.storyPoints ?? 'none'}`)
+  }
+  if (updates.resolution !== undefined) {
+    data.resolution = updates.resolution
+    if (updates.resolution) {
+      data.resolvedAt = new Date()
+    } else {
+      data.resolvedAt = null
+    }
+    changes.push(`resolution → ${updates.resolution ?? 'none'}`)
+  }
+
+  // Handle column
+  if (updates.column) {
+    const columns = await db.column.findMany({
+      where: { projectId: ticket.projectId },
+    })
+    const columnLower = updates.column.toLowerCase()
+    const column = columns.find((c) => c.name.toLowerCase() === columnLower)
+    if (column) {
+      data.column = { connect: { id: column.id } }
+      changes.push(`status → ${column.name}`)
+    }
+  }
+
+  // Handle assignee
+  if (updates.assignee !== undefined) {
+    if (updates.assignee === null) {
+      data.assignee = { disconnect: true }
+      changes.push('assignee → none')
+    } else {
+      const projectMembers = await db.projectMember.findMany({
+        where: { projectId: ticket.projectId },
+        include: { user: { select: { id: true, name: true } } },
+      })
+      const assigneeLower = updates.assignee.toLowerCase()
+      const assigneeUser = projectMembers.find((m) =>
+        m.user.name.toLowerCase().includes(assigneeLower),
+      )?.user
+      if (assigneeUser) {
+        data.assignee = { connect: { id: assigneeUser.id } }
+        changes.push(`assignee → ${assigneeUser.name}`)
+      }
+    }
+  }
+
+  // Handle sprint
+  if (updates.sprint !== undefined) {
+    if (updates.sprint === null) {
+      data.sprint = { disconnect: true }
+      changes.push('sprint → backlog')
+    } else {
+      const sprints = await db.sprint.findMany({
+        where: { projectId: ticket.projectId },
+      })
+      const sprintLower = updates.sprint.toLowerCase()
+      const sprintObj = sprints.find((s) => s.name.toLowerCase() === sprintLower)
+      if (sprintObj) {
+        data.sprint = { connect: { id: sprintObj.id } }
+        changes.push(`sprint → ${sprintObj.name}`)
+      }
+    }
+  }
+
+  // Handle labels
+  if (updates.labels) {
+    const allLabels = await db.label.findMany({
+      where: { projectId: ticket.projectId },
+    })
+    const labelsLower = updates.labels.map((l: string) => l.toLowerCase())
+    const labelObjs = allLabels.filter((l) => labelsLower.includes(l.name.toLowerCase()))
+    data.labels = { set: labelObjs.map((l) => ({ id: l.id })) }
+    changes.push(`labels → ${labelObjs.map((l) => l.name).join(', ') || 'none'}`)
+  }
+
+  if (Object.keys(data).length === 0) {
+    return { success: true, result: 'No changes to apply' }
+  }
+
+  await db.ticket.update({ where: { id: ticket.id }, data })
+
+  return { success: true, result: `Updated ${key}: ${changes.join(', ')}` }
+}
+
+async function listProjects(userId: string): Promise<ToolResult> {
+  const projects = await db.project.findMany({
+    where: { members: { some: { userId } } },
+    include: {
+      _count: { select: { tickets: true, members: true } },
+    },
+    orderBy: { name: 'asc' },
+  })
+
+  if (projects.length === 0) {
+    return { success: true, result: 'No projects found' }
+  }
+
+  const lines = projects.map(
+    (p) => `${p.key} - ${p.name} (${p._count.tickets} tickets, ${p._count.members} members)`,
+  )
+
+  return { success: true, result: `Found ${projects.length} project(s):\n${lines.join('\n')}` }
+}
+
+async function getProject(input: ToolInput, userId: string): Promise<ToolResult> {
+  const { key } = input
+
+  const project = await db.project.findFirst({
+    where: {
+      key: key.toUpperCase(),
+      members: { some: { userId } },
+    },
+    include: {
+      columns: { orderBy: { order: 'asc' }, select: { name: true } },
+      labels: { select: { name: true } },
+      sprints: {
+        where: { status: { in: ['active', 'planning'] } },
+        select: { name: true, status: true },
+        orderBy: { createdAt: 'desc' },
+      },
+      _count: { select: { tickets: true, members: true } },
+    },
+  })
+
+  if (!project) {
+    return { success: false, result: `Project ${key} not found or access denied` }
+  }
+
+  const lines = [
+    `**${project.key}**: ${project.name}`,
+    project.description || 'No description',
+    `Columns: ${project.columns.map((c) => c.name).join(' → ')}`,
+    `Labels: ${project.labels.map((l) => l.name).join(', ') || 'none'}`,
+    `Sprints: ${project.sprints.map((s) => `${s.name} (${s.status})`).join(', ') || 'none'}`,
+    `${project._count.tickets} tickets, ${project._count.members} members`,
+  ]
+
+  return { success: true, result: lines.join('\n') }
+}
+
+async function listSprints(input: ToolInput, userId: string): Promise<ToolResult> {
+  const { projectKey, status } = input
+
+  const project = await db.project.findFirst({
+    where: {
+      key: projectKey.toUpperCase(),
+      members: { some: { userId } },
+    },
+  })
+
+  if (!project) {
+    return { success: false, result: `Project ${projectKey} not found or access denied` }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const where: any = { projectId: project.id }
+  if (status) where.status = status
+
+  const sprints = await db.sprint.findMany({
+    where,
+    include: {
+      _count: { select: { tickets: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  if (sprints.length === 0) {
+    return { success: true, result: 'No sprints found' }
+  }
+
+  const lines = sprints.map((s) => {
+    const parts = [`${s.name} [${s.status}]`, `${s._count.tickets} tickets`]
+    if (s.goal) parts.push(`Goal: ${s.goal}`)
+    return parts.join(' | ')
+  })
+
+  return { success: true, result: `Found ${sprints.length} sprint(s):\n${lines.join('\n')}` }
+}
+
+async function listLabels(input: ToolInput, userId: string): Promise<ToolResult> {
+  const { projectKey } = input
+
+  const project = await db.project.findFirst({
+    where: {
+      key: projectKey.toUpperCase(),
+      members: { some: { userId } },
+    },
+  })
+
+  if (!project) {
+    return { success: false, result: `Project ${projectKey} not found or access denied` }
+  }
+
+  const labels = await db.label.findMany({
+    where: { projectId: project.id },
+    orderBy: { name: 'asc' },
+  })
+
+  if (labels.length === 0) {
+    return { success: true, result: 'No labels found' }
+  }
+
+  return {
+    success: true,
+    result: `Labels: ${labels.map((l) => l.name).join(', ')}`,
+  }
+}

--- a/src/lib/chat/tools.ts
+++ b/src/lib/chat/tools.ts
@@ -1,0 +1,250 @@
+/**
+ * Tool definitions for Claude Chat
+ * These tools allow Claude to interact with PUNT's ticket management system
+ */
+
+import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages'
+
+// Core ticket management tools
+export const chatTools: AnthropicTool[] = [
+  {
+    name: 'list_tickets',
+    description:
+      'List tickets in a project with optional filters. Returns a summary of matching tickets.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        projectKey: {
+          type: 'string',
+          description: 'Project key (e.g., PUNT)',
+        },
+        column: {
+          type: 'string',
+          description: 'Filter by column/status name (e.g., "In Progress", "To Do")',
+        },
+        type: {
+          type: 'string',
+          enum: ['epic', 'story', 'task', 'bug', 'subtask'],
+          description: 'Filter by ticket type',
+        },
+        priority: {
+          type: 'string',
+          enum: ['lowest', 'low', 'medium', 'high', 'highest', 'critical'],
+          description: 'Filter by priority',
+        },
+        assignee: {
+          type: 'string',
+          description: 'Filter by assignee name',
+        },
+        sprint: {
+          type: 'string',
+          description: 'Filter by sprint name',
+        },
+        resolution: {
+          type: 'string',
+          description:
+            'Filter by resolution: "resolved", "unresolved", or specific value like "Done"',
+        },
+        search: {
+          type: 'string',
+          description: 'Text search across title and description',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of tickets to return (default 20, max 100)',
+        },
+      },
+      required: ['projectKey'],
+    },
+  },
+  {
+    name: 'get_ticket',
+    description: 'Get detailed information about a specific ticket by its key (e.g., PUNT-123)',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        key: {
+          type: 'string',
+          description: 'Ticket key like PUNT-123',
+        },
+      },
+      required: ['key'],
+    },
+  },
+  {
+    name: 'create_ticket',
+    description: 'Create a new ticket in a project',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        projectKey: {
+          type: 'string',
+          description: 'Project key (e.g., PUNT)',
+        },
+        title: {
+          type: 'string',
+          description: 'Ticket title',
+        },
+        description: {
+          type: 'string',
+          description: 'Ticket description (markdown supported)',
+        },
+        type: {
+          type: 'string',
+          enum: ['epic', 'story', 'task', 'bug', 'subtask'],
+          description: 'Ticket type (default: task)',
+        },
+        priority: {
+          type: 'string',
+          enum: ['lowest', 'low', 'medium', 'high', 'highest', 'critical'],
+          description: 'Priority level (default: medium)',
+        },
+        assignee: {
+          type: 'string',
+          description: 'Assignee name',
+        },
+        storyPoints: {
+          type: 'number',
+          description: 'Story points estimate',
+        },
+        sprint: {
+          type: 'string',
+          description: 'Sprint name to add ticket to',
+        },
+        labels: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Label names to assign',
+        },
+        parent: {
+          type: 'string',
+          description: 'Parent ticket key for subtasks (e.g., PUNT-5)',
+        },
+      },
+      required: ['projectKey', 'title'],
+    },
+  },
+  {
+    name: 'update_ticket',
+    description: 'Update an existing ticket',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        key: {
+          type: 'string',
+          description: 'Ticket key (e.g., PUNT-123)',
+        },
+        title: {
+          type: 'string',
+          description: 'New title',
+        },
+        description: {
+          type: 'string',
+          description: 'New description',
+        },
+        type: {
+          type: 'string',
+          enum: ['epic', 'story', 'task', 'bug', 'subtask'],
+        },
+        priority: {
+          type: 'string',
+          enum: ['lowest', 'low', 'medium', 'high', 'highest', 'critical'],
+        },
+        column: {
+          type: 'string',
+          description: 'Move to column/status',
+        },
+        assignee: {
+          type: 'string',
+          description: 'New assignee name (null to unassign)',
+        },
+        storyPoints: {
+          type: 'number',
+          description: 'Story points',
+        },
+        sprint: {
+          type: 'string',
+          description: 'Sprint name (null for backlog)',
+        },
+        resolution: {
+          type: 'string',
+          enum: ['Done', "Won't Fix", 'Duplicate', 'Cannot Reproduce', 'Incomplete', "Won't Do"],
+          description: 'Resolution status',
+        },
+        labels: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Label names (replaces existing)',
+        },
+      },
+      required: ['key'],
+    },
+  },
+  {
+    name: 'list_projects',
+    description: 'List all projects the user has access to',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'get_project',
+    description: 'Get details about a project including columns, members, and ticket count',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        key: {
+          type: 'string',
+          description: 'Project key (e.g., PUNT)',
+        },
+      },
+      required: ['key'],
+    },
+  },
+  {
+    name: 'list_sprints',
+    description: 'List sprints for a project',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        projectKey: {
+          type: 'string',
+          description: 'Project key (e.g., PUNT)',
+        },
+        status: {
+          type: 'string',
+          enum: ['planning', 'active', 'completed'],
+          description: 'Filter by sprint status',
+        },
+      },
+      required: ['projectKey'],
+    },
+  },
+  {
+    name: 'list_labels',
+    description: 'List all labels for a project',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        projectKey: {
+          type: 'string',
+          description: 'Project key (e.g., PUNT)',
+        },
+      },
+      required: ['projectKey'],
+    },
+  },
+]
+
+// Tool name type for type safety
+export type ChatToolName =
+  | 'list_tickets'
+  | 'get_ticket'
+  | 'create_ticket'
+  | 'update_ticket'
+  | 'list_projects'
+  | 'get_project'
+  | 'list_sprints'
+  | 'list_labels'

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand'
 import type { TicketFormData } from '@/types'
 
+interface ChatContext {
+  projectId?: string
+  ticketKey?: string
+}
+
 interface UIState {
   // Sidebar
   sidebarOpen: boolean
@@ -52,6 +57,13 @@ interface UIState {
   drawerFocusField: string | null
   openTicketWithFocus: (ticketId: string, field: string) => void
   clearDrawerFocusField: () => void
+
+  // Chat panel
+  chatPanelOpen: boolean
+  setChatPanelOpen: (open: boolean) => void
+  toggleChatPanel: () => void
+  chatContext: ChatContext
+  setChatContext: (context: ChatContext) => void
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -107,4 +119,11 @@ export const useUIStore = create<UIState>((set) => ({
   openTicketWithFocus: (ticketId, field) =>
     set({ activeTicketId: ticketId, drawerFocusField: field }),
   clearDrawerFocusField: () => set({ drawerFocusField: null }),
+
+  // Chat panel
+  chatPanelOpen: false,
+  setChatPanelOpen: (open) => set({ chatPanelOpen: open }),
+  toggleChatPanel: () => set((state) => ({ chatPanelOpen: !state.chatPanelOpen })),
+  chatContext: {},
+  setChatContext: (context) => set({ chatContext: context }),
 }))


### PR DESCRIPTION
## Summary
- Add embedded Claude Chat panel that allows users to manage tickets, sprints, and projects through natural conversation
- Floating Action Button (FAB) in bottom-right corner + Cmd/Ctrl+I keyboard shortcut to toggle chat
- Context-aware: auto-injects current project/ticket context into system prompt
- Per-user Anthropic API key storage in Profile > Integrations
- Backend proxy pattern for API key security with streaming SSE responses

## Changes
### Backend
- `POST /api/chat` - Streaming chat endpoint with tool execution loop
- `GET/POST/DELETE /api/me/anthropic-key` - API key management
- `src/lib/chat/tools.ts` - 8 tool definitions (list_tickets, get_ticket, create_ticket, update_ticket, list_projects, get_project, list_sprints, list_labels)
- `src/lib/chat/context.ts` - Context builder for system prompts
- `src/lib/chat/executor.ts` - Tool execution against PUNT database

### UI
- `ChatPanel` - Sheet component from right side with message history
- `ChatFAB` - Floating button to open chat
- `ChatMessage` - Message bubbles with tool execution status indicators
- `ChatInput` - Auto-resizing input with send button

### Integration
- Added `chatPanelOpen`, `chatContext` state to ui-store
- Added Cmd/Ctrl+I keyboard shortcut
- Added Anthropic key UI to Profile > Integrations tab

## Test plan
- [x] Add Anthropic API key in Profile > Integrations
- [x] Press Cmd/Ctrl+I to open chat panel
- [x] Click FAB button to open chat panel
- [x] Ask "list my tickets" and verify tool execution
- [x] Ask "create a bug ticket for testing" and verify ticket creation
- [x] Verify tool execution indicators show running/completed status
- [x] Verify streaming text appears in real-time
- [x] Verify error handling when no API key is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)