### PR TITLE
fix(profile): replace Integrations tab with separate MCP and Claude tabs (PUNT-210)

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: Request) {
       const providerName = provider.name
       return new Response(
         JSON.stringify({
-          error: `${providerName} is not configured. Set it up in Profile > Integrations.`,
+          error: `${providerName} is not configured. Set it up in Profile > Claude Chat.`,
         }),
         { status: 400, headers: { 'Content-Type': 'application/json' } },
       )

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -461,7 +461,7 @@ function NotConfiguredMessage({ onNavigate }: { onNavigate: () => void }) {
 
   const handleClick = () => {
     onNavigate()
-    router.push('/profile?tab=integrations')
+    router.push('/profile?tab=claude-chat')
   }
 
   return (

--- a/src/components/layout/sidebar-content.tsx
+++ b/src/components/layout/sidebar-content.tsx
@@ -18,7 +18,6 @@ import {
   Mail,
   Palette,
   Pencil,
-  Plug,
   Plus,
   RefreshCw,
   Settings,
@@ -27,6 +26,7 @@ import {
   SlidersHorizontal,
   Tag,
   Target,
+  Terminal,
   Trash2,
   TrendingDown,
   Upload,
@@ -303,19 +303,34 @@ export function SidebarContent({
                   Security
                 </Button>
               </Link>
-              <Link href="/profile?tab=integrations" onClick={handleLinkClick}>
+              <Link href="/profile?tab=mcp" onClick={handleLinkClick}>
                 <Button
                   variant="ghost"
                   size="sm"
                   className={cn(
                     'w-full justify-start gap-2 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/50 h-7 text-xs',
                     pathname === '/profile' &&
-                      searchParams.get('tab') === 'integrations' &&
+                      searchParams.get('tab') === 'mcp' &&
                       'bg-zinc-800/50 text-zinc-100',
                   )}
                 >
-                  <Plug className="h-3 w-3" />
-                  Integrations
+                  <Terminal className="h-3 w-3" />
+                  MCP
+                </Button>
+              </Link>
+              <Link href="/profile?tab=claude-chat" onClick={handleLinkClick}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'w-full justify-start gap-2 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/50 h-7 text-xs',
+                    pathname === '/profile' &&
+                      searchParams.get('tab') === 'claude-chat' &&
+                      'bg-zinc-800/50 text-zinc-100',
+                  )}
+                >
+                  <Bot className="h-3 w-3" />
+                  Claude Chat
                 </Button>
               </Link>
             </div>

--- a/src/lib/chat/providers/anthropic.ts
+++ b/src/lib/chat/providers/anthropic.ts
@@ -34,7 +34,7 @@ export class AnthropicProvider implements ChatProvider {
     if (!user?.anthropicApiKey) {
       onEvent({
         type: 'error',
-        error: 'No Anthropic API key configured. Add your key in Profile > Integrations.',
+        error: 'No Anthropic API key configured. Add your key in Profile > Claude Chat.',
       })
       return
     }
@@ -126,7 +126,7 @@ export class AnthropicProvider implements ChatProvider {
       // Map specific errors to user-friendly messages
       let userMessage = errorMessage
       if (errorMessage.includes('Invalid API Key')) {
-        userMessage = 'Invalid Anthropic API key. Please check your key in Profile > Integrations.'
+        userMessage = 'Invalid Anthropic API key. Please check your key in Profile > Claude Chat.'
       } else if (errorMessage.includes('rate_limit')) {
         userMessage = 'Rate limit exceeded. Please wait a moment and try again.'
       }

--- a/src/lib/chat/providers/claude-cli.ts
+++ b/src/lib/chat/providers/claude-cli.ts
@@ -101,7 +101,7 @@ export class ClaudeCliProvider implements ChatProvider {
     if (!user?.claudeSessionEncrypted) {
       onEvent({
         type: 'error',
-        error: 'No Claude session configured. Upload your credentials in Profile > Integrations.',
+        error: 'No Claude session configured. Upload your credentials in Profile > Claude Chat.',
       })
       return
     }


### PR DESCRIPTION
## Summary
- Replaced the outdated "Integrations" entry in the profile sidebar navigation with separate "MCP" and "Claude Chat" entries, matching the profile page's actual tab structure
- Updated the chat panel's "not configured" redirect from `/profile?tab=integrations` to `/profile?tab=claude-chat`
- Updated error messages in chat providers (Anthropic, Claude CLI) and the chat API route to reference "Profile > Claude Chat" instead of "Profile > Integrations"

## Test plan
- [x] Open the sidebar and expand the Profile section - verify "MCP" and "Claude Chat" entries appear instead of "Integrations"
- [x] Click "MCP" in the sidebar - verify it navigates to `/profile?tab=mcp` and highlights correctly
- [x] Click "Claude Chat" in the sidebar - verify it navigates to `/profile?tab=claude-chat` and highlights correctly
- [x] Open the chat panel without configuring a provider - verify the "Go to Settings" button navigates to the Claude Chat tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)