### PR TITLE
fix(projects): change deletion confirmation from key to name (PUNT-280)

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -98,15 +98,17 @@ export function Sidebar() {
                 <div className="space-y-2">
                   <p className="text-sm text-zinc-300">
                     Type{' '}
-                    <span className="font-mono font-bold text-red-400">{projectToDelete?.key}</span>{' '}
+                    <span className="font-mono font-bold text-red-400">
+                      {projectToDelete?.name}
+                    </span>{' '}
                     to confirm:
                   </p>
                   <Input
                     type="text"
                     value={deleteConfirmText}
                     onChange={(e) => setDeleteConfirmText(e.target.value)}
-                    placeholder={`Type ${projectToDelete?.key} to confirm`}
-                    className="bg-zinc-900 border-zinc-700 text-zinc-100 font-mono"
+                    placeholder={`Type ${projectToDelete?.name} to confirm`}
+                    className="bg-zinc-900 border-zinc-700 text-zinc-100"
                     autoComplete="off"
                     disabled={deleteProject.isPending}
                   />
@@ -123,7 +125,7 @@ export function Sidebar() {
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDeleteProject}
-              disabled={deleteProject.isPending || deleteConfirmText !== projectToDelete?.key}
+              disabled={deleteProject.isPending || deleteConfirmText !== projectToDelete?.name}
               className="bg-red-600 hover:bg-red-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {deleteProject.isPending ? (

--- a/src/components/projects/settings/general-tab.tsx
+++ b/src/components/projects/settings/general-tab.tsx
@@ -473,15 +473,15 @@ export function GeneralTab({ projectId, project }: GeneralTabProps) {
                 </p>
                 <div className="space-y-2">
                   <p className="text-sm">
-                    To confirm, type <span className="font-mono text-red-400">{project.key}</span>{' '}
+                    To confirm, type <span className="font-mono text-red-400">{project.name}</span>{' '}
                     below:
                   </p>
                   <Input
                     type="text"
                     value={deleteConfirmText}
                     onChange={(e) => setDeleteConfirmText(e.target.value)}
-                    placeholder={`Type ${project.key} to confirm`}
-                    className="bg-zinc-900 border-zinc-700 text-zinc-100 font-mono"
+                    placeholder={`Type ${project.name} to confirm`}
+                    className="bg-zinc-900 border-zinc-700 text-zinc-100"
                     autoComplete="off"
                     disabled={deleteProject.isPending}
                   />
@@ -498,7 +498,7 @@ export function GeneralTab({ projectId, project }: GeneralTabProps) {
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
-              disabled={deleteProject.isPending || deleteConfirmText !== project.key}
+              disabled={deleteProject.isPending || deleteConfirmText !== project.name}
               className="bg-red-600 hover:bg-red-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {deleteProject.isPending ? (


### PR DESCRIPTION
## Summary
- Change project deletion confirmation to require typing the project name instead of the project key
- Applies to both the settings page (Danger Zone) and sidebar context menu delete dialogs
- Removed `font-mono` from the input since project names are natural language
- Exact string match on name provides a stronger safeguard (e.g., "Domination Finance" vs "DOM")

## Test plan
- [x] Go to Project Settings > Danger Zone > Delete Project — verify it asks for the project name
- [x] Right-click a project in the sidebar > Delete — verify it asks for the project name
- [x] Verify typing the project key no longer enables the delete button
- [x] Verify typing the exact project name enables the delete button

🤖 Generated with [Claude Code](https://claude.com/claude-code)