### PR TITLE
fix(admin): display correct user avatars with fallback colors on admin users page (PUNT-223)

### DIFF
--- a/src/components/admin/user-list.tsx
+++ b/src/components/admin/user-list.tsx
@@ -71,6 +71,7 @@ import { useCurrentUser } from '@/hooks/use-current-user'
 import { getTabId } from '@/hooks/use-realtime'
 import { demoStorage, isDemoMode } from '@/lib/demo'
 import { showToast } from '@/lib/toast'
+import { getAvatarColor, getInitials } from '@/lib/utils'
 import { useAdminUndoStore } from '@/stores/admin-undo-store'
 import { CreateUserDialog } from './create-user-dialog'
 
@@ -840,10 +841,12 @@ export function UserList() {
               <Avatar>
                 <AvatarImage src={user.avatar || undefined} />
                 <AvatarFallback
-                  className="text-white"
-                  style={user.avatarColor ? { backgroundColor: user.avatarColor } : undefined}
+                  className="text-xs text-white font-medium"
+                  style={{
+                    backgroundColor: user.avatarColor || getAvatarColor(user.id || user.name),
+                  }}
                 >
-                  {user.name.charAt(0).toUpperCase()}
+                  {getInitials(user.name)}
                 </AvatarFallback>
               </Avatar>
               <div>


### PR DESCRIPTION
## Summary
- Fixed user profile avatars on the `/admin/users` page to properly display fallback colors and initials when no profile picture is uploaded
- Previously, avatars without a saved `avatarColor` would render with the default muted background instead of a deterministic color, and only showed a single initial character instead of proper two-character initials
- Now uses `getAvatarColor(user.id)` as a fallback (matching the pattern used in the header, members tab, and admin user detail page) and `getInitials(user.name)` for consistent two-character initials

## Test plan
- [x] Navigate to `/admin/users` and verify all user avatars display a colored background (not gray/muted) when no profile picture is uploaded
- [x] Verify users with uploaded profile pictures still display their image correctly
- [x] Verify users with a saved `avatarColor` use that color (not the hash-based fallback)
- [x] Verify initials show up to 2 characters (e.g., "JD" for "John Doe") instead of just the first letter
- [x] Compare avatar appearance with the header dropdown and the admin user detail page to confirm consistency

Generated with [Claude Code](https://claude.com/claude-code)