### PR TITLE
refactor(links): remove redundant clones/is_cloned_by link types (PUNT-222)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PUNT is a lightweight, local-first issue tracking system for teams who want the 
 - Backlog with filtering, sorting, bulk actions, and **PQL query language**
 - Kanban board with drag-and-drop, column customization (icons, colors)
 - Sprint planning with carryover tracking
-- Ticket linking (blocks, relates to, duplicates, clones)
+- Ticket linking (blocks, relates to, duplicates)
 - Granular permissions with custom roles
 - Multi-select operations via keyboard or context menu
 - Undo/redo for moves, updates, and deletions

--- a/docs-site/docs/api-reference/tickets.md
+++ b/docs-site/docs/api-reference/tickets.md
@@ -339,8 +339,6 @@ Link related tickets to track dependencies and relationships.
 | `relates_to` | `relates_to` | General relationship |
 | `duplicates` | `is_duplicated_by` | This ticket duplicates another |
 | `is_duplicated_by` | `duplicates` | This ticket is duplicated by another |
-| `clones` | `is_cloned_by` | This ticket was cloned from another |
-| `is_cloned_by` | `clones` | This ticket was cloned to create another |
 
 ### Create Link
 

--- a/mcp/src/tools/tickets.ts
+++ b/mcp/src/tools/tickets.ts
@@ -1185,15 +1185,7 @@ export function registerTicketTools(server: McpServer) {
       fromKey: z.string().describe('Source ticket key (e.g., PUNT-2)'),
       toKey: z.string().describe('Target ticket key (e.g., PUNT-5)'),
       linkType: z
-        .enum([
-          'blocks',
-          'is_blocked_by',
-          'relates_to',
-          'duplicates',
-          'is_duplicated_by',
-          'clones',
-          'is_cloned_by',
-        ])
+        .enum(['blocks', 'is_blocked_by', 'relates_to', 'duplicates', 'is_duplicated_by'])
         .describe('Type of link'),
     },
     async ({ fromKey, toKey, linkType }) => {

--- a/prisma/migrate-clone-links.ts
+++ b/prisma/migrate-clone-links.ts
@@ -1,0 +1,37 @@
+/**
+ * Migration script: Convert clones/is_cloned_by links to duplicates/is_duplicated_by
+ *
+ * This script converts any existing ticket links using the removed
+ * `clones` and `is_cloned_by` link types to their equivalent
+ * `duplicates` and `is_duplicated_by` types.
+ *
+ * Run with: DATABASE_URL="file:./prisma/dev.db" npx tsx prisma/migrate-clone-links.ts
+ */
+import { PrismaClient } from '../src/generated/prisma'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  // Convert clones -> duplicates
+  const clonesResult = await prisma.ticketLink.updateMany({
+    where: { linkType: 'clones' },
+    data: { linkType: 'duplicates' },
+  })
+  console.log(`Converted ${clonesResult.count} 'clones' links to 'duplicates'`)
+
+  // Convert is_cloned_by -> is_duplicated_by
+  const isClonedByResult = await prisma.ticketLink.updateMany({
+    where: { linkType: 'is_cloned_by' },
+    data: { linkType: 'is_duplicated_by' },
+  })
+  console.log(`Converted ${isClonedByResult.count} 'is_cloned_by' links to 'is_duplicated_by'`)
+
+  console.log('Migration complete.')
+}
+
+main()
+  .catch((e) => {
+    console.error('Migration failed:', e)
+    process.exit(1)
+  })
+  .finally(() => prisma.$disconnect())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -384,7 +384,7 @@ model TicketWatcher {
 // Linked tickets (blocks, is blocked by, relates to, duplicates, etc.)
 model TicketLink {
   id       String @id @default(cuid())
-  linkType String // blocks, is_blocked_by, relates_to, duplicates, is_duplicated_by, clones, is_cloned_by
+  linkType String // blocks, is_blocked_by, relates_to, duplicates, is_duplicated_by
 
   fromTicketId String
   fromTicket   Ticket @relation("LinkedFrom", fields: [fromTicketId], references: [id], onDelete: Cascade)

--- a/src/lib/__tests__/prisma-middleware.test.ts
+++ b/src/lib/__tests__/prisma-middleware.test.ts
@@ -288,8 +288,6 @@ describe('Prisma Enum Validation Middleware', () => {
       'relates_to',
       'duplicates',
       'is_duplicated_by',
-      'clones',
-      'is_cloned_by',
     ]
 
     for (const linkType of validLinkTypes) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,8 +57,6 @@ export const LINK_TYPES = [
   'relates_to',
   'duplicates',
   'is_duplicated_by',
-  'clones',
-  'is_cloned_by',
 ] as const
 export type LinkType = (typeof LINK_TYPES)[number]
 
@@ -69,8 +67,6 @@ export const LINK_TYPE_LABELS: Record<LinkType, string> = {
   relates_to: 'Relates to',
   duplicates: 'Duplicates',
   is_duplicated_by: 'Is duplicated by',
-  clones: 'Clones',
-  is_cloned_by: 'Is cloned by',
 }
 
 // Inverse link types for bidirectional display
@@ -80,8 +76,6 @@ export const INVERSE_LINK_TYPES: Record<LinkType, LinkType> = {
   relates_to: 'relates_to',
   duplicates: 'is_duplicated_by',
   is_duplicated_by: 'duplicates',
-  clones: 'is_cloned_by',
-  is_cloned_by: 'clones',
 }
 
 // Resolution values for closed/done tickets


### PR DESCRIPTION
## Summary
- Remove `clones` and `is_cloned_by` link types from the codebase, as they are redundant with `duplicates` and `is_duplicated_by`
- Update Prisma schema, TypeScript types, MCP server validation, API docs, README, and tests
- Add a migration script (`prisma/migrate-clone-links.ts`) to convert any existing `clones`/`is_cloned_by` links to `duplicates`/`is_duplicated_by`

## Test plan
- [x] `pnpm db:generate` succeeds after schema changes
- [x] `pnpm lint:fix` passes with no new warnings
- [x] `prisma-middleware.test.ts` passes (86 tests) with updated valid link types
- [x] Verify the LinkTicketDialog dropdown no longer shows "Clones" / "Is cloned by" options
- [x] Run `prisma/migrate-clone-links.ts` on a database with existing clone links to verify conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)