### PR TITLE
feat(tickets): allow moving resolved tickets to completed sprints in drawer (PUNT-305)

### DIFF
--- a/src/app/api/projects/[projectId]/tickets/[ticketId]/route.ts
+++ b/src/app/api/projects/[projectId]/tickets/[ticketId]/route.ts
@@ -369,6 +369,25 @@ export async function PATCH(
       }
     }
 
+    // Validate: prevent clearing resolution on a ticket already in a completed sprint
+    if (
+      dbUpdateData.resolution === null &&
+      existingTicket.resolution &&
+      (newSprintId === undefined || newSprintId === existingTicket.sprintId) &&
+      existingTicket.sprintId
+    ) {
+      const currentSprint = await db.sprint.findFirst({
+        where: { id: existingTicket.sprintId, projectId },
+        select: { status: true },
+      })
+      if (currentSprint?.status === 'completed') {
+        return badRequestError(
+          'Cannot clear the resolution of a ticket in a completed sprint. ' +
+            'Remove the ticket from the completed sprint first, or set a different resolution.',
+        )
+      }
+    }
+
     // Track sprint history when sprintId changes
     if (newSprintId !== undefined && newSprintId !== existingTicket.sprintId) {
       // Close existing history entry for old sprint

--- a/src/components/tickets/ticket-detail-drawer.tsx
+++ b/src/components/tickets/ticket-detail-drawer.tsx
@@ -375,6 +375,11 @@ export function TicketDetailDrawer({ ticket, projectKey, onClose }: TicketDetail
             setTempResolution('Done')
           } else if (!isCompletedColumn(targetCol.name) && tempResolution) {
             setTempResolution(null)
+            // If in a completed sprint, reset sprint since resolution is being cleared
+            const selectedSprint = availableSprints.find((s) => s.id === tempSprintId)
+            if (selectedSprint?.status === 'completed') {
+              setTempSprintId(ticket.sprintId)
+            }
           }
         }
         break


### PR DESCRIPTION
## Summary
- Show completed sprints in the ticket drawer's sprint dropdown when the ticket has a resolution value (using unsaved form state, so it reacts immediately to resolution changes)
- Handle edge case: when the user clears the resolution while a completed sprint is selected, the sprint selection resets to the ticket's original sprint to prevent an invalid API state
- Completed sprints already have a `(Completed)` visual suffix in the dropdown

## Test plan
- [x] Open a ticket with no resolution, verify completed sprints are NOT shown in the sprint dropdown
- [x] Set a resolution (e.g., "Done") without saving, verify completed sprints now appear in the dropdown
- [x] Select a completed sprint, then clear the resolution — verify the sprint resets to the original value
- [x] Save a resolved ticket with a completed sprint — verify the API accepts it
- [x] Verify that a ticket already in a completed sprint still shows that sprint in the dropdown regardless of resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)