### PR TITLE
fix(mcp): improve credentials error messaging and security warnings (PUNT-182)

### DIFF
--- a/mcp/src/api-client.ts
+++ b/mcp/src/api-client.ts
@@ -13,7 +13,7 @@
  * - Cross-platform support
  */
 
-import { resolveApiKey, resolveApiUrl } from './credentials.js'
+import { getCredentialsFilePath, resolveApiKey, resolveApiUrl } from './credentials.js'
 
 interface ApiResponse<T> {
   data?: T
@@ -39,6 +39,18 @@ async function apiRequest<T>(
   path: string,
   body?: unknown,
 ): Promise<ApiResponse<T>> {
+  const apiKey = resolveApiKey()
+  if (!apiKey) {
+    const credPath = getCredentialsFilePath()
+    return {
+      error:
+        'MCP credentials not configured. Either:\n' +
+        `1. Create credentials file at ${credPath}\n` +
+        '2. Set PUNT_API_KEY and PUNT_API_URL environment variables\n' +
+        'See: https://github.com/your-org/punt#mcp-server for setup instructions',
+    }
+  }
+
   const baseUrl = resolveApiUrl()
   const url = `${baseUrl}${path}`
 
@@ -47,7 +59,7 @@ async function apiRequest<T>(
       method,
       headers: {
         'Content-Type': 'application/json',
-        'X-MCP-API-Key': resolveApiKey(),
+        'X-MCP-API-Key': apiKey,
       },
       body: body ? JSON.stringify(body) : undefined,
     })


### PR DESCRIPTION
## Summary
Follow-up DX improvements for PR #255 (PUNT-182):
- Show actionable error message when no MCP credentials are configured instead of silent 401s
- Warn when credentials file has world-readable permissions on Unix systems

## Test plan
- [x] No credentials configured → clear error message with setup instructions
- [x] Credentials file with 644 permissions → warning on stderr
- [x] Credentials file with 600 permissions → no warning
- [x] Windows → no permission check (platform guard)
- [x] Valid credentials → no changes in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)