### PR TITLE
chore(release): bump version to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "punt",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump package.json version from 0.6.2 to 0.7.1 (0.7.0 was released but package.json wasn't updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)