### PR TITLE
fix(backup): harden import/export against schema version mismatches (PUNT-311)

### DIFF
--- a/src/lib/database-export.ts
+++ b/src/lib/database-export.ts
@@ -83,6 +83,7 @@ export async function exportDatabase(options: ExportOptions = {}): Promise<Expor
     attachments,
     ticketSprintHistory,
     invitations,
+    agents,
   ] = await Promise.all([
     db.systemSettings.findUnique({ where: { id: 'system-settings' } }),
     db.user.findMany({
@@ -147,6 +148,9 @@ export async function exportDatabase(options: ExportOptions = {}): Promise<Expor
     }),
     db.invitation.findMany({
       where: projectFilter,
+      orderBy: { createdAt: 'asc' },
+    }),
+    db.agent.findMany({
       orderBy: { createdAt: 'asc' },
     }),
   ])
@@ -270,6 +274,11 @@ export async function exportDatabase(options: ExportOptions = {}): Promise<Expor
       ...inv,
       expiresAt: inv.expiresAt.toISOString(),
       createdAt: inv.createdAt.toISOString(),
+    })),
+    agents: agents.map((a) => ({
+      ...a,
+      createdAt: a.createdAt.toISOString(),
+      lastActiveAt: a.lastActiveAt?.toISOString() ?? null,
     })),
   } as ExportData
 }

