### PR TITLE
feat(tickets): show subtask progress as resolved/total (PUNT-283)

### DIFF
--- a/src/components/board/kanban-card.tsx
+++ b/src/components/board/kanban-card.tsx
@@ -95,6 +95,7 @@ export function KanbanCard({
   const commentCount = ticket._count?.comments ?? 0
   const attachmentCount = ticket._count?.attachments ?? 0
   const subtaskCount = ticket._count?.subtasks ?? 0
+  const resolvedSubtaskCount = ticket.subtasks?.filter((s) => s.resolution != null).length ?? 0
   const isOverdue = ticket.dueDate && isPast(ticket.dueDate) && !isToday(ticket.dueDate)
   const isDueToday = ticket.dueDate && isToday(ticket.dueDate)
 
@@ -211,9 +212,14 @@ export function KanbanCard({
               {/* Metadata counts */}
               <div className="flex items-center gap-2 text-zinc-600">
                 {subtaskCount > 0 && (
-                  <div className="flex items-center gap-0.5" title={`${subtaskCount} subtask(s)`}>
+                  <div
+                    className="flex items-center gap-0.5"
+                    title={`${resolvedSubtaskCount}/${subtaskCount} subtask(s) resolved`}
+                  >
                     <GitBranch className="h-3 w-3" />
-                    <span className="text-[10px]">{subtaskCount}</span>
+                    <span className="text-[10px]">
+                      {resolvedSubtaskCount}/{subtaskCount}
+                    </span>
                   </div>
                 )}
                 {attachmentCount > 0 && (

--- a/src/components/table/__tests__/ticket-cell.test.tsx
+++ b/src/components/table/__tests__/ticket-cell.test.tsx
@@ -76,6 +76,11 @@ describe('TicketCell', () => {
     it('should show subtask count when present', () => {
       const ticket = createMockTicket({
         title: 'Parent task',
+        subtasks: [
+          { id: 's1', resolution: null },
+          { id: 's2', resolution: 'Done' },
+          { id: 's3', resolution: null },
+        ],
         _count: { comments: 0, subtasks: 3, attachments: 0 },
       })
       render(
@@ -86,7 +91,7 @@ describe('TicketCell', () => {
           getStatusName={mockGetStatusName}
         />,
       )
-      expect(screen.getByText('3 subtasks')).toBeInTheDocument()
+      expect(screen.getByText('1/3 subtasks')).toBeInTheDocument()
     })
   })
 

--- a/src/components/table/ticket-cell.tsx
+++ b/src/components/table/ticket-cell.tsx
@@ -52,6 +52,7 @@ export function TicketCell({ column, ticket, projectKey, getStatusName }: Ticket
           <InlineCodeText text={ticket.title} className="truncate font-medium" />
           {ticket._count && ticket._count.subtasks > 0 && (
             <Badge variant="outline" className="shrink-0 text-xs">
+              {ticket.subtasks?.filter((s) => s.resolution != null).length ?? 0}/
               {ticket._count.subtasks} subtasks
             </Badge>
           )}

--- a/src/lib/prisma-selects.ts
+++ b/src/lib/prisma-selects.ts
@@ -173,6 +173,9 @@ export const TICKET_SELECT_FULL = {
       },
     },
   },
+  subtasks: {
+    select: { id: true, resolution: true },
+  },
   _count: {
     select: {
       comments: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -257,6 +257,7 @@ export interface TicketWithRelations {
   carriedFromSprint: SprintSummary | null
   labels: LabelSummary[]
   watchers: UserSummary[]
+  subtasks?: { id: string; resolution: string | null }[]
   attachments?: AttachmentInfo[]
   links?: TicketLinkSummary[]
   _count?: {


### PR DESCRIPTION
## Summary
- Kanban card subtask badge now shows `0/3` (resolved/total) instead of just the count
- Table row subtask badge now shows `1/3 subtasks` instead of `3 subtasks`
- Adds lightweight `subtasks` relation (`id` + `resolution`) to the ticket select for client-side resolved counting

Follow-up to #343 which added the basic subtask count badge.

## Test plan
- [x] Kanban cards show resolved/total format (e.g., `0/3`, `2/5`)
- [x] Table rows show resolved/total format (e.g., `1/3 subtasks`)
- [x] Tickets with no subtasks show no badge
- [x] All 1422 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)