### PR TITLE
feat(board): show subtask count badge on Kanban cards (PUNT-283)

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -3,7 +3,15 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { format, isPast, isToday } from 'date-fns'
-import { Ban, Calendar, GripVertical, MessageSquare, Paperclip, User } from 'lucide-react'
+import {
+  Ban,
+  Calendar,
+  GitBranch,
+  GripVertical,
+  MessageSquare,
+  Paperclip,
+  User,
+} from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { InlineCodeText } from '@/components/common/inline-code'
 import { PriorityBadge } from '@/components/common/priority-badge'
@@ -86,6 +94,7 @@ export function KanbanCard({
 
   const commentCount = ticket._count?.comments ?? 0
   const attachmentCount = ticket._count?.attachments ?? 0
+  const subtaskCount = ticket._count?.subtasks ?? 0
   const isOverdue = ticket.dueDate && isPast(ticket.dueDate) && !isToday(ticket.dueDate)
   const isDueToday = ticket.dueDate && isToday(ticket.dueDate)
 
@@ -201,6 +210,12 @@ export function KanbanCard({
 
               {/* Metadata counts */}
               <div className="flex items-center gap-2 text-zinc-600">
+                {subtaskCount > 0 && (
+                  <div className="flex items-center gap-0.5" title={`${subtaskCount} subtask(s)`}>
+                    <GitBranch className="h-3 w-3" />
+                    <span className="text-[10px]">{subtaskCount}</span>
+                  </div>
+                )}
                 {attachmentCount > 0 && (
                   <div
                     className="flex items-center gap-0.5"


### PR DESCRIPTION
## Summary
- Kanban board cards now display a subtask count badge (GitBranch icon) in the footer metadata section, next to attachment and comment counts
- Only shown when a ticket has at least one subtask

## Test plan
- [x] Open the Kanban board with tickets that have subtasks — verify the GitBranch icon and count appear
- [x] Tickets with no subtasks should not show the badge
- [x] All 1422 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)