### PR TITLE
fix(perf): deduplicate excessive setProjects calls on page load (PUNT-249)

### DIFF
--- a/src/hooks/queries/use-projects.ts
+++ b/src/hooks/queries/use-projects.ts
@@ -48,7 +48,9 @@ export function useProjectDetail(projectKey: string) {
  * Fetch all projects for the current user and sync with Zustand store
  */
 export function useProjects() {
-  const { setProjects, setLoading, setError } = useProjectsStore()
+  const setProjects = useProjectsStore((s) => s.setProjects)
+  const setLoading = useProjectsStore((s) => s.setLoading)
+  const setError = useProjectsStore((s) => s.setError)
 
   const query = useQuery<ProviderProjectSummary[], Error, ProjectSummary[]>({
     queryKey: projectKeys.all,
@@ -85,7 +87,8 @@ export function useProjects() {
  */
 export function useCreateProject() {
   const queryClient = useQueryClient()
-  const { addProject, removeProject } = useProjectsStore()
+  const addProject = useProjectsStore((s) => s.addProject)
+  const removeProject = useProjectsStore((s) => s.removeProject)
 
   return useMutation({
     mutationFn: async (data: {
@@ -140,7 +143,7 @@ export function useCreateProject() {
  */
 export function useUpdateProject() {
   const queryClient = useQueryClient()
-  const { updateProject: updateProjectInStore } = useProjectsStore()
+  const updateProjectInStore = useProjectsStore((s) => s.updateProject)
 
   return useMutation({
     mutationFn: async ({
@@ -191,7 +194,7 @@ export function useUpdateProject() {
  */
 export function useDeleteProject() {
   const queryClient = useQueryClient()
-  const { removeProject } = useProjectsStore()
+  const removeProject = useProjectsStore((s) => s.removeProject)
 
   return useMutation({
     mutationFn: async (id: string) => {

--- a/src/stores/projects-store.ts
+++ b/src/stores/projects-store.ts
@@ -40,6 +40,16 @@ export const useProjectsStore = create<ProjectsState>()((set, get) => ({
   error: null,
 
   setProjects: (projects) => {
+    const { projects: current, isLoading, error } = get()
+    // Skip update if state is already correct and data unchanged
+    if (
+      !isLoading &&
+      error === null &&
+      (current === projects ||
+        (current.length === projects.length && current.every((p, i) => p.id === projects[i].id)))
+    ) {
+      return
+    }
     logger.debug('Setting projects from server', { count: projects.length })
     set({ projects, isLoading: false, error: null })
   },


### PR DESCRIPTION
## Summary
- Add equality check in `setProjects` store action to skip redundant updates when projects data hasn't changed (same reference or same IDs)
- Use Zustand selectors in `useProjects()` hook instead of destructuring the whole store, preventing unnecessary re-renders from unrelated store state changes
- Reduces ~80+ redundant "Setting projects from server" calls on page load down to 1

## Test plan
- [x] Page loads without console spam of "Setting projects from server" debug logs
- [x] Projects still load and display correctly in sidebar, home page, board
- [x] Creating/updating/deleting projects still works with optimistic updates
- [x] All 1415 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)