### PR TITLE
docs: update README and setup docs for PostgreSQL onboarding (PUNT-272)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,35 +1,78 @@
-# Database (PostgreSQL)
-# Requires PostgreSQL 16+. Create a database named "punt" and set credentials below.
+# =============================================================================
+# PUNT Environment Configuration
+# =============================================================================
+# Copy this file to .env and fill in the required values.
+#
+# For demo mode (no database), you only need AUTH_SECRET and NEXT_PUBLIC_DEMO_MODE.
+# For full mode, you need DATABASE_URL and AUTH_SECRET at minimum.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Database (PostgreSQL 16+) -- REQUIRED for full mode
+# -----------------------------------------------------------------------------
+# Connection string format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE
+#
+# Local setup:
+#   1. Install PostgreSQL 16+ (see README.md for platform-specific instructions)
+#   2. Create user and database:
+#        sudo -u postgres psql
+#        CREATE USER punt WITH PASSWORD 'punt';
+#        CREATE DATABASE punt OWNER punt;
+#   3. Use the connection string below (adjust if your setup differs)
+#
 DATABASE_URL="postgresql://punt:punt@localhost:5432/punt"
 
-# NextAuth.js Configuration
-# Generate secret with: openssl rand -base64 32
+# -----------------------------------------------------------------------------
+# Authentication -- REQUIRED
+# -----------------------------------------------------------------------------
+# Secret key for signing JWT tokens. Generate a secure random value:
+#   openssl rand -base64 32
+#
 AUTH_SECRET="your-secret-key-here"
 
-# IMPORTANT: Set this in production to prevent host header injection attacks
-# This should be the canonical URL of your application (no trailing slash)
+# Canonical URL of your application (no trailing slash).
+# Set this in production to prevent host header injection attacks.
+# Not needed for local development.
 # Example: https://punt.example.com
 # NEXTAUTH_URL="https://your-domain.com"
 
-# Trust the host header for Auth.js in production
-# Set to true when running locally with `pnpm start` or behind a trusted reverse proxy
+# Trust the host header for Auth.js.
+# Set to true when:
+#   - Running locally with `pnpm start` (not `pnpm dev`)
+#   - Running behind a trusted reverse proxy (nginx, Cloudflare, etc.)
 # AUTH_TRUST_HOST=true
 
-# Optional: Enable debug logging (shows detailed logs in browser console)
+# -----------------------------------------------------------------------------
+# Demo Mode -- set to run without a database
+# -----------------------------------------------------------------------------
+# When enabled, all data is stored in the browser's localStorage.
+# No PostgreSQL connection is needed.
+# NEXT_PUBLIC_DEMO_MODE=true
+
+# -----------------------------------------------------------------------------
+# Optional Settings
+# -----------------------------------------------------------------------------
+
+# Enable debug logging (detailed logs in browser console)
 NEXT_PUBLIC_DEBUG=false
 
-# Optional: Trust reverse proxy headers for rate limiting
-# Only set to true if behind a trusted reverse proxy (nginx, cloudflare, etc.)
-# WARNING: If set to true without a trusted proxy, rate limiting can be bypassed
+# Trust reverse proxy headers (X-Forwarded-For) for rate limiting.
+# WARNING: Only set to true behind a trusted reverse proxy. If enabled without
+# one, clients can spoof their IP to bypass rate limiting.
 TRUST_PROXY=false
 
+# -----------------------------------------------------------------------------
 # MCP Server Authentication
-# MCP API keys are now per-user and stored in the database.
-# Users can generate their key via POST /api/me/mcp-key
+# -----------------------------------------------------------------------------
+# MCP API keys are per-user and managed in the web UI.
+# Users generate their key via Profile > Integrations > MCP API Key.
 # The key is sent via X-MCP-API-Key header to authenticate MCP requests.
 
-# Email Configuration
-# Choose one provider and set the corresponding credentials
+# -----------------------------------------------------------------------------
+# Email Configuration (optional)
+# -----------------------------------------------------------------------------
+# Choose one provider and set the corresponding credentials.
+# Configure the provider and settings in the Admin panel after first login.
 
 # Resend API (https://resend.com)
 # EMAIL_RESEND_API_KEY=re_your_api_key_here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,17 +36,30 @@ You only need to sign the CLA once. After signing, all your future contributions
 
 ## Development Setup
 
