### PR TITLE
fix(search): autofocus and trigger autosuggest when activating PQL mode (PUNT-220)

### DIFF
--- a/src/components/backlog/backlog-filters.tsx
+++ b/src/components/backlog/backlog-filters.tsx
@@ -1193,6 +1193,7 @@ export function BacklogFilters({
               }}
               error={queryError ?? null}
               dynamicValues={dynamicValues}
+              autoFocus
             />
           </div>
           {/* Exit PQL mode button */}

--- a/src/components/backlog/query-input.tsx
+++ b/src/components/backlog/query-input.tsx
@@ -43,6 +43,8 @@ interface QueryInputProps {
   error: string | null
   /** Dynamic values for context-aware autocomplete */
   dynamicValues?: DynamicValues
+  /** Auto-focus input and open autocomplete on mount */
+  autoFocus?: boolean
 }
 
 // ============================================================================
@@ -342,7 +344,14 @@ function getExistingInListValues(text: string, position: number): Set<string> {
   return values
 }
 
-export function QueryInput({ value, onChange, onClear, error, dynamicValues }: QueryInputProps) {
+export function QueryInput({
+  value,
+  onChange,
+  onClear,
+  error,
+  dynamicValues,
+  autoFocus,
+}: QueryInputProps) {
   const inputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [showAutocomplete, setShowAutocomplete] = useState(false)
@@ -380,6 +389,16 @@ export function QueryInput({ value, onChange, onClear, error, dynamicValues }: Q
   useEffect(() => {
     updateAutocomplete()
   }, [value, updateAutocomplete])
+
+  // Auto-focus input and open autocomplete on mount when autoFocus is true
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only run on mount
+  useEffect(() => {
+    if (autoFocus && inputRef.current) {
+      inputRef.current.focus()
+      setShowAutocomplete(true)
+      updateAutocomplete()
+    }
+  }, [])
 
   // Check if cursor position is inside an IN list (between "IN (" and ")")
   const isInsideInList = useCallback((text: string, position: number): boolean => {

--- a/src/components/sprints/sprint-backlog-view.tsx
+++ b/src/components/sprints/sprint-backlog-view.tsx
@@ -778,6 +778,7 @@ export function SprintBacklogView({
                 onClear={() => setQueryText('')}
                 error={queryError}
                 dynamicValues={dynamicValues}
+                autoFocus
               />
             )}
           </div>


### PR DESCRIPTION
## Summary
- When clicking the `</>` PQL mode button in the search bar, the query input now automatically focuses and opens the autocomplete dropdown showing available field suggestions
- Applied to both the backlog view and sprint backlog view PQL inputs
- Added an `autoFocus` prop to `QueryInput` component that triggers focus + autocomplete on mount

## Test plan
- [x] Navigate to the backlog view
- [x] Click the `</>` button in the search bar to switch to PQL mode
- [x] Verify the cursor is placed in the input field automatically
- [x] Verify the autocomplete dropdown appears showing available PQL fields
- [x] Navigate to the sprint planning view and repeat the above steps
- [x] Verify that typing immediately after toggling PQL mode works without an additional click

🤖 Generated with [Claude Code](https://claude.com/claude-code)