### PR TITLE
fix(tickets): save environment, affected version, and fix version fields (PUNT-243)

### DIFF
--- a/src/hooks/queries/use-tickets.ts
+++ b/src/hooks/queries/use-tickets.ts
@@ -212,6 +212,9 @@ export function useUpdateTicket() {
       if ('startDate' in updates) apiUpdates.startDate = updates.startDate
       if ('dueDate' in updates) apiUpdates.dueDate = updates.dueDate
       if ('resolution' in updates) apiUpdates.resolution = updates.resolution
+      if ('environment' in updates) apiUpdates.environment = updates.environment
+      if ('affectedVersion' in updates) apiUpdates.affectedVersion = updates.affectedVersion
+      if ('fixVersion' in updates) apiUpdates.fixVersion = updates.fixVersion
 
       // Convert labels to labelIds
       if ('labels' in updates && updates.labels) {

--- a/src/lib/data-provider/types.ts
+++ b/src/lib/data-provider/types.ts
@@ -47,6 +47,9 @@ export interface CreateTicketInput {
   startDate?: Date | null
   dueDate?: Date | null
   resolution?: string | null
+  environment?: string | null
+  affectedVersion?: string | null
+  fixVersion?: string | null
   // For undo/restore operations - preserve original resolved timestamp
   resolvedAt?: Date | string | null
   labelIds?: string[]
@@ -71,6 +74,9 @@ export interface UpdateTicketInput {
   startDate?: Date | null
   dueDate?: Date | null
   resolution?: string | null
+  environment?: string | null
+  affectedVersion?: string | null
+  fixVersion?: string | null
   labelIds?: string[]
 }
 


### PR DESCRIPTION
## Summary
- Add `environment`, `affectedVersion`, and `fixVersion` to `UpdateTicketInput` and `CreateTicketInput` types in the data provider
- Add the three fields to the `useUpdateTicket` mutation so they are included in API requests

These fields were accepted by the API route's Zod schema and stored in the database, and the ticket form UI sent them correctly, but the mutation hook that bridges the UI to the API was silently dropping them before they reached the server.

## Test plan
- [x] All 1415 existing tests pass
- [x] Linting passes
- [x] Manually edit a ticket's environment, affected version, or fix version and verify the changes persist after refresh
- [x] Verify changes to these fields appear in the activity log

🤖 Generated with [Claude Code](https://claude.com/claude-code)