+PUNT requires **Node.js 20.9+**, **pnpm 9+**, and **PostgreSQL 16+**.
+
 ```bash
 # Install dependencies
 pnpm install
 
-# Set up the database
+# Copy the example environment file and configure it
+cp .env.example .env
+# Edit .env: set DATABASE_URL and AUTH_SECRET (generate with: openssl rand -base64 32)
+
+# Generate the Prisma client
 pnpm db:generate
+
+# Push the schema to your PostgreSQL database
 pnpm db:push
+
+# Create an admin user
+pnpm db:seed --username admin --password "YourSecurePass1" --name "Admin"
 
 # Start development server
 pnpm dev
 ```
+
+See the [README](README.md#quick-start-full-mode) for detailed PostgreSQL installation and database creation steps.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -23,61 +23,188 @@ PUNT is a lightweight, local-first issue tracking system for teams who want the 
 - File attachments with configurable limits
 - Custom branding (logo, app name, colors)
 - Email system (password reset, verification, invitations)
-- **Conversational ticket management via MCP** — Create and manage tickets through natural language
+- **Conversational ticket management via MCP** -- Create and manage tickets through natural language
 - Dark UI
 
 ## Try the Demo
 
-**[Live Demo](https://punt-demo-production.up.railway.app)** — No account required. Data is stored in your browser's localStorage.
+**[Live Demo](https://punt-demo-production.up.railway.app)** -- No account required. Data is stored in your browser's localStorage.
 
 ## Requirements
 
-- Node.js 20.9+
-- pnpm 9+
+- **Node.js** 20.9+ (enforced in `package.json`)
+- **pnpm** 9+
+- **PostgreSQL** 16+ (not required for demo mode)
 
 **Recommended for MCP / Claude Code workflow:**
-- [GitHub CLI (`gh`)](https://cli.github.com/) — for PR creation, merging, and issue management from the terminal
+- [GitHub CLI (`gh`)](https://cli.github.com/) -- for PR creation, merging, and issue management from the terminal
 
-## Quick Start
+## Quick Start (Full Mode)
+
+This is the standard setup for development and production. If you just want to try the interface without a database, see [Demo Mode](#demo-mode) below.
+
+### 1. Install PostgreSQL
+
+If you do not already have PostgreSQL installed locally:
+
+**macOS (Homebrew):**
+```bash
+brew install postgresql@16
+brew services start postgresql@16
+```
+
+**Ubuntu/Debian:**
+```bash
+sudo apt install postgresql-16
+sudo systemctl start postgresql
+```
+
+**Fedora:**
+```bash
+sudo dnf install postgresql-server postgresql
+sudo postgresql-setup --initdb
+sudo systemctl start postgresql
+```
+
+**Windows:**
+Download the installer from [postgresql.org/download/windows](https://www.postgresql.org/download/windows/).
+
+### 2. Create the database
 
 ```bash
-# Clone and install
+# Connect as the postgres superuser (may require sudo on Linux)
+sudo -u postgres psql
+
+# Inside psql, create a user and database:
+CREATE USER punt WITH PASSWORD 'punt';
+CREATE DATABASE punt OWNER punt;
+\q
+```
+
+This gives you the connection string: `postgresql://punt:punt@localhost:5432/punt`
+
+If your PostgreSQL is configured differently (different port, host, or auth method), adjust the `DATABASE_URL` accordingly.
+
+### 3. Clone and install
+
+```bash
+git clone https://github.com/jmynes/punt.git
+cd punt
+pnpm install
+```
+
+### 4. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set the required values:
+
+```bash
+# Database connection (update if your credentials differ from step 2)
+DATABASE_URL="postgresql://punt:punt@localhost:5432/punt"
+
+# Auth secret -- REQUIRED. Generate one with:
+#   openssl rand -base64 32
+AUTH_SECRET="paste-your-generated-secret-here"
+```
+
+See [Configuration](#configuration) for all available environment variables.
+
+### 5. Set up the database schema
+
+```bash
+# Generate the Prisma client (TypeScript types from the schema)
+pnpm db:generate
+
+# Push the schema to your PostgreSQL database (creates all tables)
+pnpm db:push
+```
+
+> **When to use which command:**
+> - `pnpm db:generate` -- Run after cloning or after any change to `prisma/schema.prisma`. Generates the TypeScript client in `src/generated/prisma/`.
+> - `pnpm db:push` -- Syncs the schema to the database. Use during development to quickly apply schema changes. Also creates performance indexes.
+> - `pnpm db:migrate` -- Creates a versioned migration file and applies it. Use when you need a migration history (e.g., for production deployments).
+
+### 6. Create the first admin user
+
+```bash
+pnpm db:seed --username admin --password "YourSecurePass1" --name "Admin"
+```
+
+Password requirements: minimum 12 characters, at least one uppercase letter, one lowercase letter, and one number.
+
+You can optionally pass `--email admin@example.com`.
+
+### 7. Start the dev server
+
+```bash
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) and log in with the credentials from step 6.
+
+> **Note:** `pnpm dev` automatically checks for out-of-date dependencies and regenerates the Prisma client if the schema has changed, so you rarely need to run `pnpm db:generate` manually during day-to-day development.
+
+## Demo Mode
+
+Demo mode runs the app entirely client-side with no database required. All data is stored in the browser's localStorage.
+
+```bash
 git clone https://github.com/jmynes/punt.git
 cd punt
 pnpm install
 
-# Configure environment
-cp .env.example .env
-# Edit .env and set AUTH_SECRET (generate with: openssl rand -base64 32)
+# Create a minimal .env for demo mode
+cat > .env <<EOF
+NEXT_PUBLIC_DEMO_MODE=true
+AUTH_SECRET=$(openssl rand -base64 32)
+AUTH_TRUST_HOST=true
+EOF
 
-# Set up database
+# Generate the Prisma client (still needed for type imports)
 pnpm db:generate
-pnpm db:push
 
-# Create admin user
-pnpm db:seed --username admin --password "YourPassword123" --name "Admin"
-
-# Start server
+# Start the server
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) and log in.
+Open [http://localhost:3000](http://localhost:3000) -- you are automatically signed in as a demo user.
 
 ## Configuration
 
+All configuration is done through environment variables in `.env`. See `.env.example` for the full template.
+
+### Required Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL connection string (not needed in demo mode) |
+| `AUTH_SECRET` | Secret for JWT signing. Generate with `openssl rand -base64 32` |
+
+### Optional Variables
+
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@localhost:5432/punt` |
-| `AUTH_SECRET` | Secret for JWT signing | Required |
-| `TRUST_PROXY` | Trust `X-Forwarded-For` for rate limiting | `false` |
-| `NEXT_PUBLIC_DEBUG` | Enable debug logging | `false` |
+| `AUTH_TRUST_HOST` | Trust the host header (set `true` behind a reverse proxy or with `pnpm start`) | _not set_ |
+| `NEXTAUTH_URL` | Canonical app URL in production (e.g., `https://punt.example.com`) | _auto-detected_ |
+| `TRUST_PROXY` | Trust `X-Forwarded-For` for rate limiting (only behind a trusted proxy) | `false` |
+| `NEXT_PUBLIC_DEBUG` | Enable debug logging in the browser console | `false` |
 | `NEXT_PUBLIC_DEMO_MODE` | Run in demo mode (no database) | `false` |
+| `EMAIL_RESEND_API_KEY` | API key for [Resend](https://resend.com) email provider | _not set_ |
+| `EMAIL_SMTP_PASSWORD` | Password for SMTP email provider | _not set_ |
 
-Only enable `TRUST_PROXY` when running behind a trusted reverse proxy.
+> **Warning:** Only enable `TRUST_PROXY` when running behind a trusted reverse proxy. Setting it to `true` without one allows rate limiting to be bypassed.
 
-### Demo Mode
+### `.env` vs `.env.local`
 
-Set `NEXT_PUBLIC_DEMO_MODE=true` to run without a database. All data is stored in the browser's localStorage. Useful for demos and trying out the interface.
+Next.js supports both `.env` and `.env.local` files. For PUNT:
+- **`.env`** -- Main configuration file. Copy from `.env.example` and edit.
+- **`.env.local`** -- Optional override file (gitignored by Next.js). Useful for personal settings that differ from the team's `.env`.
+- **`.env.test`** -- Loaded automatically by Vitest for the test environment. Points to a separate `punt_test` database.
+
+In most cases, `.env` is all you need.
 
 ## Production
 
@@ -86,30 +213,58 @@ pnpm build
 pnpm start
 ```
 
+Set `AUTH_TRUST_HOST=true` when running with `pnpm start` or behind a reverse proxy.
+
 ### Railway Deployment
 
 A `railway.toml` is included for easy deployment to [Railway](https://railway.app):
 
 ```bash
 railway link
-railway variables --set "NEXT_PUBLIC_DEMO_MODE=true"
 railway variables --set "AUTH_SECRET=$(openssl rand -base64 32)"
 railway variables --set "AUTH_TRUST_HOST=true"
-railway variables --set "DATABASE_URL=<your-postgresql-url>"  # PostgreSQL connection string
+railway variables --set "DATABASE_URL=<your-postgresql-url>"
 railway up
 railway domain
+```
+
+For a demo-only deployment (no database), also set:
+```bash
+railway variables --set "NEXT_PUBLIC_DEMO_MODE=true"
 ```
 
 ## Development
 
 ```bash
-pnpm dev          # Start dev server
+pnpm dev          # Start dev server (Turbopack, port 3000)
 pnpm test         # Run tests
-pnpm lint         # Check linting
-pnpm db:studio    # Open database browser
+pnpm test:watch   # Run tests in watch mode
+pnpm lint         # Check linting (Biome)
+pnpm lint:fix     # Auto-fix lint issues
+pnpm db:studio    # Open Prisma Studio (visual database browser)
 ```
 
-Pre-commit hooks automatically lint staged files.
+Pre-commit hooks (husky + lint-staged) automatically lint staged files before each commit.
+
+### Testing with a Separate Database
+
+Tests use a separate database to avoid interfering with development data. The connection string is configured in `.env.test`:
+
+```
+DATABASE_URL="postgresql://punt:punt@localhost:5432/punt_test"
+```
+
+Create the test database the same way as the main one:
+```bash
+sudo -u postgres psql -c "CREATE DATABASE punt_test OWNER punt;"
+```
+
+Then push the schema:
+```bash
+DATABASE_URL="postgresql://punt:punt@localhost:5432/punt_test" pnpm db:push
+```
+
+See [docs/TESTING.md](docs/TESTING.md) for the full testing guide.
 
 ## Conversational Ticket Management (MCP)
 
@@ -129,7 +284,7 @@ AI:  Created PUNT-42: Login page not loading
    ```
 
 2. Generate your API key in the PUNT web UI:
-   - Go to **Profile → Integrations**
+   - Go to **Profile > Integrations**
    - Click **Generate Key** under MCP API Key
    - Copy the key (it won't be shown again)
 
@@ -196,7 +351,7 @@ See the [MCP documentation](https://jmynes.github.io/punt/user-guide/mcp) for de
 
 ## Documentation
 
-- [User Guide & API Reference](https://jmynes.github.io/punt/) — Full documentation
+- [User Guide & API Reference](https://jmynes.github.io/punt/) -- Full documentation
 - [Testing Guide](docs/TESTING.md)
 - [Contributing Guidelines](CONTRIBUTING.md)
 - [Contributor License Agreement](CLA.md)
@@ -207,4 +362,4 @@ PUNT is under active development. The API may change between versions. Mobile re
 
 ## License
 
-[AGPL-3.0](LICENSE) — If you modify PUNT and run it as a service, you must make your source code available.
+[AGPL-3.0](LICENSE) -- If you modify PUNT and run it as a service, you must make your source code available.


### PR DESCRIPTION
## Summary
- Rewrites the README Quick Start into a numbered step-by-step guide covering PostgreSQL installation (macOS/Ubuntu/Fedora/Windows), database creation, environment configuration, Prisma setup, admin user seeding, and server startup
- Adds a dedicated Demo Mode section with a self-contained setup flow (no database required)
- Expands the Configuration section with required vs optional variable tables, `.env` vs `.env.local` vs `.env.test` clarification, and `AUTH_TRUST_HOST` / `NEXTAUTH_URL` documentation
- Adds a "Testing with a Separate Database" section explaining `punt_test` setup
- Clarifies when to use `db:generate` vs `db:push` vs `db:migrate`
- Updates `.env.example` with structured sections, inline setup instructions, and clearer comments
- Updates CONTRIBUTING.md development setup to include PostgreSQL prerequisites, `.env` configuration, and seed step

## Test plan
- [ ] Follow the Quick Start (Full Mode) steps from a clean state to verify the flow is accurate
- [ ] Follow the Demo Mode steps to verify they produce a working demo instance
- [ ] Verify all links in the README resolve correctly
- [ ] Confirm `.env.example` values match the documented connection string format

🤖 Generated with [Claude Code](https://claude.com/claude-code)