### PR TITLE
feat(comments): add markdown rendering to ticket comments (PUNT-189)

### DIFF
--- a/src/components/tickets/comments-section.tsx
+++ b/src/components/tickets/comments-section.tsx
@@ -27,6 +27,7 @@ import { useCurrentUser } from '@/hooks/use-current-user'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { PERMISSIONS } from '@/lib/permissions'
 import { cn, getAvatarColor, getInitials } from '@/lib/utils'
+import { MarkdownViewer } from './markdown-viewer'
 
 interface CommentsSectionProps {
   projectId: string
@@ -266,9 +267,9 @@ export const CommentsSection = forwardRef<CommentsSectionRef, CommentsSectionPro
                       </div>
                     </div>
                   ) : (
-                    <p className="mt-1 text-sm text-zinc-300 whitespace-pre-wrap break-words">
-                      {comment.content}
-                    </p>
+                    <div className="mt-1 break-words">
+                      <MarkdownViewer markdown={comment.content} />
+                    </div>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Add markdown rendering support to ticket comments using the existing `MarkdownViewer` component
- Comments now support formatting: bold, italic, code, links, lists, headings, blockquotes, and code blocks with syntax highlighting
- Ticket references (e.g., PUNT-123) are automatically linked and @mentions are highlighted

## Test plan
- [x] Create a comment with markdown formatting (e.g., `**bold**, *italic*, \`code\``)
- [x] Verify code blocks render with syntax highlighting
- [x] Test that ticket references like PUNT-123 become clickable links
- [x] Verify existing comment functionality (edit, delete, timestamps) still works
- [x] Confirm no XSS vulnerabilities with malicious content (handled by MDXEditor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)