### PR TITLE
fix(selection): allow deselecting tickets by clicking header and footer (PUNT-288)

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,12 +5,19 @@ import { RoleSimulationBanner } from '@/components/common/role-simulation-banner
 import { SearchClearOnLeave } from '@/components/common/search-clear-on-leave'
 import { Dialogs } from '@/components/dialogs'
 import { KeyboardShortcuts } from '@/components/keyboard-shortcuts'
-import { Footer, Header, MobileNav, MobileNotice, Sidebar } from '@/components/layout'
+import {
+  ClickToDeselectWrapper,
+  Footer,
+  Header,
+  MobileNav,
+  MobileNotice,
+  Sidebar,
+} from '@/components/layout'
 import { SelectionIndicator } from '@/components/selection-indicator'
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="relative h-full flex flex-col overflow-hidden">
+    <ClickToDeselectWrapper className="relative h-full flex flex-col overflow-hidden">
       <EmailVerificationBanner />
       <RoleSimulationBanner />
       <Header />
@@ -29,6 +36,6 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       <ChatPanel />
       <ChatFAB />
       <SearchClearOnLeave />
-    </div>
+    </ClickToDeselectWrapper>
   )
 }

--- a/src/app/(app)/projects/[projectId]/backlog/page.tsx
+++ b/src/app/(app)/projects/[projectId]/backlog/page.tsx
@@ -29,7 +29,6 @@ import {
   useColumnsByProject,
   useTicketsByProject,
 } from '@/hooks/queries/use-tickets'
-import { useClickToDeselect } from '@/hooks/use-click-to-deselect'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { useRealtime } from '@/hooks/use-realtime'
 import { useSprintCompletion } from '@/hooks/use-sprint-completion'
@@ -300,9 +299,6 @@ export default function BacklogPage() {
     setQueryText,
     setQueryMode,
   } = useBacklogStore()
-
-  // Click-to-deselect on empty space (covers page header and areas outside BacklogTable)
-  const handleDeselect = useClickToDeselect()
 
   // Tab cycling keyboard shortcut (Ctrl+Shift+Arrow)
   useTabCycleShortcut({ tabs: getProjectViewTabs(projectKey) })
