### PR TITLE
fix(security): medium/low severity fixes from audit (PUNT-181)

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -31,8 +31,13 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
         const { username, password } = parsed.data
 
+        // Normalize username to NFC form for consistent matching
+        // Registration also normalizes to NFC, so this ensures login works
+        // regardless of which Unicode form the client sends
+        const normalizedUsername = username.normalize('NFC')
+
         const user = await db.user.findUnique({
-          where: { username },
+          where: { username: normalizedUsername },
         })
 
         if (!user || !user.passwordHash) {

--- a/src/lib/email/providers/resend-provider.ts
+++ b/src/lib/email/providers/resend-provider.ts
@@ -36,8 +36,9 @@ export class ResendProvider implements EmailProvider {
 
     try {
       const sanitizedName = sanitizeEmailDisplayName(this.settings.emailFromName)
+      // Quote the display name for RFC 5322 compliance and consistency with SMTP
       const from = sanitizedName
-        ? `${sanitizedName} <${this.settings.emailFromAddress}>`
+        ? `"${sanitizedName}" <${this.settings.emailFromAddress}>`
         : this.settings.emailFromAddress
 
       const { data, error } = await this.client.emails.send({


### PR DESCRIPTION
## Summary

Medium and low severity security fixes from the comprehensive security audit.

### Changes

- **M4: Email display name injection** - Improved `sanitizeEmailDisplayName` to use a whitelist approach with Unicode NFC normalization. Made Resend provider quote display names consistently with SMTP (RFC 5322 compliance).

- **M5: Role deletion race condition** - Wrapped member count check and role delete in a transaction to prevent race condition where members could be added between the check and delete (the schema has `onDelete: Cascade` which would delete all members).

- **L1: Unicode normalization on login** - Normalize username to NFC form before database lookup, matching the registration behavior. This ensures users can log in regardless of which Unicode form the client sends.

- **L2: Silent JSON parsing failures** - Added logging when system settings JSON parsing fails, making it easier to debug corrupted data issues.

## Test plan

- [x] All 1173 tests pass
- [ ] Manual test: Login with Unicode username works
- [ ] Manual test: Role deletion fails gracefully if members exist
- [ ] Manual test: Email sending with special characters in display name

🤖 Generated with [Claude Code](https://claude.com/claude-code)