### PR TITLE
feat(keyboard): add Ctrl+S shortcut to save forms (PUNT-152)

### DIFF
--- a/src/components/admin/board-settings-form.tsx
+++ b/src/components/admin/board-settings-form.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { useSystemSettings, useUpdateSystemSettings } from '@/hooks/queries/use-system-settings'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 
 export function BoardSettingsForm() {
   const { data: settings, isLoading, error } = useSystemSettings()
@@ -32,6 +33,12 @@ export function BoardSettingsForm() {
       setShowAddColumnButton(settings.showAddColumnButton)
     }
   }
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: handleSave,
+    enabled: hasChanges && !updateSettings.isPending,
+  })
 
   if (isLoading) {
     return (

--- a/src/components/admin/branding-settings-form.tsx
+++ b/src/components/admin/branding-settings-form.tsx
@@ -13,6 +13,7 @@ import {
   useUpdateSystemSettings,
   useUploadLogo,
 } from '@/hooks/queries/use-system-settings'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { DEFAULT_BRANDING } from '@/lib/branding'
 
 export function BrandingSettingsForm() {
@@ -53,6 +54,12 @@ export function BrandingSettingsForm() {
       logoGradientTo,
     })
   }
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: handleSave,
+    enabled: hasChanges && !updateSettings.isPending,
+  })
 
   const handleResetToDefaults = () => {
     setAppName(DEFAULT_BRANDING.appName)

--- a/src/components/admin/email-settings-form.tsx
+++ b/src/components/admin/email-settings-form.tsx
@@ -20,6 +20,7 @@ import {
   useSystemSettings,
   useUpdateSystemSettings,
 } from '@/hooks/queries/use-system-settings'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import type { EmailProviderType } from '@/lib/email/types'
 
 export function EmailSettingsForm() {
@@ -91,6 +92,12 @@ export function EmailSettingsForm() {
       emailInvitations,
     })
   }
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: handleSave,
+    enabled: hasChanges && !updateSettings.isPending,
+  })
 
   const handleSendTestEmail = () => {
     if (testEmailAddress) {

--- a/src/components/admin/repository-settings-form.tsx
+++ b/src/components/admin/repository-settings-form.tsx
@@ -20,6 +20,7 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { useSystemSettings, useUpdateSystemSettings } from '@/hooks/queries/use-system-settings'
 import { useCheckForUpdates, useLocalVersion } from '@/hooks/queries/use-version'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 
 const DEFAULT_REPO_URL = 'https://github.com/jmynes/punt/'
 
@@ -208,6 +209,12 @@ export function RepositorySettingsForm() {
   const handleCheckForUpdates = () => {
     checkForUpdates.mutate()
   }
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: handleSave,
+    enabled: hasChanges && !urlError && !forkUrlError && !updateSettings.isPending,
+  })
 
   if (isLoading) {
     return (

--- a/src/components/admin/role-permissions-form.tsx
+++ b/src/components/admin/role-permissions-form.tsx
@@ -37,6 +37,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { getTabId } from '@/hooks/use-realtime'
 import { LABEL_COLORS } from '@/lib/constants'
 import type { Permission } from '@/lib/permissions/constants'
@@ -547,6 +548,12 @@ export function RolePermissionsForm() {
       setCustomRoles([])
     }
   }
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: handleSave,
+    enabled: hasChanges && !updateMutation.isPending,
+  })
 
   if (isLoading) {
     return (

--- a/src/components/admin/settings-form.tsx
+++ b/src/components/admin/settings-form.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
 import { useSystemSettings, useUpdateSystemSettings } from '@/hooks/queries/use-system-settings'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 
 // All available MIME types that can be enabled
 const ALL_IMAGE_TYPES = [
@@ -79,6 +80,24 @@ export function SettingsForm() {
         JSON.stringify(settings.allowedVideoTypes.sort()) ||
       JSON.stringify(allowedDocumentTypes.sort()) !==
         JSON.stringify(settings.allowedDocumentTypes.sort()))
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: () => {
+      if (hasChanges) {
+        updateSettings.mutate({
+          maxImageSizeMB,
+          maxVideoSizeMB,
+          maxDocumentSizeMB,
+          maxAttachmentsPerTicket,
+          allowedImageTypes,
+          allowedVideoTypes,
+          allowedDocumentTypes,
+        })
+      }
+    },
+    enabled: hasChanges && !updateSettings.isPending,
+  })
 
   const handleSave = () => {
     updateSettings.mutate({

--- a/src/components/keyboard-shortcuts.tsx
+++ b/src/components/keyboard-shortcuts.tsx
@@ -2826,10 +2826,16 @@ export function KeyboardShortcuts() {
               </div>
             </div>
 
-            {/* Undo/Redo */}
+            {/* Save / Undo / Redo */}
             <div>
-              <h3 className="text-sm font-semibold text-zinc-200 mb-2">Undo / Redo</h3>
+              <h3 className="text-sm font-semibold text-zinc-200 mb-2">Save / Undo / Redo</h3>
               <div className="space-y-2 text-sm text-zinc-400">
+                <div className="flex items-center justify-between">
+                  <span>Save changes (in forms/drawers)</span>
+                  <kbd className="px-2 py-1 text-xs font-semibold text-zinc-300 bg-zinc-800 border border-zinc-700 rounded">
+                    Ctrl / Cmd + S
+                  </kbd>
+                </div>
                 <div className="flex items-center justify-between">
                   <span>Undo last action</span>
                   <kbd className="px-2 py-1 text-xs font-semibold text-zinc-300 bg-zinc-800 border border-zinc-700 rounded">

--- a/src/components/profile/profile-tab.tsx
+++ b/src/components/profile/profile-tab.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { getTabId } from '@/hooks/use-realtime'
 import { showToast } from '@/lib/toast'
 import { getAvatarColor, getInitials } from '@/lib/utils'
@@ -83,6 +84,21 @@ export function ProfileTab({
 
   const displayAvatar = getDisplayAvatar()
   const displayName = name || user.name || ''
+
+  // Check if profile name has changed
+  const hasProfileChanges = name.trim() !== user.name
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save profile
+  useCtrlSave({
+    onSave: () => {
+      // Trigger form submit programmatically
+      const form = document.querySelector('form[data-profile-form]') as HTMLFormElement
+      if (form) {
+        form.requestSubmit()
+      }
+    },
+    enabled: hasProfileChanges && !profileLoading && !!name.trim(),
+  })
 
   const handleProfileUpdate = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -275,7 +291,7 @@ export function ProfileTab({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleProfileUpdate} className="space-y-4">
+          <form data-profile-form onSubmit={handleProfileUpdate} className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="name" className="text-zinc-300">
                 Name

--- a/src/components/projects/settings/agents-tab.tsx
+++ b/src/components/projects/settings/agents-tab.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useRepositoryConfig, useUpdateRepository } from '@/hooks/queries/use-repository'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { previewBranchName } from '@/lib/branch-utils'
 import { PERMISSIONS } from '@/lib/permissions'
@@ -108,6 +109,12 @@ export function AgentsTab({ projectId, projectKey }: AgentsTabProps) {
 
   const isPending = updateRepository.isPending
   const isDisabled = !canEditSettings || isPending
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: handleSave,
+    enabled: hasChanges && !isDisabled,
+  })
 
   if (isLoading) {
     return (

--- a/src/components/projects/settings/general-tab.tsx
+++ b/src/components/projects/settings/general-tab.tsx
@@ -20,6 +20,7 @@ import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
 import { Textarea } from '@/components/ui/textarea'
 import { useDeleteProject, useProjectDetail, useUpdateProject } from '@/hooks/queries/use-projects'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { PERMISSIONS } from '@/lib/permissions'
 import { showToast } from '@/lib/toast'
@@ -191,6 +192,12 @@ export function GeneralTab({ projectId, project }: GeneralTabProps) {
   const isValid = formData.name.trim().length > 0 && formData.key.length > 0
   const isPending = updateProject.isPending || deleteProject.isPending
   const isDisabled = !canEditSettings || isPending
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: handleSave,
+    enabled: hasChanges && isValid && !isDisabled,
+  })
 
   return (
     <div className="space-y-6">

--- a/src/components/projects/settings/hooks-tab.tsx
+++ b/src/components/projects/settings/hooks-tab.tsx
@@ -42,6 +42,7 @@ import {
   useRepositoryConfig,
   useWebhookSecret,
 } from '@/hooks/queries/use-repository'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { PERMISSIONS } from '@/lib/permissions'
 
@@ -183,6 +184,12 @@ export function HooksTab({ projectId, projectKey }: HooksTabProps) {
 
   const isDisabled = !canEditSettings
   const hasWebhookSecret = config?.hasWebhookSecret || generatedSecret
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: savePatterns,
+    enabled: patternsHaveChanges && !isDisabled,
+  })
 
   if (isLoading) {
     return (

--- a/src/components/projects/settings/repository-tab.tsx
+++ b/src/components/projects/settings/repository-tab.tsx
@@ -13,6 +13,7 @@ import {
   useRepositoryConfig,
   useUpdateRepository,
 } from '@/hooks/queries/use-repository'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { previewBranchName, validateBranchTemplate } from '@/lib/branch-utils'
 import { PERMISSIONS } from '@/lib/permissions'
@@ -246,6 +247,12 @@ export function RepositoryTab({ projectId, projectKey }: RepositoryTabProps) {
   const isPending = updateRepository.isPending
   const isDisabled = !canEditSettings || isPending
   const isValid = !branchTemplateError
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: handleSave,
+    enabled: hasChanges && isValid && !isDisabled,
+  })
 
   if (isLoading) {
     return (

--- a/src/components/tickets/ticket-detail-drawer.tsx
+++ b/src/components/tickets/ticket-detail-drawer.tsx
@@ -71,6 +71,7 @@ import {
   useUpdateLabel,
   useUpdateTicket,
 } from '@/hooks/queries/use-tickets'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { useCurrentUser, useProjectMembers } from '@/hooks/use-current-user'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { deleteTickets } from '@/lib/actions/delete-tickets'
@@ -622,6 +623,12 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
     updateTicketMutation,
     availableLabels,
   ])
+
+  // Ctrl+S / Cmd+S keyboard shortcut to save
+  useCtrlSave({
+    onSave: handleSave,
+    enabled: hasUnsavedChanges,
+  })
 
   if (!ticket) return null
 

--- a/src/hooks/use-ctrl-save.ts
+++ b/src/hooks/use-ctrl-save.ts
@@ -1,0 +1,50 @@
+'use client'
+
+import { useCallback, useEffect } from 'react'
+
+interface UseCtrlSaveOptions {
+  /**
+   * Callback to trigger when Ctrl+S (or Cmd+S on Mac) is pressed
+   */
+  onSave: () => void
+  /**
+   * Whether the save shortcut is enabled. Defaults to true.
+   * Use this to disable the shortcut when there are no changes to save.
+   */
+  enabled?: boolean
+}
+
+/**
+ * Hook to handle Ctrl+S (Windows/Linux) or Cmd+S (Mac) keyboard shortcut for saving.
+ * Prevents the browser's default "Save Page As" dialog.
+ *
+ * @example
+ * ```tsx
+ * useCtrlSave({
+ *   onSave: handleSave,
+ *   enabled: hasUnsavedChanges
+ * })
+ * ```
+ */
+export function useCtrlSave({ onSave, enabled = true }: UseCtrlSaveOptions) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Check for Ctrl+S (Windows/Linux) or Cmd+S (Mac)
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        // Always prevent default to avoid "Save Page As" dialog
+        e.preventDefault()
+
+        // Only trigger save if enabled
+        if (enabled) {
+          onSave()
+        }
+      }
+    },
+    [onSave, enabled],
+  )
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+}


### PR DESCRIPTION
## Summary
- Add `useCtrlSave` hook for handling Ctrl+S / Cmd+S keyboard shortcuts
- Integrate save shortcut with ticket drawer, settings forms, and profile pages
- Prevents browser's default "Save Page As" dialog
- Updated keyboard shortcuts cheatsheet to document the new shortcut

## Applicable areas
- Ticket drawer (save ticket changes)
- Project settings forms (general, repository, agents, hooks)
- Admin settings forms (uploads, branding, email, board, role permissions)
- Profile settings (display name)

## Test plan
- [ ] Open ticket drawer, make changes, press Ctrl+S → saves
- [ ] Open project settings, make changes, press Ctrl+S → saves
- [ ] Open admin settings, make changes, press Ctrl+S → saves
- [ ] Open profile settings, change name, press Ctrl+S → saves
- [ ] Verify Cmd+S works on Mac
- [ ] Press `?` to open keyboard shortcuts, verify Ctrl+S is documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)