### PR TITLE
fix(board): propagate resolution to linked tickets (PUNT-307)

### DIFF
--- a/src/stores/board-store.ts
+++ b/src/stores/board-store.ts
@@ -365,40 +365,69 @@ export const useBoardStore = create<BoardState>()(
           const _startTime = performance.now()
 
           const columns = state.getColumns(projectId)
+
+          // Look up the ticket and compute resolution change before mapping
+          const sourceTicket = columns
+            .find((c) => c.id === fromColumnId)
+            ?.tickets.find((t) => t.id === ticketId)
+          const targetColumn = columns.find((c) => c.id === toColumnId)
+          const targetIsDone = targetColumn ? isCompletedColumn(targetColumn.name) : false
+          const newResolution = sourceTicket
+            ? targetIsDone && !sourceTicket.resolution
+              ? ('Done' as const)
+              : !targetIsDone && sourceTicket.resolution
+                ? null
+                : sourceTicket.resolution
+            : null
+          const resolutionChanged =
+            sourceTicket != null && newResolution !== sourceTicket.resolution
+
           const newColumns = columns.map((column) => {
             // Remove from source column
             if (column.id === fromColumnId) {
               return {
                 ...column,
-                tickets: column.tickets.filter((t) => t.id !== ticketId),
+                tickets: column.tickets
+                  .filter((t) => t.id !== ticketId)
+                  .map((t) =>
+                    resolutionChanged ? propagateResolutionToLinks(t, ticketId, newResolution) : t,
+                  ),
               }
             }
 
             // Add to target column
             if (column.id === toColumnId) {
-              const ticket = columns
-                .find((c) => c.id === fromColumnId)
-                ?.tickets.find((t) => t.id === ticketId)
+              if (!sourceTicket) return column
 
-              if (!ticket) return column
-
-              const targetIsDone = isCompletedColumn(column.name)
               const updatedTicket = {
-                ...ticket,
+                ...sourceTicket,
                 columnId: toColumnId,
                 order: newOrder,
-                // Auto-couple resolution: set "Done" when moving to done, clear when moving out
-                ...(targetIsDone && !ticket.resolution ? { resolution: 'Done' as const } : {}),
-                ...(!targetIsDone && ticket.resolution ? { resolution: null } : {}),
+                resolution: newResolution,
+                ...(resolutionChanged ? { resolvedAt: newResolution ? new Date() : null } : {}),
               }
 
-              const newTickets = [...column.tickets]
+              const newTickets = [
+                ...column.tickets.map((t) =>
+                  resolutionChanged ? propagateResolutionToLinks(t, ticketId, newResolution) : t,
+                ),
+              ]
               newTickets.splice(newOrder, 0, updatedTicket)
 
               // Reorder remaining tickets
               return {
                 ...column,
                 tickets: newTickets.map((t, idx) => ({ ...t, order: idx })),
+              }
+            }
+
+            // Propagate resolution to other columns
+            if (resolutionChanged) {
+              return {
+                ...column,
+                tickets: column.tickets.map((t) =>
+                  propagateResolutionToLinks(t, ticketId, newResolution),
+                ),
               }
             }
 
@@ -465,9 +494,22 @@ export const useBoardStore = create<BoardState>()(
 
           if (sortedTickets.length === 0) return state
 
+          // Collect tickets whose resolution changed for link propagation
+          const resolutionChanges = sortedTickets.filter((t) => {
+            const original = columns.flatMap((c) => c.tickets).find((orig) => orig.id === t.id)
+            return original && original.resolution !== t.resolution
+          })
+
           const newColumns = columns.map((column) => {
             // Remove selected tickets from any column they're in
-            const remainingTickets = column.tickets.filter((t) => !ticketIds.includes(t.id))
+            let remainingTickets = column.tickets.filter((t) => !ticketIds.includes(t.id))
+
+            // Propagate resolution changes to linked tickets
+            for (const changed of resolutionChanges) {
+              remainingTickets = remainingTickets.map((t) =>
+                propagateResolutionToLinks(t, changed.id, changed.resolution),
+              )
+            }
 
             // Add to target column
             if (column.id === toColumnId) {


### PR DESCRIPTION
## Summary
- When a ticket's resolution changes (e.g., marked Done), the board store now propagates that change to `linkedTicket.resolution` in all other tickets' link data
- This clears the "Blocked" badge immediately when a blocker is resolved, without waiting for a full API refetch
- Handles all update paths: single ticket updates, column-change moves (auto-resolve), and batch updates

## Root Cause
The optimistic update for ticket resolution only updated the resolved ticket itself. Other tickets linking to it still had stale `linkedTicket.resolution = null`, so the `isBlocked` check continued showing "Blocked" even though the blocker was resolved. The SSE same-tab skip prevented the full refetch that would have corrected this.

## Test plan
- [x] Resolve a ticket that blocks another ticket (set resolution to Done)
- [x] Verify the "Blocked" badge disappears immediately on the dependent ticket
- [x] Drag a blocking ticket to a "Done" column (auto-resolve) and verify badge clears
- [x] Undo the resolution and verify "Blocked" badge reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)