### PR TITLE
feat(mcp): add tools for ticket links, comments, and search (PUNT-158, PUNT-159, PUNT-160)

### DIFF
--- a/mcp/src/api-client.ts
+++ b/mcp/src/api-client.ts
@@ -485,3 +485,83 @@ export async function deleteComment(projectKey: string, ticketId: string, commen
     `/api/projects/${projectKey}/tickets/${ticketId}/comments/${commentId}`,
   )
 }
+
+export async function updateComment(
+  projectKey: string,
+  ticketId: string,
+  commentId: string,
+  content: string,
+) {
+  return apiRequest<CommentData>(
+    'PATCH',
+    `/api/projects/${projectKey}/tickets/${ticketId}/comments/${commentId}`,
+    { content },
+  )
+}
+
+// ============================================================================
+// Ticket Links API
+// ============================================================================
+
+export interface TicketLinkData {
+  id: string
+  linkType: string
+  fromTicket: {
+    id: string
+    number: number
+    title: string
+    type: string
+    column: { name: string }
+  }
+  toTicket: {
+    id: string
+    number: number
+    title: string
+    type: string
+    column: { name: string }
+  }
+  createdAt: string
+}
+
+export async function listTicketLinks(projectKey: string, ticketId: string) {
+  return apiRequest<TicketLinkData[]>(
+    'GET',
+    `/api/projects/${projectKey}/tickets/${ticketId}/links`,
+  )
+}
+
+export interface CreateTicketLinkInput {
+  toTicketId: string
+  linkType: string
+}
+
+export async function createTicketLink(
+  projectKey: string,
+  ticketId: string,
+  data: CreateTicketLinkInput,
+) {
+  return apiRequest<TicketLinkData>(
+    'POST',
+    `/api/projects/${projectKey}/tickets/${ticketId}/links`,
+    data,
+  )
+}
+
+export async function deleteTicketLink(projectKey: string, ticketId: string, linkId: string) {
+  return apiRequest<{ success: boolean }>(
+    'DELETE',
+    `/api/projects/${projectKey}/tickets/${ticketId}/links/${linkId}`,
+  )
+}
+
+// ============================================================================
+// Ticket Search API
+// ============================================================================
+
+export async function searchTickets(projectKey: string, query: string) {
+  const encodedQuery = encodeURIComponent(query)
+  return apiRequest<TicketData[]>(
+    'GET',
+    `/api/projects/${projectKey}/tickets/search?q=${encodedQuery}`,
+  )
+}


### PR DESCRIPTION
## Summary
- Add `list_ticket_links`, `add_ticket_link`, `remove_ticket_link` tools (PUNT-158)
- Add `update_comment` tool (PUNT-159 - list/add/delete already existed)
- Add `search_tickets` tool for full-text search (PUNT-160)

## New Tools
| Tool | Description |
|------|-------------|
| `list_ticket_links` | List all links for a ticket |
| `add_ticket_link` | Create link between tickets (blocks, relates_to, duplicates, etc.) |
| `remove_ticket_link` | Remove a link by ID |
| `update_comment` | Edit an existing comment |
| `search_tickets` | Full-text search across titles and descriptions |

## Test plan
- [x] `list_ticket_links` on PUNT-130 shows the link to PUNT-113
- [x] `add_ticket_link` creates a new link
- [x] `remove_ticket_link` removes a link
- [x] `search_tickets` returns matching tickets
- [x] `update_comment` modifies comment content

🤖 Generated with [Claude Code](https://claude.com/claude-code)