### PR TITLE
fix(ui): auto-focus delete button in confirmation modals (PUNT-143)

### DIFF
--- a/src/components/tickets/attachment-list.tsx
+++ b/src/components/tickets/attachment-list.tsx
@@ -74,17 +74,6 @@ export function AttachmentList({
   const [fileToDelete, setFileToDelete] = useState<UploadedFile | null>(null)
   const deleteButtonRef = useRef<HTMLButtonElement>(null)
 
-  // Focus delete button when dialog opens
-  useEffect(() => {
-    if (fileToDelete && deleteButtonRef.current) {
-      // Small delay to ensure dialog is rendered
-      const timer = setTimeout(() => {
-        deleteButtonRef.current?.focus()
-      }, 50)
-      return () => clearTimeout(timer)
-    }
-  }, [fileToDelete])
-
   if (attachments.length === 0) {
     return null
   }
@@ -222,7 +211,13 @@ export function AttachmentList({
 
         {/* Delete Confirmation Dialog */}
         <AlertDialog open={!!fileToDelete} onOpenChange={(open) => !open && setFileToDelete(null)}>
-          <AlertDialogContent className="bg-zinc-900 border-zinc-800">
+          <AlertDialogContent
+            className="bg-zinc-900 border-zinc-800"
+            onOpenAutoFocus={(e) => {
+              e.preventDefault()
+              deleteButtonRef.current?.focus()
+            }}
+          >
             <AlertDialogHeader>
               <AlertDialogTitle>Delete Attachment</AlertDialogTitle>
               <AlertDialogDescription className="text-zinc-400">
@@ -236,6 +231,7 @@ export function AttachmentList({
                 Cancel
               </AlertDialogCancel>
               <AlertDialogAction
+                ref={deleteButtonRef}
                 onClick={handleConfirmDelete}
                 className="bg-red-600 hover:bg-red-700 text-white"
               >
@@ -365,7 +361,13 @@ export function AttachmentList({
 
       {/* Delete Confirmation Dialog */}
       <AlertDialog open={!!fileToDelete} onOpenChange={(open) => !open && setFileToDelete(null)}>
-        <AlertDialogContent className="bg-zinc-900 border-zinc-800">
+        <AlertDialogContent
+          className="bg-zinc-900 border-zinc-800"
+          onOpenAutoFocus={(e) => {
+            e.preventDefault()
+            deleteButtonRef.current?.focus()
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle>Delete Attachment</AlertDialogTitle>
             <AlertDialogDescription className="text-zinc-400">

--- a/src/components/tickets/ticket-detail-drawer.tsx
+++ b/src/components/tickets/ticket-detail-drawer.tsx
@@ -214,6 +214,7 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
   const [_pendingClose, setPendingClose] = useState(false)
   const [rememberPreference, setRememberPreference] = useState(false)
   const deleteButtonRef = useRef<HTMLButtonElement>(null)
+  const removeAllAttachmentsButtonRef = useRef<HTMLButtonElement>(null)
   const storyPointsInputRef = useRef<HTMLInputElement>(null)
   const commentsSectionRef = useRef<CommentsSectionRef>(null)
   const [hasPendingComment, setHasPendingComment] = useState(false)
@@ -621,15 +622,6 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
     updateTicketMutation,
     availableLabels,
   ])
-
-  // Focus delete button when dialog opens
-  useEffect(() => {
-    if (showDeleteConfirm) {
-      setTimeout(() => {
-        deleteButtonRef.current?.focus()
-      }, 0)
-    }
-  }, [showDeleteConfirm])
 
   if (!ticket) return null
 
@@ -1684,7 +1676,13 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
 
       {/* Delete confirmation dialog */}
       <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <AlertDialogContent className="bg-zinc-950 border-zinc-800">
+        <AlertDialogContent
+          className="bg-zinc-950 border-zinc-800"
+          onOpenAutoFocus={(e) => {
+            e.preventDefault()
+            deleteButtonRef.current?.focus()
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle className="text-zinc-100">Delete ticket?</AlertDialogTitle>
             <AlertDialogDescription className="text-zinc-400">
@@ -1712,7 +1710,13 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
 
       {/* Remove all attachments confirmation dialog */}
       <AlertDialog open={showRemoveAllAttachments} onOpenChange={setShowRemoveAllAttachments}>
-        <AlertDialogContent className="bg-zinc-950 border-zinc-800">
+        <AlertDialogContent
+          className="bg-zinc-950 border-zinc-800"
+          onOpenAutoFocus={(e) => {
+            e.preventDefault()
+            removeAllAttachmentsButtonRef.current?.focus()
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle className="text-zinc-100">Remove all attachments?</AlertDialogTitle>
             <AlertDialogDescription className="text-zinc-400">
@@ -1726,6 +1730,7 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
               Cancel
             </AlertDialogCancel>
             <AlertDialogAction
+              ref={removeAllAttachmentsButtonRef}
               onClick={() => {
                 if (!ticket) return
                 const attachmentsToRemove = [...tempAttachments]


### PR DESCRIPTION
## Summary
- Fixed auto-focus behavior on delete confirmation modals so the delete button is focused when the modal opens
- Users can now press Enter immediately after a modal opens to confirm deletion, without needing to tab through elements first
- Replaced setTimeout-based focus approach with Radix UI's `onOpenAutoFocus` callback which properly integrates with Radix's focus trap

## Changes
- `src/components/tickets/ticket-detail-drawer.tsx`:
  - Added `onOpenAutoFocus` to delete ticket confirmation dialog
  - Added `onOpenAutoFocus` to remove all attachments confirmation dialog
  - Added ref for the remove all attachments button
- `src/components/tickets/attachment-list.tsx`:
  - Added `onOpenAutoFocus` to delete attachment dialogs (both grid and list layouts)
  - Added ref to the delete button in grid layout dialog

## Test plan
- [x] Open a ticket detail drawer
- [x] Click the Delete button to open the delete confirmation modal
- [x] Verify the Delete button in the modal is focused (has visible focus ring)
- [x] Press Enter and verify the ticket is deleted
- [x] Open a ticket with multiple attachments
- [x] Click "Remove all" to open the remove all attachments modal
- [x] Verify the "Remove all" button is focused
- [x] Press Enter and verify attachments are removed
- [x] In grid view, hover over an attachment and click the delete button
- [x] Verify the Delete button in the confirmation modal is focused
- [x] Press Enter and verify the attachment is deleted

---
Generated with [Claude Code](https://claude.com/claude-code)