### PR TITLE
feat(keyboard): add Ctrl+S to sprint and project dialogs (PUNT-152)

### DIFF
--- a/src/components/projects/create-project-dialog.tsx
+++ b/src/components/projects/create-project-dialog.tsx
@@ -17,6 +17,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { useCreateProject } from '@/hooks/queries/use-projects'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { LABEL_COLORS } from '@/lib/constants'
 import { useUIStore } from '@/stores/ui-store'
 
@@ -124,6 +125,11 @@ export function CreateProjectDialog() {
   }, [formData, createProject, handleClose, setActiveProjectId, router])
 
   const isValid = formData.name.trim().length > 0 && formData.key.trim().length >= 2
+
+  useCtrlSave({
+    onSave: handleSubmit,
+    enabled: createProjectOpen && isValid && !createProject.isPending,
+  })
 
   return (
     <Dialog open={createProjectOpen} onOpenChange={setCreateProjectOpen}>

--- a/src/components/sprints/sprint-complete-dialog.tsx
+++ b/src/components/sprints/sprint-complete-dialog.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { useCompleteSprint, useProjectSprints, useSprintDetail } from '@/hooks/queries/use-sprints'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { isCompletedColumn } from '@/lib/sprint-utils'
 import { useBoardStore } from '@/stores/board-store'
 import { useSprintStore } from '@/stores/sprint-store'
@@ -112,6 +113,11 @@ export function SprintCompleteDialog({ projectId }: SprintCompleteDialogProps) {
       },
     )
   }, [sprintCompleteId, action, targetSprintId, createNextSprint, completeSprint, handleClose])
+
+  useCtrlSave({
+    onSave: handleSubmit,
+    enabled: sprintCompleteOpen && !!sprintCompleteId && !completeSprint.isPending,
+  })
 
   if (!sprintCompleteId) return null
 

--- a/src/components/sprints/sprint-create-dialog.tsx
+++ b/src/components/sprints/sprint-create-dialog.tsx
@@ -18,6 +18,7 @@ import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Textarea } from '@/components/ui/textarea'
 import { useCreateSprint, useSprintSettings } from '@/hooks/queries/use-sprints'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { cn } from '@/lib/utils'
 import { useUIStore } from '@/stores/ui-store'
 
@@ -101,6 +102,11 @@ export function SprintCreateDialog({ projectId }: SprintCreateDialogProps) {
   }, [formData, createSprint, handleClose])
 
   const isValid = formData.name.trim().length > 0
+
+  useCtrlSave({
+    onSave: handleSubmit,
+    enabled: sprintCreateOpen && isValid && !createSprint.isPending,
+  })
 
   return (
     <Dialog open={sprintCreateOpen} onOpenChange={handleOpenChange}>

--- a/src/components/sprints/sprint-edit-dialog.tsx
+++ b/src/components/sprints/sprint-edit-dialog.tsx
@@ -18,6 +18,7 @@ import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Textarea } from '@/components/ui/textarea'
 import { useProjectSprints, useUpdateSprint } from '@/hooks/queries/use-sprints'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { cn } from '@/lib/utils'
 import { useUIStore } from '@/stores/ui-store'
 
@@ -112,6 +113,11 @@ export function SprintEditDialog({ projectId }: SprintEditDialogProps) {
       formData.endDate?.getTime() !==
         (sprint.endDate ? new Date(sprint.endDate).getTime() : undefined) ||
       formData.budget !== (sprint.budget?.toString() || ''))
+
+  useCtrlSave({
+    onSave: handleSubmit,
+    enabled: sprintEditOpen && isValid && !!hasChanges && !updateSprint.isPending,
+  })
 
   return (
     <Dialog open={sprintEditOpen} onOpenChange={handleOpenChange}>

--- a/src/components/sprints/sprint-start-dialog.tsx
+++ b/src/components/sprints/sprint-start-dialog.tsx
@@ -21,6 +21,7 @@ import {
   useSprintSettings,
   useStartSprint,
 } from '@/hooks/queries/use-sprints'
+import { useCtrlSave } from '@/hooks/use-ctrl-save'
 import { cn } from '@/lib/utils'
 import { useUIStore } from '@/stores/ui-store'
 
@@ -81,9 +82,14 @@ export function SprintStartDialog({ projectId }: SprintStartDialogProps) {
     )
   }, [sprintStartId, startDate, endDate, startSprint, handleClose])
 
-  if (!sprintStartId) return null
-
   const hasActiveSprint = !!activeSprint
+
+  useCtrlSave({
+    onSave: handleSubmit,
+    enabled: sprintStartOpen && !!sprintStartId && !hasActiveSprint && !startSprint.isPending,
+  })
+
+  if (!sprintStartId) return null
 
   return (
     <Dialog open={sprintStartOpen} onOpenChange={(open) => !open && handleClose()}>


### PR DESCRIPTION
## Summary
- Add `useCtrlSave` hook to sprint create, edit, start, and complete dialogs
- Add `useCtrlSave` hook to create project dialog
- Each dialog only enables the shortcut when the form is valid and not already submitting

## Test plan
- [ ] Create Sprint dialog: fill name, press Ctrl+S — sprint created
- [ ] Edit Sprint dialog: change a field, press Ctrl+S — changes saved
- [ ] Start Sprint dialog: press Ctrl+S — sprint starts (blocked if active sprint exists)
- [ ] Complete Sprint dialog: press Ctrl+S — sprint completed
- [ ] Create Project dialog: fill name + key, press Ctrl+S — project created
- [ ] Verify browser "Save Page As" does not appear in any dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)