### PR TITLE
fix(ui): replace checkboxes with Switch component in settings (PUNT-141)

### DIFF
--- a/src/app/(app)/preferences/page.tsx
+++ b/src/app/(app)/preferences/page.tsx
@@ -4,11 +4,11 @@ import { Settings } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { PageHeader } from '@/components/common'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import { useProjectsStore } from '@/stores/projects-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -78,11 +78,11 @@ export default function PreferencesPage() {
                   When pasting a single ticket, automatically open it in the detail drawer
                 </p>
               </div>
-              <Checkbox
+              <Switch
                 id="open-single-pasted"
                 checked={openSinglePastedTicket}
                 onCheckedChange={(checked) => setOpenSinglePastedTicket(checked === true)}
-                className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                className="data-[state=checked]:bg-amber-600"
               />
             </div>
 
@@ -98,11 +98,11 @@ export default function PreferencesPage() {
                   confirmation dialog
                 </p>
               </div>
-              <Checkbox
+              <Switch
                 id="auto-save-drawer"
                 checked={autoSaveOnDrawerClose}
                 onCheckedChange={(checked) => setAutoSaveOnDrawerClose(checked === true)}
-                className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                className="data-[state=checked]:bg-amber-600"
               />
             </div>
 
@@ -118,11 +118,11 @@ export default function PreferencesPage() {
                   confirmation dialog
                 </p>
               </div>
-              <Checkbox
+              <Switch
                 id="auto-save-role-editor"
                 checked={autoSaveOnRoleEditorClose}
                 onCheckedChange={(checked) => setAutoSaveOnRoleEditorClose(checked === true)}
-                className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                className="data-[state=checked]:bg-amber-600"
               />
             </div>
 
@@ -138,11 +138,11 @@ export default function PreferencesPage() {
                   operations
                 </p>
               </div>
-              <Checkbox
+              <Switch
                 id="show-undo-buttons"
                 checked={showUndoButtons}
                 onCheckedChange={(checked) => setShowUndoButtons(checked === true)}
-                className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                className="data-[state=checked]:bg-amber-600"
               />
             </div>
           </CardContent>
@@ -167,11 +167,11 @@ export default function PreferencesPage() {
                   always reset to their default sort order on page load.
                 </p>
               </div>
-              <Checkbox
+              <Switch
                 id="persist-table-sort"
                 checked={persistTableSort}
                 onCheckedChange={(checked) => setPersistTableSort(checked === true)}
-                className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                className="data-[state=checked]:bg-amber-600"
               />
             </div>
           </CardContent>
@@ -287,11 +287,11 @@ export default function PreferencesPage() {
                   swatches
                 </p>
               </div>
-              <Checkbox
+              <Switch
                 id="hide-color-removal-warning"
                 checked={hideColorRemovalWarning}
                 onCheckedChange={(checked) => setHideColorRemovalWarning(checked === true)}
-                className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                className="data-[state=checked]:bg-amber-600"
               />
             </div>
           </CardContent>
@@ -315,11 +315,11 @@ export default function PreferencesPage() {
                   Keep the admin settings section expanded in the sidebar
                 </p>
               </div>
-              <Checkbox
+              <Switch
                 id="sidebar-admin"
                 checked={sidebarExpandedSections.admin ?? false}
                 onCheckedChange={(checked) => setSidebarSectionExpanded('admin', checked === true)}
-                className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                className="data-[state=checked]:bg-amber-600"
               />
             </div>
 
@@ -334,13 +334,13 @@ export default function PreferencesPage() {
                   Keep the profile tabs section expanded in the sidebar
                 </p>
               </div>
-              <Checkbox
+              <Switch
                 id="sidebar-profile"
                 checked={sidebarExpandedSections.profile ?? false}
                 onCheckedChange={(checked) =>
                   setSidebarSectionExpanded('profile', checked === true)
                 }
-                className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                className="data-[state=checked]:bg-amber-600"
               />
             </div>
 
@@ -355,7 +355,7 @@ export default function PreferencesPage() {
                         Keep project settings sections expanded in the sidebar
                       </p>
                     </div>
-                    <Checkbox
+                    <Switch
                       id="sidebar-all-projects"
                       checked={projects.every((p) => sidebarExpandedSections[p.id] ?? false)}
                       onCheckedChange={(checked) => {
@@ -363,7 +363,7 @@ export default function PreferencesPage() {
                           setSidebarSectionExpanded(project.id, checked === true)
                         }
                       }}
-                      className="mt-1 border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                      className="data-[state=checked]:bg-amber-600"
                     />
                   </div>
                   <div className="space-y-3 mt-3">
@@ -381,13 +381,13 @@ export default function PreferencesPage() {
                             {project.name}
                           </Label>
                         </div>
-                        <Checkbox
+                        <Switch
                           id={`sidebar-project-${project.id}`}
                           checked={sidebarExpandedSections[project.id] ?? false}
                           onCheckedChange={(checked) =>
                             setSidebarSectionExpanded(project.id, checked === true)
                           }
-                          className="border-zinc-700 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
+                          className="data-[state=checked]:bg-amber-600"
                         />
                       </div>
                     ))}

--- a/src/components/admin/board-settings-form.tsx
+++ b/src/components/admin/board-settings-form.tsx
@@ -4,8 +4,8 @@ import { Loader2, Save } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import { useSystemSettings, useUpdateSystemSettings } from '@/hooks/queries/use-system-settings'
 
 export function BoardSettingsForm() {
@@ -58,13 +58,7 @@ export function BoardSettingsForm() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="flex items-start gap-3">
-            <Checkbox
-              id="showAddColumnButton"
-              checked={showAddColumnButton}
-              onCheckedChange={(checked) => setShowAddColumnButton(checked === true)}
-              className="mt-0.5 border-zinc-600 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
-            />
+          <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">
               <Label htmlFor="showAddColumnButton" className="text-zinc-300 cursor-pointer">
                 Show &quot;Add Column&quot; button on boards
@@ -75,6 +69,12 @@ export function BoardSettingsForm() {
                 Projects can override this setting.
               </p>
             </div>
+            <Switch
+              id="showAddColumnButton"
+              checked={showAddColumnButton}
+              onCheckedChange={(checked) => setShowAddColumnButton(checked === true)}
+              className="data-[state=checked]:bg-amber-600"
+            />
           </div>
 
           {/* Save/Reset buttons */}

--- a/src/components/admin/email-settings-form.tsx
+++ b/src/components/admin/email-settings-form.tsx
@@ -4,7 +4,6 @@ import { AlertCircle, Info, Loader2, Mail, Save, Send } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -15,6 +14,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
 import {
   useSendTestEmail,
   useSystemSettings,
@@ -137,16 +137,16 @@ export function EmailSettingsForm() {
         </CardHeader>
         <CardContent className="space-y-6">
           {/* Master Toggle */}
-          <div className="flex items-center space-x-3">
-            <Checkbox
-              id="emailEnabled"
-              checked={emailEnabled}
-              onCheckedChange={(checked) => setEmailEnabled(checked === true)}
-              className="border-zinc-600 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
-            />
+          <div className="flex items-center justify-between">
             <Label htmlFor="emailEnabled" className="text-zinc-300 cursor-pointer">
               Enable email functionality
             </Label>
+            <Switch
+              id="emailEnabled"
+              checked={emailEnabled}
+              onCheckedChange={(checked) => setEmailEnabled(checked === true)}
+              className="data-[state=checked]:bg-amber-600"
+            />
           </div>
 
           {emailEnabled && (
@@ -272,16 +272,16 @@ export function EmailSettingsForm() {
                         />
                       </div>
                       <div className="space-y-2 flex items-end">
-                        <div className="flex items-center space-x-2 pb-2">
-                          <Checkbox
-                            id="smtpSecure"
-                            checked={smtpSecure}
-                            onCheckedChange={(checked) => setSmtpSecure(checked === true)}
-                            className="border-zinc-600 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
-                          />
+                        <div className="flex items-center justify-between w-full pb-2">
                           <Label htmlFor="smtpSecure" className="text-zinc-300 cursor-pointer">
                             Use TLS/SSL
                           </Label>
+                          <Switch
+                            id="smtpSecure"
+                            checked={smtpSecure}
+                            onCheckedChange={(checked) => setSmtpSecure(checked === true)}
+                            className="data-[state=checked]:bg-amber-600"
+                          />
                         </div>
                       </div>
                     </div>
@@ -327,43 +327,37 @@ export function EmailSettingsForm() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="flex items-center space-x-3">
-                <Checkbox
-                  id="emailPasswordReset"
-                  checked={emailPasswordReset}
-                  onCheckedChange={(checked) => setEmailPasswordReset(checked === true)}
-                  className="border-zinc-600 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
-                />
+              <div className="flex items-center justify-between">
                 <div>
                   <Label htmlFor="emailPasswordReset" className="text-zinc-300 cursor-pointer">
                     Password Reset
                   </Label>
                   <p className="text-xs text-zinc-500">Send password reset emails</p>
                 </div>
+                <Switch
+                  id="emailPasswordReset"
+                  checked={emailPasswordReset}
+                  onCheckedChange={(checked) => setEmailPasswordReset(checked === true)}
+                  className="data-[state=checked]:bg-amber-600"
+                />
               </div>
 
-              <div className="flex items-center space-x-3">
-                <Checkbox
-                  id="emailWelcome"
-                  checked={emailWelcome}
-                  onCheckedChange={(checked) => setEmailWelcome(checked === true)}
-                  className="border-zinc-600 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
-                />
+              <div className="flex items-center justify-between">
                 <div>
                   <Label htmlFor="emailWelcome" className="text-zinc-300 cursor-pointer">
                     Welcome Emails
                   </Label>
                   <p className="text-xs text-zinc-500">Send welcome emails to new users</p>
                 </div>
+                <Switch
+                  id="emailWelcome"
+                  checked={emailWelcome}
+                  onCheckedChange={(checked) => setEmailWelcome(checked === true)}
+                  className="data-[state=checked]:bg-amber-600"
+                />
               </div>
 
-              <div className="flex items-center space-x-3">
-                <Checkbox
-                  id="emailVerification"
-                  checked={emailVerification}
-                  onCheckedChange={(checked) => setEmailVerification(checked === true)}
-                  className="border-zinc-600 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
-                />
+              <div className="flex items-center justify-between">
                 <div>
                   <Label htmlFor="emailVerification" className="text-zinc-300 cursor-pointer">
                     Email Verification
@@ -372,16 +366,15 @@ export function EmailSettingsForm() {
                     Prompt users to verify their email addresses
                   </p>
                 </div>
+                <Switch
+                  id="emailVerification"
+                  checked={emailVerification}
+                  onCheckedChange={(checked) => setEmailVerification(checked === true)}
+                  className="data-[state=checked]:bg-amber-600"
+                />
               </div>
 
-              <div className="flex items-center space-x-3">
-                <Checkbox
-                  id="emailInvitations"
-                  checked={emailInvitations}
-                  onCheckedChange={(checked) => setEmailInvitations(checked === true)}
-                  className="border-zinc-600 data-[state=checked]:bg-amber-600 data-[state=checked]:border-amber-600"
-                  disabled
-                />
+              <div className="flex items-center justify-between">
                 <div>
                   <Label htmlFor="emailInvitations" className="text-zinc-400 cursor-not-allowed">
                     Project Invitations
@@ -390,6 +383,13 @@ export function EmailSettingsForm() {
                     Send project invitation emails (coming soon)
                   </p>
                 </div>
+                <Switch
+                  id="emailInvitations"
+                  checked={emailInvitations}
+                  onCheckedChange={(checked) => setEmailInvitations(checked === true)}
+                  className="data-[state=checked]:bg-amber-600"
+                  disabled
+                />
               </div>
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary
- Replace checkbox inputs with shadcn Switch component for on/off toggles
- Updated user preferences page (10 toggles for ticket behavior, table behavior, color picker, sidebar settings)
- Updated admin board settings (show add column button toggle)
- Updated admin email settings (enable email, TLS/SSL, and 4 email feature toggles)
- Provides clearer visual feedback and better touch targets for boolean settings

## Test plan
- [ ] Verify user preferences toggles work correctly (open single pasted ticket, auto-save on drawer close, etc.)
- [ ] Verify admin board settings toggle works correctly
- [ ] Verify admin email settings toggles work correctly (enable email, TLS/SSL, password reset, welcome, verification, invitations)
- [ ] Verify all toggles maintain their state after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)