@@ -934,7 +930,7 @@ export default function BacklogPage() {
   const hasActiveSprints = activeSprints.length > 0 || planningSprints.length > 0
 
   return (
-    <div className="flex h-full flex-col" onClick={handleDeselect}>
+    <div className="flex h-full flex-col">
       {/* Page header */}
       <div className="flex-shrink-0 flex flex-col gap-4 border-b border-zinc-800 px-4 py-4 lg:flex-row lg:items-center lg:justify-between lg:px-6">
         <div className="flex items-center gap-3">

--- a/src/app/(app)/projects/[projectId]/board/page.tsx
+++ b/src/app/(app)/projects/[projectId]/board/page.tsx
@@ -10,7 +10,6 @@ import { TicketDetailDrawer } from '@/components/tickets'
 import { Button } from '@/components/ui/button'
 import { useProjectSprints } from '@/hooks/queries/use-sprints'
 import { useColumnsByProject, useTicketsByProject } from '@/hooks/queries/use-tickets'
-import { useClickToDeselect } from '@/hooks/use-click-to-deselect'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { useRealtime } from '@/hooks/use-realtime'
 import { useSprintCompletion } from '@/hooks/use-sprint-completion'
@@ -61,9 +60,6 @@ export default function BoardPage() {
     setQueryText,
     setQueryMode,
   } = useBacklogStore()
-
-  // Click-to-deselect on empty space (covers page header, filter bar, and content)
-  const handleDeselect = useClickToDeselect()
 
   // Tab cycling keyboard shortcut (Ctrl+Shift+Arrow)
   useTabCycleShortcut({ tabs: getProjectViewTabs(projectKey) })
@@ -406,7 +402,7 @@ export default function BoardPage() {
   }
 
   return (
-    <div className="flex h-full flex-col" onClick={handleDeselect}>
+    <div className="flex h-full flex-col">
       {/* Page header */}
       <div className="flex-shrink-0 flex flex-col gap-4 border-b border-zinc-800 px-4 py-4 lg:flex-row lg:items-center lg:justify-between lg:px-6">
         <div className="flex items-center gap-3">

--- a/src/app/(app)/projects/[projectId]/sprints/page.tsx
+++ b/src/app/(app)/projects/[projectId]/sprints/page.tsx
@@ -8,7 +8,6 @@ import { SprintBacklogView, SprintHeader } from '@/components/sprints'
 import { TicketDetailDrawer } from '@/components/tickets'
 import { useProjectSprints } from '@/hooks/queries/use-sprints'
 import { useColumnsByProject, useTicketsByProject } from '@/hooks/queries/use-tickets'
-import { useClickToDeselect } from '@/hooks/use-click-to-deselect'
 import { useRealtime } from '@/hooks/use-realtime'
 import { getProjectViewTabs, useTabCycleShortcut } from '@/hooks/use-tab-cycle-shortcut'
 import { useTicketUrlSync } from '@/hooks/use-ticket-url-sync'
@@ -33,9 +32,6 @@ export default function SprintPlanningPage() {
   const { getColumns, _hasHydrated } = useBoardStore()
   const { setActiveProjectId, activeTicketId, setActiveTicketId } = useUIStore()
   const { clearSelection } = useSelectionStore()
-
-  // Click-to-deselect on empty space (covers page header, filter bar, and content)
-  const handleDeselect = useClickToDeselect()
 
   // Tab cycling keyboard shortcut (Ctrl+Shift+Arrow)
   useTabCycleShortcut({ tabs: getProjectViewTabs(projectKey) })
@@ -256,7 +252,7 @@ export default function SprintPlanningPage() {
   }
 
   return (
-    <div className="flex h-full flex-col" onClick={handleDeselect}>
+    <div className="flex h-full flex-col">
       {/* Page header */}
       <div className="flex-shrink-0 flex flex-col gap-4 border-b border-zinc-800 px-4 py-4 lg:px-6">
         <div className="flex items-center gap-3">

--- a/src/components/layout/click-to-deselect-wrapper.tsx
+++ b/src/components/layout/click-to-deselect-wrapper.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useClickToDeselect } from '@/hooks/use-click-to-deselect'
+
+/**
+ * Client wrapper that attaches the click-to-deselect handler at the app layout level.
+ * This ensures that clicks on the header, footer, sidebar, and any dead space
+ * clear the ticket selection, not just clicks within individual page containers.
+ */
+export function ClickToDeselectWrapper({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  const handleDeselect = useClickToDeselect()
+
+  return (
+    <div className={className} onClick={handleDeselect}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,3 +1,4 @@
+export { ClickToDeselectWrapper } from './click-to-deselect-wrapper'
 export { Footer } from './footer'
 export { Header } from './header'
 export { MobileNav } from './mobile-nav'


### PR DESCRIPTION
## Summary
- Lifted the `useClickToDeselect` handler from individual page containers (board, backlog, sprints) up to the app layout level via a new `ClickToDeselectWrapper` client component
- Clicks on the header, footer, sidebar, and any dead space now clear ticket selection
- Removed redundant per-page `useClickToDeselect` calls from all three project view pages

## Test plan
- [x] Select one or more tickets on the board, then click the sticky header bar -- selection should clear
- [x] Select tickets on the backlog page, then click the footer -- selection should clear
- [x] Select tickets on sprint planning, then click the sidebar -- selection should clear
- [x] Clicking on buttons, inputs, links, ticket cards/rows, and Radix popovers should NOT clear the selection (interactive element exclusion still works)
- [x] Drag-and-drop on board and backlog should still function correctly
- [x] Context menus on tickets should still work without clearing selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)