--- a/src/lib/database-import.ts
+++ b/src/lib/database-import.ts
@@ -54,6 +54,7 @@ export interface ImportResult {
     attachments: number
     ticketSprintHistory: number
     invitations: number
+    agents: number
   }
   files: {
     attachmentsRestored: number
@@ -128,7 +129,7 @@ function parseBackupJson(
   const exportFile = result.data as AnyDatabaseExport
 
   // Check version compatibility
-  const COMPATIBLE_VERSIONS = ['1.0.0', '1.1.0', '1.2.0', EXPORT_VERSION]
+  const COMPATIBLE_VERSIONS = ['1.0.0', '1.1.0', '1.2.0', '1.3.0', EXPORT_VERSION]
   if (!COMPATIBLE_VERSIONS.includes(exportFile.version)) {
     return {
       success: false,
@@ -371,7 +372,19 @@ async function restoreFilesFromZip(
  * Deletes all data from the database in reverse FK order
  */
 async function wipeDatabase(tx: Parameters<Parameters<typeof db.$transaction>[0]>[0]) {
+  // Safely delete from tables that may not exist yet (added in later schema versions).
+  // Uses PL/pgSQL exception handling so a missing table doesn't abort the transaction.
+  const safeDeleteAll = (table: string) =>
+    tx.$executeRawUnsafe(`
+      DO $$ BEGIN
+        DELETE FROM "${table}";
+      EXCEPTION WHEN undefined_table THEN NULL;
+      END $$
+    `)
+
   // Delete in reverse FK order to avoid constraint violations
+  await safeDeleteAll('ChatMessage')
+  await safeDeleteAll('ChatSession')
   await tx.ticketSprintHistory.deleteMany()
   await tx.attachment.deleteMany()
   await tx.ticketActivity.deleteMany()
@@ -380,6 +393,7 @@ async function wipeDatabase(tx: Parameters<Parameters<typeof db.$transaction>[0]
   await tx.ticketWatcher.deleteMany()
   await tx.ticketLink.deleteMany()
   await tx.ticket.deleteMany()
+  await safeDeleteAll('Agent')
   await tx.projectSprintSettings.deleteMany()
   await tx.projectMember.deleteMany()
   await tx.sprint.deleteMany()
@@ -424,6 +438,7 @@ export async function importDatabase(
     attachments: 0,
     ticketSprintHistory: 0,
     invitations: 0,
+    agents: 0,
   }
 
   let files = {
@@ -486,50 +501,108 @@ export async function importDatabase(
   // Use a transaction with a long timeout (2 minutes) for large imports
   await db.$transaction(
     async (tx) => {
+      // Check which optional columns exist in the database to handle schema differences.
+      // This lets us safely import exports from newer/older versions without P2022 errors.
+      const columnCheck = await tx.$queryRaw<{ column_name: string }[]>`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name IN ('User', 'Project', 'Ticket', 'SystemSettings', 'ProjectSprintSettings')
+      `
+      const existingColumns = new Set(columnCheck.map((c) => c.column_name))
+
       // Step 1: Wipe existing data
       await wipeDatabase(tx)
 
       // Step 2: Import SystemSettings (upsert)
       if (dataToImport.systemSettings) {
-        const { defaultRolePermissions, ...settingsRest } = dataToImport.systemSettings
-        const settingsData = {
+        const {
+          defaultRolePermissions,
+          showAddColumnButton: ssShowAddCol,
+          canonicalRepoUrl,
+          repoHostingProvider,
+          forkRepoUrl,
+          defaultBranchTemplate,
+          defaultAgentGuidance,
+          defaultSprintStartTime,
+          defaultSprintEndTime,
+          ...settingsRest
+        } = dataToImport.systemSettings
+        const settingsData: Record<string, unknown> = {
           ...settingsRest,
           updatedAt: new Date(dataToImport.systemSettings.updatedAt),
           defaultRolePermissions: defaultRolePermissions
             ? (defaultRolePermissions as Prisma.InputJsonValue)
             : Prisma.DbNull,
         }
+        // Only include fields that exist in the current database schema
+        if (existingColumns.has('showAddColumnButton'))
+          settingsData.showAddColumnButton = ssShowAddCol
+        if (existingColumns.has('canonicalRepoUrl'))
+          settingsData.canonicalRepoUrl = canonicalRepoUrl
+        if (existingColumns.has('repoHostingProvider'))
+          settingsData.repoHostingProvider = repoHostingProvider
+        if (existingColumns.has('forkRepoUrl')) settingsData.forkRepoUrl = forkRepoUrl
+        if (existingColumns.has('defaultBranchTemplate'))
+          settingsData.defaultBranchTemplate = defaultBranchTemplate
+        if (existingColumns.has('defaultAgentGuidance'))
+          settingsData.defaultAgentGuidance = defaultAgentGuidance
+        if (existingColumns.has('defaultSprintStartTime'))
+          settingsData.defaultSprintStartTime = defaultSprintStartTime
+        if (existingColumns.has('defaultSprintEndTime'))
+          settingsData.defaultSprintEndTime = defaultSprintEndTime
+
+        type SettingsUpsertData = Parameters<typeof tx.systemSettings.upsert>[0]['create']
         await tx.systemSettings.upsert({
           where: { id: 'system-settings' },
-          create: settingsData,
-          update: settingsData,
+          create: settingsData as SettingsUpsertData,
+          update: settingsData as SettingsUpsertData,
         })
       }
 
       // Step 3: Import Users
       if (dataToImport.users.length > 0) {
         for (const user of dataToImport.users) {
-          // Strip legacy/extra fields from passthrough
+          // Strip legacy fields and extract Json/optional fields for special handling
           const {
             usernameLower: _ul,
             enabledMcpServers,
             totpRecoveryCodes,
+            mcpApiKeyEncrypted,
+            mcpApiKeyHint,
+            anthropicApiKey,
+            chatProvider,
+            claudeSessionEncrypted,
             ...userData
-          } = user as typeof user & { usernameLower?: string; enabledMcpServers?: unknown }
+          } = user as typeof user & { usernameLower?: string }
+          // Build data with conditionally-included fields for schema compatibility.
+          // Cast needed because Prisma types assume current schema, but DB may be older.
+          const createData: Record<string, unknown> = {
+            ...userData,
+            totpRecoveryCodes:
+              Array.isArray(totpRecoveryCodes) || typeof totpRecoveryCodes === 'string'
+                ? totpRecoveryCodes
+                : Prisma.DbNull,
+            createdAt: new Date(user.createdAt),
+            updatedAt: new Date(user.updatedAt),
+            lastLoginAt: user.lastLoginAt ? new Date(user.lastLoginAt) : null,
+            passwordChangedAt: user.passwordChangedAt ? new Date(user.passwordChangedAt) : null,
+            emailVerified: user.emailVerified ? new Date(user.emailVerified) : null,
+          }
+          // Only include fields that exist in the current database schema
+          if (existingColumns.has('enabledMcpServers'))
+            createData.enabledMcpServers = enabledMcpServers ?? Prisma.DbNull
+          if (existingColumns.has('mcpApiKeyEncrypted'))
+            createData.mcpApiKeyEncrypted = mcpApiKeyEncrypted
+          if (existingColumns.has('mcpApiKeyHint')) createData.mcpApiKeyHint = mcpApiKeyHint
+          if (existingColumns.has('anthropicApiKey')) createData.anthropicApiKey = anthropicApiKey
+          if (existingColumns.has('chatProvider')) createData.chatProvider = chatProvider
+          if (existingColumns.has('claudeSessionEncrypted'))
+            createData.claudeSessionEncrypted = claudeSessionEncrypted
+
+          // Use select:{id:true} to prevent Prisma from generating a RETURNING clause
+          // that references columns which may not exist in the database yet.
           await tx.user.create({
-            data: {
-              ...userData,
-              enabledMcpServers: enabledMcpServers ?? Prisma.DbNull,
-              totpRecoveryCodes:
-                Array.isArray(totpRecoveryCodes) || typeof totpRecoveryCodes === 'string'
-                  ? totpRecoveryCodes
-                  : Prisma.DbNull,
-              createdAt: new Date(user.createdAt),
-              updatedAt: new Date(user.updatedAt),
-              lastLoginAt: user.lastLoginAt ? new Date(user.lastLoginAt) : null,
-              passwordChangedAt: user.passwordChangedAt ? new Date(user.passwordChangedAt) : null,
-              emailVerified: user.emailVerified ? new Date(user.emailVerified) : null,
-            },
+            data: createData as Parameters<typeof tx.user.create>[0]['data'],
+            select: { id: true },
           })
         }
         counts.users = dataToImport.users.length
@@ -538,12 +611,49 @@ export async function importDatabase(
       // Step 4: Import Projects
       if (dataToImport.projects.length > 0) {
         for (const project of dataToImport.projects) {
+          const {
+            environmentBranches,
+            commitPatterns,
+            showAddColumnButton,
+            repositoryUrl,
+            repositoryProvider,
+            localPath,
+            defaultBranch,
+            branchTemplate,
+            agentGuidance,
+            monorepoPath,
+            webhookSecret,
+            ...projectData
+          } = project
+          const projCreateData: Record<string, unknown> = {
+            ...projectData,
+            createdAt: new Date(project.createdAt),
+            updatedAt: new Date(project.updatedAt),
+          }
+          // Only include fields that exist in the current database schema
+          if (existingColumns.has('showAddColumnButton'))
+            projCreateData.showAddColumnButton = showAddColumnButton
+          if (existingColumns.has('repositoryUrl')) projCreateData.repositoryUrl = repositoryUrl
+          if (existingColumns.has('repositoryProvider'))
+            projCreateData.repositoryProvider = repositoryProvider
+          if (existingColumns.has('localPath')) projCreateData.localPath = localPath
+          if (existingColumns.has('defaultBranch')) projCreateData.defaultBranch = defaultBranch
+          if (existingColumns.has('branchTemplate')) projCreateData.branchTemplate = branchTemplate
+          if (existingColumns.has('agentGuidance')) projCreateData.agentGuidance = agentGuidance
+          if (existingColumns.has('monorepoPath')) projCreateData.monorepoPath = monorepoPath
+          if (existingColumns.has('webhookSecret')) projCreateData.webhookSecret = webhookSecret
+          if (existingColumns.has('environmentBranches'))
+            projCreateData.environmentBranches = environmentBranches
+              ? (environmentBranches as Prisma.InputJsonValue)
+              : Prisma.DbNull
+          if (existingColumns.has('commitPatterns'))
+            projCreateData.commitPatterns = commitPatterns
+              ? (commitPatterns as Prisma.InputJsonValue)
+              : Prisma.DbNull
+
           await tx.project.create({
-            data: {
-              ...project,
-              createdAt: new Date(project.createdAt),
-              updatedAt: new Date(project.updatedAt),
-            },
+            data: projCreateData as Parameters<typeof tx.project.create>[0]['data'],
+            select: { id: true },
           })
         }
         counts.projects = dataToImport.projects.length
@@ -559,6 +669,7 @@ export async function importDatabase(
               createdAt: new Date(role.createdAt),
               updatedAt: new Date(role.updatedAt),
             },
+            select: { id: true },
           })
         }
         counts.roles = dataToImport.roles.length
@@ -567,7 +678,7 @@ export async function importDatabase(
       // Step 6: Import Columns
       if (dataToImport.columns.length > 0) {
         for (const column of dataToImport.columns) {
-          await tx.column.create({ data: column })
+          await tx.column.create({ data: column, select: { id: true } })
         }
         counts.columns = dataToImport.columns.length
       }
@@ -575,7 +686,7 @@ export async function importDatabase(
       // Step 7: Import Labels
       if (dataToImport.labels.length > 0) {
         for (const label of dataToImport.labels) {
-          await tx.label.create({ data: label })
+          await tx.label.create({ data: label, select: { id: true } })
         }
         counts.labels = dataToImport.labels.length
       }
@@ -593,6 +704,7 @@ export async function importDatabase(
               createdAt: new Date(sprint.createdAt),
               updatedAt: new Date(sprint.updatedAt),
             },
+            select: { id: true },
           })
         }
         counts.sprints = dataToImport.sprints.length
@@ -610,6 +722,7 @@ export async function importDatabase(
               createdAt: new Date(member.createdAt),
               updatedAt: new Date(member.updatedAt),
             },
+            select: { id: true },
           })
         }
         counts.projectMembers = dataToImport.projectMembers.length
@@ -618,13 +731,18 @@ export async function importDatabase(
       // Step 10: Import ProjectSprintSettings
       if (dataToImport.projectSprintSettings.length > 0) {
         for (const settings of dataToImport.projectSprintSettings) {
+          const { defaultStartTime, defaultEndTime, ...sprintSettingsData } = settings
+          const pssData: Record<string, unknown> = {
+            ...sprintSettingsData,
+            doneColumnIds: settings.doneColumnIds as Prisma.InputJsonValue,
+            createdAt: new Date(settings.createdAt),
+            updatedAt: new Date(settings.updatedAt),
+          }
+          if (existingColumns.has('defaultStartTime')) pssData.defaultStartTime = defaultStartTime
+          if (existingColumns.has('defaultEndTime')) pssData.defaultEndTime = defaultEndTime
           await tx.projectSprintSettings.create({
-            data: {
-              ...settings,
-              doneColumnIds: settings.doneColumnIds as Prisma.InputJsonValue,
-              createdAt: new Date(settings.createdAt),
-              updatedAt: new Date(settings.updatedAt),
-            },
+            data: pssData as Parameters<typeof tx.projectSprintSettings.create>[0]['data'],
+            select: { id: true },
           })
         }
         counts.projectSprintSettings = dataToImport.projectSprintSettings.length
@@ -636,7 +754,7 @@ export async function importDatabase(
       // parentId first, then update the parent references in a second pass.
       if (dataToImport.tickets.length > 0) {
         for (const ticket of dataToImport.tickets) {
-          const { labelIds, parentId, ...ticketData } = ticket
+          const { labelIds, parentId, createdByAgentId: _agentId, ...ticketData } = ticket
           await tx.ticket.create({
             data: {
               ...ticketData,
@@ -649,6 +767,7 @@ export async function importDatabase(
               createdAt: new Date(ticketData.createdAt),
               updatedAt: new Date(ticketData.updatedAt),
             },
+            select: { id: true },
           })
         }
         counts.tickets = dataToImport.tickets.length
@@ -659,6 +778,7 @@ export async function importDatabase(
             await tx.ticket.update({
               where: { id: ticket.id },
               data: { parentId: ticket.parentId },
+              select: { id: true },
             })
           }
         }
@@ -673,6 +793,7 @@ export async function importDatabase(
                   connect: ticket.labelIds.map((id) => ({ id })),
                 },
               },
+              select: { id: true },
             })
           }
         }
@@ -687,6 +808,7 @@ export async function importDatabase(
               linkType: link.linkType as LinkType,
               createdAt: new Date(link.createdAt),
             },
+            select: { id: true },
           })
         }
         counts.ticketLinks = dataToImport.ticketLinks.length
@@ -700,6 +822,7 @@ export async function importDatabase(
               ...watcher,
               createdAt: new Date(watcher.createdAt),
             },
+            select: { id: true },
           })
         }
         counts.ticketWatchers = dataToImport.ticketWatchers.length
