### PR TITLE
fix(demo): handle createdAt type conversion in demo provider

### DIFF
--- a/src/lib/data-provider/demo-provider.ts
+++ b/src/lib/data-provider/demo-provider.ts
@@ -163,12 +163,20 @@ export class DemoDataProvider implements DataProvider {
       ? allUsers.find((u) => u.id === data.reporterId) || DEMO_USER_SUMMARY
       : DEMO_USER_SUMMARY
 
+    // Convert createdAt to Date if provided (for undo/restore operations)
+    const createdAt = data.createdAt
+      ? data.createdAt instanceof Date
+        ? data.createdAt
+        : new Date(data.createdAt)
+      : undefined
+
     return demoStorage.createTicket(projectId, data.columnId, {
       ...data,
       labels,
       sprint,
       assignee,
       creator,
+      createdAt,
     })
   }
 


### PR DESCRIPTION
## Summary
- Fix TypeScript build error introduced by PR #237 (PUNT-164)
- Convert `createdAt` from `Date | string | null` to `Date | undefined` when calling `demoStorage.createTicket()`

## Test plan
- [x] Build passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)