### PR TITLE
feat(sprints): prevent unresolved tickets from being orphaned in completed sprints (PUNT-296)

### DIFF
--- a/mcp/src/tools/tickets.ts
+++ b/mcp/src/tools/tickets.ts
@@ -764,6 +764,18 @@ export function registerTicketTools(server: McpServer) {
           if (!sp) {
             return errorResponse(`Sprint not found: ${sprint}`)
           }
+          // Block assigning unresolved tickets to completed sprints
+          if (sp.status === 'completed') {
+            const effectiveResolution =
+              resolution !== undefined ? resolution : existingTicket.resolution
+            if (!effectiveResolution) {
+              return errorResponse(
+                `Cannot assign unresolved ticket to completed sprint "${sp.name}". ` +
+                  'To add a ticket to a completed sprint, it must have a resolution status ' +
+                  "(e.g., Done, Won't Fix). Otherwise the ticket will be orphaned and not visible in active views.",
+              )
+            }
+          }
           updateData.sprintId = sp.id
         }
       }
@@ -909,6 +921,14 @@ export function registerTicketTools(server: McpServer) {
           )
           if (!sp) {
             return errorResponse(`Sprint not found: ${sprint}`)
+          }
+          // Block assigning unresolved tickets to completed sprints
+          if (sp.status === 'completed' && !existingTicket.resolution) {
+            return errorResponse(
+              `Cannot move unresolved ticket to completed sprint "${sp.name}". ` +
+                'To add a ticket to a completed sprint, it must have a resolution status ' +
+                "(e.g., Done, Won't Fix). Otherwise the ticket will be orphaned and not visible in active views.",
+            )
           }
           updateData.sprintId = sp.id
           // Escape user-controlled sprint names

--- a/src/app/api/projects/[projectId]/tickets/[ticketId]/route.ts
+++ b/src/app/api/projects/[projectId]/tickets/[ticketId]/route.ts
@@ -342,8 +342,34 @@ export async function PATCH(
       }
     }
 
-    // Track sprint history when sprintId changes
+    // Validate: prevent assigning unresolved tickets to completed sprints
     const newSprintId = updateData.sprintId
