### PR TITLE
fix(ui): correct settings link URL and add Ctrl+S to create ticket form (PUNT-147, PUNT-152)

### DIFF
--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -253,7 +253,7 @@ function NoApiKeyMessage() {
         <p className="mt-1 text-sm text-zinc-400">Add your Anthropic API key to use Claude Chat</p>
       </div>
       <Button asChild className="bg-purple-600 hover:bg-purple-700">
-        <Link href="/settings?tab=integrations">Go to Settings</Link>
+        <Link href="/profile?tab=integrations">Go to Settings</Link>
       </Button>
     </div>
   )

--- a/src/components/tickets/create-ticket-dialog.tsx
+++ b/src/components/tickets/create-ticket-dialog.tsx
@@ -22,6 +22,7 @@ import {
   useProjectSprints,
   useUpdateLabel,
 } from '@/hooks/queries/use-tickets'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { useCurrentUser, useProjectMembers } from '@/hooks/use-current-user'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { PERMISSIONS } from '@/lib/permissions'
@@ -348,6 +349,11 @@ export function CreateTicketDialog() {
   ])
 
   const isValid = formData.title.trim().length > 0 && !!projectId
+
+  useCtrlSave({
+    onSave: handleSubmit,
+    enabled: createTicketOpen && isValid && !isSubmitting,
+  })
 
   return (
     <Dialog open={createTicketOpen} onOpenChange={setCreateTicketOpen}>


### PR DESCRIPTION
## Summary
- Chat panel "Go to Settings" button now navigates to `/profile?tab=integrations` instead of `/settings?tab=integrations` (PUNT-147 followup)
- Create ticket dialog now supports `Ctrl+S` / `Cmd+S` to submit when the form is valid and not already submitting (PUNT-152 followup)

## Test plan
- [ ] Open Claude chat sidebar when unauthenticated, verify "Go to Settings" links to `/profile?tab=integrations`
- [ ] Open Create Ticket dialog, fill in title, press Ctrl+S — ticket should be created
- [ ] Open Create Ticket dialog with empty title, press Ctrl+S — nothing should happen

🤖 Generated with [Claude Code](https://claude.com/claude-code)