### PR TITLE
fix(sidebar): navigate to integrations tab from Claude sidebar (PUNT-147)

### DIFF
--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -253,7 +253,7 @@ function NoApiKeyMessage() {
         <p className="mt-1 text-sm text-zinc-400">Add your Anthropic API key to use Claude Chat</p>
       </div>
       <Button asChild className="bg-purple-600 hover:bg-purple-700">
-        <Link href="/profile">Go to Settings</Link>
+        <Link href="/settings?tab=integrations">Go to Settings</Link>
       </Button>
     </div>
   )


### PR DESCRIPTION
## Summary
- Update 'Go to Settings' button in Claude sidebar to navigate directly to Integrations tab
- Allows users to quickly set up their MCP API key

## Test plan
- [ ] Click 'Go to Settings' button in Claude sidebar when unauthenticated
- [ ] Verify it navigates to /settings?tab=integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)