### PR TITLE
feat(sprints): add ability to reopen completed sprint (PUNT-192)

### DIFF
--- a/src/app/api/projects/[projectId]/sprints/[sprintId]/reopen/route.ts
+++ b/src/app/api/projects/[projectId]/sprints/[sprintId]/reopen/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from 'next/server'
+import { badRequestError, handleApiError, notFoundError } from '@/lib/api-utils'
+import { requireAuth, requirePermission, requireProjectByKey } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { projectEvents } from '@/lib/events'
+import { PERMISSIONS } from '@/lib/permissions'
+import { SPRINT_SELECT_FULL } from '@/lib/prisma-selects'
+
+type RouteParams = { params: Promise<{ projectId: string; sprintId: string }> }
+
+/**
+ * POST /api/projects/[projectId]/sprints/[sprintId]/reopen - Reopen a completed sprint
+ * Requires SPRINTS_MANAGE permission
+ * - Only works on completed sprints
+ * - Fails if there's already an active sprint
+ * - Sets sprint status back to 'active'
+ */
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const user = await requireAuth()
+    const { projectId: projectKey, sprintId } = await params
+    const projectId = await requireProjectByKey(projectKey)
+
+    await requirePermission(user.id, projectId, PERMISSIONS.SPRINTS_MANAGE)
+
+    // Check if sprint exists and is completed
+    const sprint = await db.sprint.findFirst({
+      where: { id: sprintId, projectId },
+      select: { status: true },
+    })
+
+    if (!sprint) {
+      return notFoundError('Sprint')
+    }
+
+    if (sprint.status !== 'completed') {
+      return badRequestError('Can only reopen a completed sprint')
+    }
+
+    // Check if there's already an active sprint
+    const activeSprint = await db.sprint.findFirst({
+      where: { projectId, status: 'active' },
+      select: { id: true, name: true },
+    })
+
+    if (activeSprint) {
+      return badRequestError(
+        `Another sprint "${activeSprint.name}" is already active. Complete it first before reopening this sprint.`,
+      )
+    }
+
+    // Reopen the sprint
+    const updatedSprint = await db.sprint.update({
+      where: { id: sprintId },
+      data: {
+        status: 'active',
+        // Clear completion metadata since sprint is no longer completed
+        completedAt: null,
+        completedById: null,
+      },
+      select: SPRINT_SELECT_FULL,
+    })
+
+    // Emit sprint reopened event
+    const tabId = request.headers.get('X-Tab-Id') || undefined
+    projectEvents.emitSprintEvent({
+      type: 'sprint.reopened',
+      projectId,
+      sprintId,
+      userId: user.id,
+      tabId,
+      timestamp: Date.now(),
+    })
+
+    return NextResponse.json(updatedSprint)
+  } catch (error) {
+    return handleApiError(error, 'reopen sprint')
+  }
+}

--- a/src/components/sprints/sprint-card.tsx
+++ b/src/components/sprints/sprint-card.tsx
@@ -8,6 +8,7 @@ import {
   MoreHorizontal,
   Pencil,
   Play,
+  RotateCcw,
   Target,
   Trash2,
 } from 'lucide-react'
