### PR TITLE
feat(chat): add button to hide chat sidebar (PUNT-188)

### DIFF
--- a/src/app/(app)/preferences/page.tsx
+++ b/src/app/(app)/preferences/page.tsx
@@ -63,6 +63,8 @@ function PreferencesContent() {
     setHideColorRemovalWarning,
     enableParticleAnimations,
     setEnableParticleAnimations,
+    showChatPanel,
+    setShowChatPanel,
   } = useSettingsStore()
 
   const projects = useProjectsStore((s) => s.projects)
@@ -585,6 +587,35 @@ function PreferencesContent() {
                     id="enable-particle-animations"
                     checked={enableParticleAnimations}
                     onCheckedChange={(checked) => setEnableParticleAnimations(checked === true)}
+                    className="data-[state=checked]:bg-amber-600"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Chat Panel */}
+            <Card className="border-zinc-800 bg-zinc-900/50">
+              <CardHeader>
+                <CardTitle className="text-zinc-100">Chat Panel</CardTitle>
+                <CardDescription className="text-zinc-500">
+                  Control the Claude Chat panel visibility
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="flex items-start justify-between space-x-4">
+                  <div className="flex-1 space-y-1">
+                    <Label htmlFor="enable-chat-panel" className="text-zinc-300">
+                      Enable chat panel
+                    </Label>
+                    <p className="text-sm text-zinc-500">
+                      Show the Claude Chat panel and floating action button. When disabled, the chat
+                      panel and FAB will be hidden from the interface.
+                    </p>
+                  </div>
+                  <Switch
+                    id="enable-chat-panel"
+                    checked={showChatPanel}
+                    onCheckedChange={(checked) => setShowChatPanel(checked === true)}
                     className="data-[state=checked]:bg-amber-600"
                   />
                 </div>

--- a/src/components/chat/chat-fab.tsx
+++ b/src/components/chat/chat-fab.tsx
@@ -2,10 +2,16 @@
 
 import { MessageSquareIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useSettingsStore } from '@/stores/settings-store'
 import { useUIStore } from '@/stores/ui-store'
 
 export function ChatFAB() {
   const { chatPanelOpen, toggleChatPanel } = useUIStore()
+  const showChatPanel = useSettingsStore((s) => s.showChatPanel)
+
+  if (!showChatPanel) {
+    return null
+  }
 
   return (
     <button

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQueryClient } from '@tanstack/react-query'
-import { BotIcon, KeyIcon, Loader2Icon } from 'lucide-react'
+import { BotIcon, EyeOffIcon, KeyIcon, Loader2Icon } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
@@ -22,6 +22,7 @@ import { useCurrentUser } from '@/hooks/use-current-user'
 import { getHelpText, type SlashCommand } from '@/lib/chat/commands'
 import { showToast } from '@/lib/toast'
 import { transformMetadataToToolCalls, useChatStore } from '@/stores/chat-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import { useUIStore } from '@/stores/ui-store'
 import { ChatInput } from './chat-input'
 import { type ChatMessage, ChatMessageComponent } from './chat-message'
@@ -39,6 +40,8 @@ interface StreamEvent {
 
 export function ChatPanel() {
   const { chatPanelOpen, setChatPanelOpen, chatContext } = useUIStore()
+  const showChatPanel = useSettingsStore((s) => s.showChatPanel)
+  const setShowChatPanel = useSettingsStore((s) => s.setShowChatPanel)
   const {
     currentSessionId,
     setCurrentSessionId,
@@ -301,6 +304,12 @@ export function ChatPanel() {
     setIsLoading(false)
   }, [clearMessages])
 
+  const handleDismiss = useCallback(() => {
+    setChatPanelOpen(false)
+    setShowChatPanel(false)
+    showToast.info('Chat panel hidden. Re-enable in Preferences > Appearance.')
+  }, [setChatPanelOpen, setShowChatPanel])
+
   // Handle slash commands
   const handleCommand = useCallback(
     (command: SlashCommand, args?: string) => {
@@ -361,6 +370,10 @@ export function ChatPanel() {
     ],
   )
 
+  if (!showChatPanel) {
+    return null
+  }
+
   return (
     <Sheet open={chatPanelOpen} onOpenChange={setChatPanelOpen}>
       <SheetContent side="right" className="flex w-full flex-col p-0 sm:max-w-md">
@@ -386,6 +399,15 @@ export function ChatPanel() {
                 Clear
               </Button>
             )}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleDismiss}
+              className="h-8 w-8 text-zinc-400 hover:text-zinc-100 shrink-0"
+              title="Hide chat panel"
+            >
+              <EyeOffIcon className="h-4 w-4" />
+            </Button>
           </div>
         </SheetHeader>
 

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -62,6 +62,10 @@ interface SettingsState {
   // Particle animations for celebrations and warnings
   enableParticleAnimations: boolean
   setEnableParticleAnimations: (value: boolean) => void
+
+  // Chat panel visibility
+  showChatPanel: boolean
+  setShowChatPanel: (value: boolean) => void
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -153,6 +157,10 @@ export const useSettingsStore = create<SettingsState>()(
       // Particle animations (on by default)
       enableParticleAnimations: true,
       setEnableParticleAnimations: (value) => set({ enableParticleAnimations: value }),
+
+      // Chat panel visibility (on by default)
+      showChatPanel: true,
+      setShowChatPanel: (value) => set({ showChatPanel: value }),
     }),
     {
       name: 'punt-settings',


### PR DESCRIPTION
## Summary
- Add `showChatPanel` setting to settings-store with default value `true` to maintain current behavior
- Add Hide button (eye-off icon) in chat panel header that dismisses the panel and disables it
- Both `ChatFAB` and `ChatPanel` return `null` when `showChatPanel` is false
- Add "Chat Panel" card in Preferences > Appearance tab with toggle to re-enable the panel
- Show toast notification when hiding: "Chat panel hidden. Re-enable in Preferences > Appearance."

## Test plan
- [x] Open the chat panel using the FAB
- [x] Click the Hide button (eye-off icon) in the panel header
- [x] Verify toast notification appears with instructions to re-enable
- [x] Verify the FAB disappears and chat panel closes
- [x] Navigate to Preferences > Appearance tab
- [x] Verify "Chat Panel" card appears with toggle
- [x] Toggle the switch on to re-enable
- [x] Verify FAB reappears
- [x] Verify chat panel can be opened again

🤖 Generated with [Claude Code](https://claude.ai/code)