@@ -714,6 +837,7 @@ export async function importDatabase(
               createdAt: new Date(comment.createdAt),
               updatedAt: new Date(comment.updatedAt),
             },
+            select: { id: true },
           })
         }
         counts.comments = dataToImport.comments.length
@@ -727,6 +851,7 @@ export async function importDatabase(
               ...edit,
               createdAt: new Date(edit.createdAt),
             },
+            select: { id: true },
           })
         }
         counts.ticketEdits = dataToImport.ticketEdits.length
@@ -741,6 +866,7 @@ export async function importDatabase(
               ...activity,
               createdAt: new Date(activity.createdAt),
             },
+            select: { id: true },
           })
         }
         counts.ticketActivities = ticketActivities.length
@@ -755,6 +881,7 @@ export async function importDatabase(
               ...attachment,
               createdAt: new Date(attachment.createdAt),
             },
+            select: { id: true },
           })
         }
         counts.attachments = dataToImport.attachments.length
@@ -771,6 +898,7 @@ export async function importDatabase(
               addedAt: new Date(history.addedAt),
               removedAt: history.removedAt ? new Date(history.removedAt) : null,
             },
+            select: { id: true },
           })
         }
         counts.ticketSprintHistory = dataToImport.ticketSprintHistory.length
@@ -787,9 +915,33 @@ export async function importDatabase(
               expiresAt: new Date(invitation.expiresAt),
               createdAt: new Date(invitation.createdAt),
             },
