### PR TITLE
feat(tickets): show current value checkmarks in all context menu submenus (PUNT-278)

### DIFF
--- a/src/components/board/ticket-context-menu.tsx
+++ b/src/components/board/ticket-context-menu.tsx
@@ -5,6 +5,7 @@ import {
   Bug,
   CalendarMinus,
   CalendarPlus,
+  Check,
   CheckCircle2,
   CheckSquare,
   ChevronRight,
@@ -1070,7 +1071,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                         >
                           <PriorityBadge priority={p} size="sm" />
                           {ticket.priority === p && !multi && (
-                            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400 ml-auto" />
+                            <Check className="size-4 text-zinc-400 ml-auto" />
                           )}
                         </button>
                       ),
@@ -1090,7 +1091,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                           <TypeIcon className={`h-4 w-4 ${cfg.color}`} />
                           <span>{cfg.label}</span>
                           {ticket.type === t && !multi && (
-                            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400 ml-auto" />
+                            <Check className="size-4 text-zinc-400 ml-auto" />
                           )}
                         </button>
                       )
@@ -1117,6 +1118,9 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                               </AvatarFallback>
                             </Avatar>
                             <span>Assign to me</span>
+                            {ticket.assigneeId === currentUser.id && !multi && (
+                              <Check className="size-4 text-zinc-400 ml-auto" />
+                            )}
                           </button>
                           <div className="my-1 border-t border-zinc-800" />
                         </>
@@ -1138,6 +1142,9 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                             </AvatarFallback>
                           </Avatar>
                           <span>{m.name}</span>
+                          {ticket.assigneeId === m.id && !multi && (
+                            <Check className="size-4 text-zinc-400 ml-auto" />
+                          )}
                         </button>
                       ))}
                       <div className="my-1 border-t border-zinc-800" />
@@ -1168,6 +1175,9 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                         >
                           <StatusIcon className={`h-4 w-4 ${color}`} />
                           <span>{col.name}</span>
+                          {ticket.columnId === col.id && !multi && (
+                            <Check className="size-4 text-zinc-400 ml-auto" />
+                          )}
                         </button>
                       )
                     })}
@@ -1189,7 +1199,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                                 <Icon className="h-4 w-4" style={{ color: config.color }} />
                                 <span>{r}</span>
                                 {ticket.resolution === r && !multi && (
-                                  <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400 ml-auto" />
+                                  <Check className="size-4 text-zinc-400 ml-auto" />
                                 )}
                               </button>
                             )
@@ -1212,7 +1222,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                             {p} point{p === 1 ? '' : 's'}
                           </span>
                           {ticket.storyPoints === p && !multi && (
-                            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400 ml-auto" />
+                            <Check className="size-4 text-zinc-400 ml-auto" />
                           )}
                         </button>
                       ))}
@@ -1257,7 +1267,7 @@ export function TicketContextMenu({ ticket, children }: MenuProps) {
                           <CalendarPlus className="h-4 w-4 text-blue-400" />
                           <span>{sprint.name}</span>
                           {ticket.sprintId === sprint.id && !multi ? (
-                            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400 ml-auto" />
+                            <Check className="size-4 text-zinc-400 ml-auto" />
                           ) : (
                             sprint.status === 'active' && (
                               <span className="ml-auto text-[10px] text-emerald-400 uppercase">


### PR DESCRIPTION
## Summary
- Add a grey `Check` checkmark icon next to the currently active value in all single-select context menu submenus: **Type**, **Priority**, **Assignee**, **Status (Send To)**, **Resolution**, **Story Points**, and **Sprint**
- Uses the same `Check` icon and muted styling (`text-zinc-400`) as the drawer's `DropdownMenuCheckboxItem` for visual consistency
- Checkmarks only appear in single-select mode (hidden during multi-select since tickets may have different values)
- For the Sprint submenu, the checkmark takes precedence over the "Active" badge when the ticket is already in that sprint

## Test plan
- [x] Right-click a single ticket and verify a checkmark appears next to the current type in the Type submenu
- [x] Verify a checkmark appears next to the current priority in the Priority submenu
- [x] Verify a checkmark appears next to the current assignee in the Assign submenu (both "Assign to me" and member list)
- [x] Verify a checkmark appears next to the current column in the Status/Send To submenu
- [x] Verify a checkmark appears next to the current resolution in the Resolution submenu (if set)
- [x] Verify a checkmark appears next to the current story points in the Points submenu (if set)
- [x] Verify a checkmark appears next to the current sprint in the Sprint submenu (if in a sprint)
- [x] Verify no checkmarks appear when multiple tickets are selected
- [ ] Verify the "Active" badge still shows for active sprints when the ticket is NOT in that sprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)