### PR TITLE
chore(release): bump version to 0.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "punt",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump version from 0.9.4 to 0.9.5

After merge, tag `v0.9.5` will be created to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)