+    if (
+      newSprintId !== undefined &&
+      newSprintId !== null &&
+      newSprintId !== existingTicket.sprintId
+    ) {
+      const targetSprint = await db.sprint.findFirst({
+        where: { id: newSprintId as string, projectId },
+        select: { status: true },
+      })
+      if (targetSprint?.status === 'completed') {
+        // Check the effective resolution: use the update value if provided, otherwise the existing value
+        const effectiveResolution =
+          dbUpdateData.resolution !== undefined
+            ? dbUpdateData.resolution
+            : existingTicket.resolution
+        if (!effectiveResolution) {
+          return badRequestError(
+            'Cannot assign an unresolved ticket to a completed sprint. ' +
+              'To add a ticket to a completed sprint, it must have a resolution status ' +
+              "(e.g., Done, Won't Fix). Otherwise the ticket will be orphaned and not visible in active views.",
+          )
+        }
+      }
+    }
+
+    // Track sprint history when sprintId changes
     if (newSprintId !== undefined && newSprintId !== existingTicket.sprintId) {
       // Close existing history entry for old sprint
       if (existingTicket.sprintId) {

--- a/src/app/api/projects/[projectId]/tickets/route.ts
+++ b/src/app/api/projects/[projectId]/tickets/route.ts
@@ -188,6 +188,21 @@ export async function POST(
       }
     }
 
+    // Validate: prevent assigning unresolved tickets to completed sprints
+    if (ticketData.sprintId) {
+      const targetSprint = await db.sprint.findFirst({
+        where: { id: ticketData.sprintId, projectId },
+        select: { status: true },
+      })
+      if (targetSprint?.status === 'completed' && !ticketData.resolution) {
+        return badRequestError(
+          'Cannot assign an unresolved ticket to a completed sprint. ' +
+            'To add a ticket to a completed sprint, it must have a resolution status ' +
+            "(e.g., Done, Won't Fix). Otherwise the ticket will be orphaned and not visible in active views.",
+        )
+      }
+    }
+
     // Create ticket with atomic ticket number generation
     const ticket = await db.$transaction(async (tx) => {
       // Get max ticket number for this project

--- a/src/components/sprints/sprint-backlog-view.tsx
+++ b/src/components/sprints/sprint-backlog-view.tsx
@@ -476,6 +476,23 @@ export function SprintBacklogView({
       // Case 2: Cross-section move
       if (ticketsChangingSprint.length === 0) return
 
+      // Block moving unresolved tickets to completed sprints
+      if (targetSprintId) {
+        const targetSprint = sprints?.find((s) => s.id === targetSprintId)
+        if (targetSprint?.status === 'completed') {
+          const unresolvedTickets = ticketsChangingSprint.filter((t) => !t.resolution)
+          if (unresolvedTickets.length > 0) {
+            showUndoRedoToast('error', {
+              title: 'Cannot move to completed sprint',
+              description:
+                'Unresolved tickets cannot be added to a completed sprint. ' +
+                "Set a resolution (e.g., Done, Won't Fix) first, or the tickets will be orphaned.",
+            })
+            return
+          }
+        }
+      }
+
       // Calculate new orders for tickets in target section
       const targetSectionKey = targetSprintId ?? 'backlog'
       const targetSectionTickets = ticketsBySprint[targetSectionKey] ?? []

--- a/src/components/sprints/sprint-selector.tsx
+++ b/src/components/sprints/sprint-selector.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Plus, Target } from 'lucide-react'
+import { AlertCircle, Plus, Target } from 'lucide-react'
 import {
   Select,
   SelectContent,
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useProjectSprints } from '@/hooks/queries/use-sprints'
 import { cn } from '@/lib/utils'
 import { useUIStore } from '@/stores/ui-store'
@@ -23,11 +24,15 @@ interface SprintSelectorProps {
   placeholder?: string
   showCreateButton?: boolean
   className?: string
+  /** When provided, completed sprints are blocked if the ticket has no resolution. */
+  ticketResolution?: string | null
 }
 
 /**
  * Dropdown selector for choosing a sprint.
  * Groups sprints by status (active, planning, completed).
+ * When ticketResolution is provided and null/empty, completed sprints are disabled
+ * to prevent orphaning unresolved tickets.
  */
 export function SprintSelector({
   projectId,
@@ -37,6 +42,7 @@ export function SprintSelector({
   placeholder = 'Select sprint',
   showCreateButton = true,
   className,
+  ticketResolution,
 }: SprintSelectorProps) {
   const { data: sprints, isLoading } = useProjectSprints(projectId)
   const { setSprintCreateOpen } = useUIStore()
@@ -45,12 +51,22 @@ export function SprintSelector({
   const planningSprints = sprints?.filter((s) => s.status === 'planning') ?? []
   const completedSprints = sprints?.filter((s) => s.status === 'completed') ?? []
 
+  // Completed sprints are blocked for unresolved tickets when ticketResolution is explicitly provided
+  const blockCompletedSprints = ticketResolution !== undefined && !ticketResolution
+
   const handleValueChange = (newValue: string) => {
     if (newValue === '__none__') {
       onChange(null)
     } else if (newValue === '__create__') {
       setSprintCreateOpen(true)
     } else {
+      // Block selection of completed sprints for unresolved tickets
+      if (blockCompletedSprints) {
+        const selectedSprint = sprints?.find((s) => s.id === newValue)
+        if (selectedSprint?.status === 'completed') {
+          return
+        }
+      }
       onChange(newValue)
     }
   }
@@ -113,13 +129,37 @@ export function SprintSelector({
         {completedSprints.length > 0 && (
           <SelectGroup>
             <SelectLabel className="text-zinc-500 text-xs">Completed</SelectLabel>
+            {blockCompletedSprints && (
+              <div className="flex items-start gap-2 px-2 py-1.5 text-xs text-amber-400/80">
+                <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                <span>
+                  Unresolved tickets cannot be added to completed sprints. Set a resolution first.
+                </span>
+              </div>
+            )}
             {completedSprints.slice(0, 5).map((sprint) => (
-              <SelectItem key={sprint.id} value={sprint.id}>
-                <div className="flex items-center gap-2">
-                  <span className={cn('w-1.5 h-1.5 rounded-full', 'bg-zinc-500')} />
-                  <span className="text-zinc-400">{sprint.name}</span>
-                </div>
-              </SelectItem>
+              <Tooltip key={sprint.id}>
+                <TooltipTrigger asChild>
+                  <div>
+                    <SelectItem
+                      value={sprint.id}
+                      disabled={blockCompletedSprints}
+                      className={blockCompletedSprints ? 'opacity-40 cursor-not-allowed' : ''}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className={cn('w-1.5 h-1.5 rounded-full', 'bg-zinc-500')} />
+                        <span className="text-zinc-400">{sprint.name}</span>
+                      </div>
+                    </SelectItem>
+                  </div>
+                </TooltipTrigger>
+                {blockCompletedSprints && (
+                  <TooltipContent side="right" className="max-w-xs">
+                    This sprint is completed. To add a ticket to a completed sprint, it must have a
+                    resolution status (e.g., Done, Won&apos;t Fix).
+                  </TooltipContent>
+                )}
+              </Tooltip>
             ))}
             {completedSprints.length > 5 && (
               <SelectItem disabled value="__more__">


### PR DESCRIPTION
## Summary

- Add API validation (400 response) to block assigning unresolved tickets to completed sprints on both ticket create and update endpoints
- Add MCP pre-flight validation in `update_ticket` and `move_ticket` tools with clear error messages
- Add UI blocking in sprint backlog drag-and-drop with toast error for unresolved tickets targeting completed sprints
- Enhance `SprintSelector` component with `ticketResolution` prop to disable completed sprint options with inline warning and tooltip

## Details

**API layer** (`src/app/api/projects/[projectId]/tickets/route.ts` and `.../[ticketId]/route.ts`):
- POST (create): Checks if `sprintId` points to a completed sprint and the ticket has no resolution
- PATCH (update): Considers both the existing resolution and any resolution being set in the same request (so setting resolution + sprint in one call works)
- Returns a descriptive 400 error explaining that resolved tickets are allowed for retroactive bookkeeping

**MCP tools** (`mcp/src/tools/tickets.ts`):
- `update_ticket`: Pre-validates sprint status, considers effective resolution (update value or existing)
- `move_ticket`: Pre-validates sprint status against existing ticket resolution

**UI** (`src/components/sprints/`):
- `sprint-backlog-view.tsx`: Drag-and-drop handler blocks moves of unresolved tickets to completed sprints with an error toast
- `sprint-selector.tsx`: New `ticketResolution` prop; when ticket is unresolved, completed sprint options are visually disabled with an inline amber warning and tooltip

**Sprint completion safeguard**: The existing `complete` API already requires an explicit `action` field (`close_to_next`, `close_to_backlog`, or `close_keep`), so incomplete tickets cannot be silently orphaned.

## Test plan

- [x] Try to assign an unresolved ticket to a completed sprint via API (should get 400)
- [x] Try the same via MCP `update_ticket` and `move_ticket` (should get error response)
- [x] Try dragging an unresolved ticket to a completed sprint section in the UI (should show error toast)
- [ ] Verify that a ticket with a resolution CAN be moved to a completed sprint (retroactive bookkeeping)
- [x] Verify that setting resolution and sprint in the same API call works when targeting a completed sprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)