### PR TITLE
feat(api): attribute ticket creation to Agent (PUNT-301)

### DIFF
--- a/src/app/api/projects/[projectId]/tickets/route.ts
+++ b/src/app/api/projects/[projectId]/tickets/route.ts
@@ -227,6 +227,8 @@ export async function POST(
           order: nextOrder,
           projectId,
           creatorId,
+          // Attribute to agent if this is an MCP request
+          createdByAgentId: user.agentId ?? null,
           type: ticketData.type as IssueType,
           priority: ticketData.priority as Priority,
           // Set resolvedAt: use provided value (for restore), or current time if resolution exists
@@ -257,6 +259,7 @@ export async function POST(
     })
 
     // Log ticket creation in audit trail
+    // TODO: Pass agent context (user.agentId) to audit logging when the schema supports it
     const activityId = await logTicketCreated(ticket.id, user.id)
 
     // Emit real-time event for other clients


### PR DESCRIPTION
## Summary

- Sets `createdByAgentId` on new tickets when created via MCP (agent request), linking the ticket to the Agent that created it
- `creatorId` continues to point to the human API key owner; `createdByAgentId` tracks which agent performed the action
- Adds TODO comment noting future opportunity to pass agent context to audit logging

## Test plan

- [x] Create a ticket via the web UI — verify `createdByAgentId` is null
- [x] Create a ticket via MCP API key — verify `createdByAgentId` is set to the agent's ID
- [x] Verify TypeScript compiles without new errors
- [x] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)