### PR TITLE
fix(preferences): wrap useSearchParams in Suspense boundary

### DIFF
--- a/src/app/(app)/preferences/page.tsx
+++ b/src/app/(app)/preferences/page.tsx
@@ -3,7 +3,7 @@
 import { Bell, Palette, Settings, Sliders } from 'lucide-react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { useEffect, useRef } from 'react'
+import { Suspense, useEffect, useRef } from 'react'
 import { PageHeader } from '@/components/common'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -26,6 +26,14 @@ function isValidTab(tab: string | null): tab is PreferencesTab {
 }
 
 export default function PreferencesPage() {
+  return (
+    <Suspense>
+      <PreferencesContent />
+    </Suspense>
+  )
+}
+
+function PreferencesContent() {
   const {
     openSinglePastedTicket,
     setOpenSinglePastedTicket,


### PR DESCRIPTION
## Summary
- Wraps `useSearchParams()` in the preferences page with a `<Suspense>` boundary to fix Next.js build failure
- Extracts page content into a `PreferencesContent` component wrapped by `Suspense` in the default export

## Test plan
- [x] Verify `pnpm build` completes without errors
- [x] Verify preferences page tabs still work correctly (general, notifications, appearance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)