### PR TITLE
fix(attachments): ensure file picker opens on upload button click (PUNT-162)

### DIFF
--- a/src/components/tickets/file-upload.tsx
+++ b/src/components/tickets/file-upload.tsx
@@ -231,22 +231,20 @@ export function FileUpload({ value, onChange, maxFiles: maxFilesProp, disabled }
             <Upload className="h-8 w-8 text-zinc-500" />
             <p className="mt-2 text-sm text-zinc-400">
               Drag & drop files here, or{' '}
-              <label className="cursor-pointer text-amber-500 hover:text-amber-400">
-                browse
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  multiple
-                  accept={allowedExtensions.join(',')}
-                  onChange={handleFileSelect}
-                  disabled={disabled || isUploading}
-                  className="sr-only"
-                />
-              </label>
+              <span className="text-amber-500 hover:text-amber-400">browse</span>
             </p>
             <p className="mt-1 text-xs text-zinc-500">
               Images, videos, PDFs, documents up to {maxSizeDisplay}MB
             </p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept={allowedExtensions.join(',')}
+              onChange={handleFileSelect}
+              disabled={disabled || isUploading}
+              className="sr-only"
+            />
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Fix upload attachment button not opening file browser in Chrome
- Move hidden file input element outside of label wrapper to prevent Chrome from blocking programmatic `.click()` calls
- Follow the same pattern used in `custom-image-dialog.tsx` where the file input is a standalone element with `sr-only` class

## Root Cause
When a hidden `<input type="file">` is nested inside a `<label>` element and the parent container has an `onClick` handler that calls `inputRef.current?.click()`, Chrome may conflict between the programmatic click and the label's native file input association. This causes the file picker dialog to not open.

## Test plan
- [ ] Click upload attachment button in Chrome - verify file picker dialog opens
- [ ] Click upload attachment button in Firefox - verify file picker dialog opens
- [ ] Click upload attachment button in Safari - verify file picker dialog opens
- [ ] Drag and drop files onto the upload zone - verify upload works
- [ ] Click the "browse" text - verify file picker opens
- [ ] Verify uploaded files appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)