### PR TITLE
fix(auth): use client-side redirect after sign-out (PUNT-291)

### DIFF
--- a/src/components/admin/database-import-dialog.tsx
+++ b/src/components/admin/database-import-dialog.tsx
@@ -198,7 +198,9 @@ export function DatabaseImportDialog({
       onComplete()
       // Sign out to clear the session cookie and redirect to login
       // The imported database has different users, so current session is invalid
-      signOut({ callbackUrl: '/login' })
+      signOut({ redirect: false }).then(() => {
+        window.location.href = '/login'
+      })
       return
     }
 

--- a/src/components/admin/user-list.tsx
+++ b/src/components/admin/user-list.tsx
@@ -274,7 +274,9 @@ export function UserList() {
           ('isActive' in updates && updates.isActive === false) ||
           ('isSystemAdmin' in updates && updates.isSystemAdmin === false)
         ) {
-          signOut({ callbackUrl: '/login' })
+          signOut({ redirect: false }).then(() => {
+            window.location.href = '/login'
+          })
           return
         }
       }
@@ -354,7 +356,9 @@ export function UserList() {
       if (data.action === 'demo') return
       // If the user deleted/disabled themselves, sign them out
       if (deleteUsername === currentUser?.username) {
-        signOut({ callbackUrl: '/login' })
+        signOut({ redirect: false }).then(() => {
+          window.location.href = '/login'
+        })
         return
       }
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -29,7 +29,8 @@ export function Header() {
   const { data: branding } = useBranding()
 
   const handleLogout = async () => {
-    await signOut({ callbackUrl: '/login' })
+    await signOut({ redirect: false })
+    window.location.href = '/login'
   }
 
   return (

--- a/src/components/profile/security-tab.tsx
+++ b/src/components/profile/security-tab.tsx
@@ -143,7 +143,8 @@ export function SecurityTab({ user, isDemo, onUserUpdate, onSessionUpdate }: Sec
     }
 
     showToast.success('Account deleted. Signing out...')
-    await signOut({ callbackUrl: '/login' })
+    await signOut({ redirect: false })
+    window.location.href = '/login'
   }
 
   return (

--- a/src/hooks/queries/use-database-backup.ts
+++ b/src/hooks/queries/use-database-backup.ts
@@ -343,7 +343,9 @@ export function useWipeDatabase() {
       showToast.success('Database wiped successfully. Redirecting to login...')
       // Sign out to clear the session cookie, then redirect to login
       setTimeout(() => {
-        signOut({ callbackUrl: '/login' })
+        signOut({ redirect: false }).then(() => {
+          window.location.href = '/login'
+        })
       }, 1500)
     },
     onError: (err) => {

--- a/src/hooks/use-realtime-projects.ts
+++ b/src/hooks/use-realtime-projects.ts
@@ -107,7 +107,9 @@ export function useRealtimeProjects(enabled = true): RealtimeProjectsStatus {
           // Skip tab check since all tabs need to sign out
           // If suppressed, the import dialog will handle sign-out after showing results
           if (!_suppressWipeSignOut) {
-            signOut({ callbackUrl: '/login' })
+            signOut({ redirect: false }).then(() => {
+              window.location.href = '/login'
+            })
           }
           return
         }


### PR DESCRIPTION
## Summary
- All 7 `signOut({ callbackUrl: '/login' })` calls resolved the callback URL server-side against `AUTH_URL`, which defaults to `http://localhost:3000`. When deployed on an external server, sign-out redirected to localhost instead of the actual address.
- Changed all calls to `signOut({ redirect: false })` followed by `window.location.href = '/login'`, so the browser always redirects using its current origin.
- Affected files: `header.tsx`, `security-tab.tsx`, `use-database-backup.ts`, `use-realtime-projects.ts`, `database-import-dialog.tsx`, `user-list.tsx`

## Test plan
- [ ] Deploy on a non-localhost server and verify sign-out redirects to the correct address
- [ ] Test sign-out from the header user menu
- [ ] Test sign-out after account self-deletion (Profile > Security)
- [ ] Test sign-out after database wipe (Admin > Database)
- [ ] Test sign-out after database import (Admin > Database)
- [ ] Test sign-out after self-demotion from admin (Admin > Users)
- [ ] Verify sign-out still works correctly on localhost development

🤖 Generated with [Claude Code](https://claude.com/claude-code)