### PR TITLE
feat(tickets): add deselect-all button and Esc shortcut (PUNT-207)

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { RoleSimulationBanner } from '@/components/common/role-simulation-banner
 import { Dialogs } from '@/components/dialogs'
 import { KeyboardShortcuts } from '@/components/keyboard-shortcuts'
 import { Footer, Header, MobileNav, MobileNotice, Sidebar } from '@/components/layout'
+import { SelectionIndicator } from '@/components/selection-indicator'
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   return (
@@ -23,6 +24,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       <MobileNotice />
       <Dialogs />
       <KeyboardShortcuts />
+      <SelectionIndicator />
       <ChatPanel />
       <ChatFAB />
     </div>

--- a/src/components/keyboard-shortcuts.tsx
+++ b/src/components/keyboard-shortcuts.tsx
@@ -158,7 +158,26 @@ export function KeyboardShortcuts() {
       }
 
       // Escape: clear selection or close delete dialog
+      // Precedence: modal/drawer close (handled by Radix) > delete dialog > ticket deselection > role preview exit
       if (e.key === 'Escape') {
+        // Skip if already handled by a Radix dialog/drawer
+        if (e.defaultPrevented) return
+
+        // Skip if a modal or drawer is open (they handle their own Escape)
+        const uiState = useUIStore.getState()
+        if (
+          uiState.activeTicketId ||
+          uiState.createTicketOpen ||
+          uiState.createProjectOpen ||
+          uiState.editProjectOpen ||
+          uiState.sprintCreateOpen ||
+          uiState.sprintEditOpen ||
+          uiState.sprintCompleteOpen ||
+          uiState.sprintStartOpen
+        ) {
+          return
+        }
+
         if (showDeleteConfirm) {
           setShowDeleteConfirm(false)
           return

--- a/src/components/selection-indicator.tsx
+++ b/src/components/selection-indicator.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useSelectionStore } from '@/stores/selection-store'
+
+/**
+ * Floating selection indicator that appears when tickets are selected.
+ * Shows the count of selected tickets with a clear button.
+ * Works across both board and backlog views.
+ */
+export function SelectionIndicator() {
+  const selectedTicketIds = useSelectionStore((state) => state.selectedTicketIds)
+  const clearSelection = useSelectionStore((state) => state.clearSelection)
+
+  const count = selectedTicketIds.size
+  if (count === 0) return null
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-in slide-in-from-bottom-4 fade-in duration-200">
+      <div className="flex items-center gap-2 pl-4 pr-2 py-2 bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl shadow-black/50">
+        <span className="text-sm text-zinc-300 font-medium">
+          {count} {count === 1 ? 'ticket' : 'tickets'} selected
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={clearSelection}
+          className="h-7 w-7 p-0 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800"
+          aria-label="Clear selection"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+        <span className="text-xs text-zinc-500 hidden sm:inline">Esc</span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a floating selection indicator that appears at the bottom of the screen when tickets are selected, showing "N tickets selected" with a clear (X) button and Esc hint
- Improve Escape key shortcut precedence: modals/drawers close first, then ticket deselection, then role preview exit
- Works in both board and backlog views

## Test plan
- [x] Select multiple tickets on the board view and verify the floating "N tickets selected" indicator appears
- [x] Click the X button on the indicator to clear selection
- [x] Press Esc with tickets selected (no modal open) to clear selection
- [x] Open a ticket drawer, press Esc -- drawer should close, selection should remain
- [x] Open create ticket modal, press Esc -- modal should close, selection should remain
- [x] Verify indicator appears in backlog view as well
- [x] Verify the indicator animates in from the bottom smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)