@@ -20,6 +21,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { useReopenSprint } from '@/hooks/queries/use-sprints'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { PERMISSIONS } from '@/lib/permissions'
 import {
@@ -45,6 +47,7 @@ interface SprintCardProps {
 export function SprintCard({ sprint, projectId, ticketCount = 0, onDelete }: SprintCardProps) {
   const { openSprintEdit, openSprintStart, openSprintComplete } = useUIStore()
   const canManageSprints = useHasPermission(projectId, PERMISSIONS.SPRINTS_MANAGE)
+  const reopenSprintMutation = useReopenSprint(projectId)
 
   const isPlanning = sprint.status === 'planning'
   const isActive = sprint.status === 'active'
@@ -124,6 +127,17 @@ export function SprintCard({ sprint, projectId, ticketCount = 0, onDelete }: Spr
                 >
                   <CheckCircle2 className="h-4 w-4 mr-2" />
                   Complete Sprint
+                </DropdownMenuItem>
+              )}
+
+              {isCompleted && (
+                <DropdownMenuItem
+                  onClick={() => reopenSprintMutation.mutate(sprint.id)}
+                  disabled={reopenSprintMutation.isPending}
+                  className="text-zinc-300 focus:bg-zinc-800 focus:text-zinc-100"
+                >
+                  <RotateCcw className="h-4 w-4 mr-2" />
+                  Reopen Sprint
                 </DropdownMenuItem>
               )}
 

--- a/src/hooks/queries/use-sprints.ts
+++ b/src/hooks/queries/use-sprints.ts
@@ -277,6 +277,29 @@ export function useCompleteSprint(projectId: string) {
 }
 
 /**
+ * Reopen a completed sprint
+ */
+export function useReopenSprint(projectId: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (sprintId: string) => {
+      const provider = getDataProvider(getTabId())
+      // Provider returns SprintSummary but API actually returns SprintWithMetrics
+      return provider.reopenSprint(projectId, sprintId) as Promise<SprintWithMetrics>
+    },
+    onSuccess: () => {
+      showToast.success('Sprint reopened')
+      queryClient.invalidateQueries({ queryKey: sprintKeys.byProject(projectId) })
+      queryClient.invalidateQueries({ queryKey: sprintKeys.active(projectId) })
+    },
+    onError: (err) => {
+      showToast.error(err.message)
+    },
+  })
+}
+
+/**
  * Extend a sprint
  */
 export function useExtendSprint(projectId: string) {

--- a/src/lib/data-provider/api-provider.ts
+++ b/src/lib/data-provider/api-provider.ts
@@ -283,6 +283,13 @@ export class APIDataProvider implements DataProvider {
     })
   }
 
+  async reopenSprint(projectId: string, sprintId: string): Promise<SprintSummary> {
+    return this.fetchJson(`/api/projects/${projectId}/sprints/${sprintId}/reopen`, {
+      method: 'POST',
+      body: JSON.stringify({}),
+    })
+  }
+
   async getSprintSettings(projectId: string): Promise<SprintSettings> {
     return this.fetchJson(`/api/projects/${projectId}/sprints/settings`)
   }

--- a/src/lib/data-provider/demo-provider.ts
+++ b/src/lib/data-provider/demo-provider.ts
@@ -391,6 +391,29 @@ export class DemoDataProvider implements DataProvider {
     return updated
   }
 
+  async reopenSprint(projectId: string, sprintId: string): Promise<SprintSummary> {
+    const sprint = demoStorage.getSprints(projectId).find((s) => s.id === sprintId)
+    if (!sprint) throw new Error('Sprint not found')
+
+    if (sprint.status !== 'completed') {
+      throw new Error('Can only reopen a completed sprint')
+    }
+
+    // Check if there's already an active sprint
+    const activeSprint = demoStorage.getActiveSprint(projectId)
+    if (activeSprint) {
+      throw new Error(
+        `Another sprint "${activeSprint.name}" is already active. Complete it first before reopening this sprint.`,
+      )
+    }
+
+    const updated = demoStorage.updateSprint(projectId, sprintId, {
+      status: 'active',
+    })
+    if (!updated) throw new Error('Sprint not found')
+    return updated
+  }
+
   async getSprintSettings(_projectId: string): Promise<SprintSettings> {
     // Return default sprint settings for demo mode
     return {

--- a/src/lib/data-provider/types.ts
+++ b/src/lib/data-provider/types.ts
@@ -267,6 +267,7 @@ export interface DataProvider {
     data: CompleteSprintInput,
   ): Promise<SprintSummary>
   extendSprint(projectId: string, sprintId: string, data: ExtendSprintInput): Promise<SprintSummary>
+  reopenSprint(projectId: string, sprintId: string): Promise<SprintSummary>
   getSprintSettings(projectId: string): Promise<SprintSettings>
   updateSprintSettings(projectId: string, data: Partial<SprintSettings>): Promise<SprintSettings>
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -38,6 +38,7 @@ export type SprintEventType =
   | 'sprint.deleted'
   | 'sprint.started'
   | 'sprint.completed'
+  | 'sprint.reopened'
 
 /**
  * Event types for user profile operations


### PR DESCRIPTION
## Summary
- Adds a new "Reopen Sprint" action for completed sprints that returns them to active status
- Includes API endpoint, data providers, mutation hook, and UI integration
- Validates that no other sprint is already active before allowing reopen

## Test plan
- [x] Complete a sprint with some tickets
- [ ] Verify "Reopen Sprint" appears in the dropdown menu for completed sprints
- [ ] Click "Reopen Sprint" and verify the sprint status changes to "active"
- [ ] Verify attempting to reopen when another sprint is active shows an error
- [ ] Verify the sprint card updates correctly with active sprint styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)