### PR TITLE
fix(auth): use client-side redirect after sign-out (PUNT-291)

### DIFF
--- a/docs-site/docs/api-reference/realtime.md
+++ b/docs-site/docs/api-reference/realtime.md
@@ -278,8 +278,9 @@ When `database.wiped` is received:
 if (data.type === 'database.wiped') {
   // Clear all queries
   queryClient.clear()
-  // Sign out
-  signOut({ callbackUrl: '/login' })
+  // Sign out (use redirect: false + client-side redirect to avoid AUTH_URL resolving to localhost)
+  await signOut({ redirect: false })
+  window.location.href = '/login'
 }
 ```
 


### PR DESCRIPTION
## Summary
- Updates the documentation example in `docs-site/docs/api-reference/realtime.md` to use the `signOut({ redirect: false })` + `window.location.href = '/login'` pattern
- The source code was already fixed in PR #342, but the documentation example still showed the old `signOut({ callbackUrl: '/login' })` pattern which resolves against `AUTH_URL` (defaults to `http://localhost:3000`)

## Test plan
- [ ] Verify the documentation example in `docs-site/docs/api-reference/realtime.md` matches the actual source code pattern
- [ ] Confirm no remaining `signOut({ callbackUrl: ... })` calls exist in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)