+            select: { id: true },
           })
         }
         counts.invitations = dataToImport.invitations.length
+      }
+      // Step 19: Import Agents (table may not exist in older database schemas)
+      const agents = dataToImport.agents ?? []
+      if (agents.length > 0) {
+        const agentTableExists = await tx.$queryRaw<{ exists: boolean }[]>`
+          SELECT EXISTS (
+            SELECT FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = 'Agent'
+          ) as exists
+        `
+        if (agentTableExists[0]?.exists) {
+          for (const agent of agents) {
+            await tx.agent.create({
+              data: {
+                ...agent,
+                createdAt: new Date(agent.createdAt),
+                lastActiveAt: agent.lastActiveAt ? new Date(agent.lastActiveAt) : null,
+              },
+              select: { id: true },
+            })
+          }
+          counts.agents = agents.length
+        }
       }
     },
     {

--- a/src/lib/schemas/database-export.ts
+++ b/src/lib/schemas/database-export.ts
@@ -17,83 +17,110 @@ const nullableDate = z.union([z.string().datetime(), z.null()])
 // Helper for JSON fields that may be stored as strings (legacy exports) or native JSON
 const jsonOrString = z.union([z.string(), z.array(z.unknown()), z.record(z.string(), z.unknown())])
 
-export const SystemSettingsSchema = z
-  .object({
-    id: z.string(),
-    updatedAt: z.string().datetime(),
-    updatedBy: z.string().nullable(),
-    // Branding
-    appName: z.string(),
-    logoUrl: z.string().nullable(),
-    logoLetter: z.string(),
-    logoGradientFrom: z.string(),
-    logoGradientTo: z.string(),
-    // Upload limits
-    maxImageSizeMB: z.number(),
-    maxVideoSizeMB: z.number(),
-    maxDocumentSizeMB: z.number(),
-    maxAttachmentsPerTicket: z.number(),
-    // Allowed MIME types (native JSON arrays or legacy strings)
-    allowedImageTypes: z.union([z.string(), z.array(z.string())]),
-    allowedVideoTypes: z.union([z.string(), z.array(z.string())]),
-    allowedDocumentTypes: z.union([z.string(), z.array(z.string())]),
-    // Email settings
-    emailEnabled: z.boolean(),
-    emailProvider: z.string(),
-    emailFromAddress: z.string(),
-    emailFromName: z.string(),
-    smtpHost: z.string(),
-    smtpPort: z.number(),
-    smtpUsername: z.string(),
-    smtpSecure: z.boolean(),
-    emailPasswordReset: z.boolean(),
-    emailWelcome: z.boolean(),
-    emailVerification: z.boolean(),
-    emailInvitations: z.boolean(),
-    // Default role permissions (native JSON or legacy string)
-    defaultRolePermissions: z.union([z.string(), z.record(z.string(), z.unknown())]).nullable(),
-  })
-  .passthrough()
+export const SystemSettingsSchema = z.object({
+  id: z.string(),
+  updatedAt: z.string().datetime(),
+  updatedBy: z.string().nullable(),
+  // Branding
+  appName: z.string(),
+  logoUrl: z.string().nullable(),
+  logoLetter: z.string(),
+  logoGradientFrom: z.string(),
+  logoGradientTo: z.string(),
+  // Upload limits
+  maxImageSizeMB: z.number(),
+  maxVideoSizeMB: z.number(),
+  maxDocumentSizeMB: z.number(),
+  maxAttachmentsPerTicket: z.number(),
+  // Allowed MIME types (native JSON arrays or legacy strings)
+  allowedImageTypes: z.union([z.string(), z.array(z.string())]),
+  allowedVideoTypes: z.union([z.string(), z.array(z.string())]),
+  allowedDocumentTypes: z.union([z.string(), z.array(z.string())]),
+  // Email settings
+  emailEnabled: z.boolean(),
+  emailProvider: z.string(),
+  emailFromAddress: z.string(),
+  emailFromName: z.string(),
+  smtpHost: z.string(),
+  smtpPort: z.number(),
+  smtpUsername: z.string(),
+  smtpSecure: z.boolean(),
+  emailPasswordReset: z.boolean(),
+  emailWelcome: z.boolean(),
+  emailVerification: z.boolean(),
+  emailInvitations: z.boolean(),
+  // Board settings
+  showAddColumnButton: z.boolean().optional(),
+  // Default role permissions (native JSON or legacy string)
+  defaultRolePermissions: z.union([z.string(), z.record(z.string(), z.unknown())]).nullable(),
+  // Repository configuration (global defaults)
+  canonicalRepoUrl: z.string().nullable().optional(),
+  repoHostingProvider: z.string().nullable().optional(),
+  forkRepoUrl: z.string().nullable().optional(),
+  // Agent configuration (global defaults)
+  defaultBranchTemplate: z.string().optional(),
+  defaultAgentGuidance: z.string().nullable().optional(),
+  // Default sprint times (system-wide defaults)
+  defaultSprintStartTime: z.string().optional(),
+  defaultSprintEndTime: z.string().optional(),
+})
 
-export const UserSchema = z
-  .object({
-    id: z.string(),
-    username: z.string(),
-    usernameLower: z.string().nullable().optional(), // Legacy field, ignored on import
-    email: z.string().nullable(),
-    name: z.string(),
-    avatar: z.string().nullable(),
-    avatarColor: z.string().nullable(),
-    createdAt: z.string().datetime(),
-    updatedAt: z.string().datetime(),
-    lastLoginAt: nullableDate,
-    passwordHash: z.string().nullable(),
-    passwordChangedAt: nullableDate,
-    emailVerified: nullableDate,
-    isSystemAdmin: z.boolean(),
-    isActive: z.boolean(),
-    mcpApiKey: z.string().nullable(),
-    // 2FA fields (optional for backward compatibility with pre-1.2.0 exports)
-    totpSecret: z.string().nullable().optional(),
-    totpEnabled: z.boolean().optional(),
-    totpRecoveryCodes: z
-      .union([z.string(), z.array(z.string()), z.record(z.string(), z.unknown())])
-      .nullable()
-      .optional(),
-  })
-  .passthrough()
+export const UserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  usernameLower: z.string().nullable().optional(), // Legacy field, ignored on import
+  email: z.string().nullable(),
+  name: z.string(),
+  avatar: z.string().nullable(),
+  avatarColor: z.string().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  lastLoginAt: nullableDate,
+  passwordHash: z.string().nullable(),
+  passwordChangedAt: nullableDate,
+  emailVerified: nullableDate,
+  isSystemAdmin: z.boolean(),
+  isActive: z.boolean(),
+  mcpApiKey: z.string().nullable(),
+  // MCP API key fields (optional for backward compatibility)
+  mcpApiKeyEncrypted: z.string().nullable().optional(),
+  mcpApiKeyHint: z.string().nullable().optional(),
+  // Claude Chat API access (optional for backward compatibility)
+  anthropicApiKey: z.string().nullable().optional(),
+  chatProvider: z.string().nullable().optional(),
+  claudeSessionEncrypted: z.string().nullable().optional(),
+  enabledMcpServers: jsonOrString.nullable().optional(),
+  // 2FA fields (optional for backward compatibility with pre-1.2.0 exports)
+  totpSecret: z.string().nullable().optional(),
+  totpEnabled: z.boolean().optional(),
+  totpRecoveryCodes: z
+    .union([z.string(), z.array(z.string()), z.record(z.string(), z.unknown())])
+    .nullable()
+    .optional(),
+})
 
