### PR TITLE
fix(tickets): force MDXEditor remount when description changes (PUNT-105)

### DIFF
--- a/src/components/tickets/markdown-viewer.tsx
+++ b/src/components/tickets/markdown-viewer.tsx
@@ -138,6 +138,14 @@ export const MarkdownViewer = React.memo(function MarkdownViewer({
     return linkifyMentions(linkifyTicketReferences(trimmed))
   }, [markdown])
 
+  // Generate a stable key based on markdown content to force MDXEditor remount when content changes.
+  // MDXEditor maintains internal state that doesn't sync with prop changes, so we need to remount
+  // when the markdown actually changes (e.g., after saving a description update).
+  const editorKey = useMemo(() => {
+    const content = processedMarkdown || ''
+    return `${content.length}-${content.substring(0, 100)}`
+  }, [processedMarkdown])
+
   // Show loading placeholder during SSR to prevent hydration mismatch
   if (!isMounted) {
     return <div className={`text-sm text-zinc-300 ${className}`}>{markdown}</div>
@@ -158,6 +166,7 @@ export const MarkdownViewer = React.memo(function MarkdownViewer({
       }}
     >
       <MDXEditor
+        key={editorKey}
         markdown={processedMarkdown}
         readOnly
         plugins={plugins}


### PR DESCRIPTION
## Summary
- Fix issue where users had to edit a description twice for the save to appear without refreshing
- MDXEditor maintains internal state that doesn't sync with prop changes
- Added `key` prop to MDXEditor based on markdown content to force remount when content changes

## Root Cause
`MarkdownViewer` uses `MDXEditor` in read-only mode to display ticket descriptions. When the description is saved:
1. The mutation updates the database
2. Optimistic update changes the store
3. `MarkdownViewer` receives new `markdown` prop
4. But MDXEditor's internal state still shows the old content

## Solution
Added a `key` prop to MDXEditor based on markdown content (length + first 100 chars). When the markdown changes, React sees a different key and remounts the component with the new content.

## Test plan
- [x] Edit a ticket description in the drawer
- [x] Save the description
- [x] Verify the saved content appears immediately in the viewer without requiring a second edit or page refresh

🤖 Generated with [Claude Code](https://claude.ai/code)