-export const ProjectSchema = z
-  .object({
-    id: z.string(),
-    name: z.string(),
-    key: z.string(),
-    description: z.string().nullable(),
-    color: z.string(),
-    createdAt: z.string().datetime(),
-    updatedAt: z.string().datetime(),
-  })
-  .passthrough()
+export const ProjectSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  key: z.string(),
+  description: z.string().nullable(),
+  color: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  // Board settings (optional for backward compatibility)
+  showAddColumnButton: z.boolean().nullable().optional(),
+  // Repository integration (optional for backward compatibility)
+  repositoryUrl: z.string().nullable().optional(),
+  repositoryProvider: z.string().nullable().optional(),
+  localPath: z.string().nullable().optional(),
+  defaultBranch: z.string().nullable().optional(),
+  branchTemplate: z.string().nullable().optional(),
+  agentGuidance: z.string().nullable().optional(),
+  monorepoPath: z.string().nullable().optional(),
+  environmentBranches: jsonOrString.nullable().optional(),
+  webhookSecret: z.string().nullable().optional(),
+  commitPatterns: jsonOrString.nullable().optional(),
+})
 
 export const RoleSchema = z.object({
   id: z.string(),
@@ -153,17 +180,18 @@ export const ProjectMemberSchema = z.object({
   updatedAt: z.string().datetime(),
 })
 
-export const ProjectSprintSettingsSchema = z
-  .object({
-    id: z.string(),
-    projectId: z.string(),
-    defaultSprintDuration: z.number(),
-    autoCarryOverIncomplete: z.boolean(),
-    doneColumnIds: jsonOrString,
-    createdAt: z.string().datetime(),
-    updatedAt: z.string().datetime(),
-  })
-  .passthrough()
+export const ProjectSprintSettingsSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  defaultSprintDuration: z.number(),
+  autoCarryOverIncomplete: z.boolean(),
+  doneColumnIds: jsonOrString,
+  // Default times (optional for backward compatibility)
+  defaultStartTime: z.string().optional(),
+  defaultEndTime: z.string().optional(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+})
 
 export const TicketSchema = z.object({
   id: z.string(),
@@ -193,6 +221,8 @@ export const TicketSchema = z.object({
   carriedFromSprintId: z.string().nullable(),
   carriedOverCount: z.number(),
   parentId: z.string().nullable(),
+  // Agent attribution (optional for backward compatibility)
+  createdByAgentId: z.string().nullable().optional(),
   // Many-to-many label IDs (handled separately)
   labelIds: z.array(z.string()).optional(),
 })
@@ -277,6 +307,16 @@ export const InvitationSchema = z.object({
   projectId: z.string(),
 })
 
+export const AgentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  apiKeyHash: z.string(),
+  ownerId: z.string(),
+  createdAt: z.string().datetime(),
+  lastActiveAt: nullableDate,
+  isActive: z.boolean(),
+})
+
 // ============================================================================
 // Export data schema
 // ============================================================================
@@ -301,6 +341,7 @@ export const ExportDataSchema = z.object({
   attachments: z.array(AttachmentSchema),
   ticketSprintHistory: z.array(TicketSprintHistorySchema),
   invitations: z.array(InvitationSchema),
+  agents: z.array(AgentSchema).optional().default([]),
 })
 
 export type ExportData = z.infer<typeof ExportDataSchema>
@@ -358,4 +399,4 @@ export const AnyDatabaseExportSchema = z.union([
 export type AnyDatabaseExport = z.infer<typeof AnyDatabaseExportSchema>
 
 // Export version for compatibility checks
-export const EXPORT_VERSION = '1.3.0'
+export const EXPORT_VERSION = '1.4.0'


### PR DESCRIPTION
## Summary
- Remove `.passthrough()` from Zod export schemas and add all current model fields (as optional) to prevent unknown fields from reaching Prisma `create()` calls
- Add `information_schema.columns` check at import start to conditionally include fields based on what exists in the target database
- Add `select: { id: true }` to all Prisma create/update calls during import to prevent `RETURNING *` from referencing missing columns
- Add PL/pgSQL exception handling in `wipeDatabase()` for tables (Agent, ChatMessage, ChatSession) that may not exist
- Include Agent model in export/import pipeline with table existence checks

## Test plan
- [x] Import a pre-1.4.0 backup into a current schema database
- [ ] Import a current backup into a database missing newer columns
- [x] Verify wipe handles missing tables without errors
- [ ] Verify all data imports correctly with both old and new format backups

🤖 Generated with [Claude Code](https://claude.com/claude-code)