### PR TITLE
fix(editor): remove duplicate InsertCodeBlock toolbar button

### DIFF
--- a/src/components/tickets/description-editor.tsx
+++ b/src/components/tickets/description-editor.tsx
@@ -5,7 +5,6 @@ import {
   codeMirrorPlugin,
   diffSourcePlugin,
   headingsPlugin,
-  InsertCodeBlock,
   InsertThematicBreak,
   imagePlugin,
   linkDialogPlugin,
@@ -114,7 +113,6 @@ export const DescriptionEditor = React.memo(function DescriptionEditor({
         <CustomBlockTypeSelect />
         <Separator />
         <ResponsiveLinkImageToggle />
-        <InsertCodeBlock />
         <InsertThematicBreak />
       </ResponsiveViewModeToggle>
     ),


### PR DESCRIPTION
## Summary
In PR #565 I added an \`<InsertCodeBlock />\` button next to \`<InsertThematicBreak />\`, not realizing that \`ResponsiveCodeToggle\` already renders \`<InsertCodeBlock />\` on desktop (right of the inline-code toggle). Result: the toolbar showed two identical buttons. Removed the redundant one.

PUNT-416 still tracks making ``` typing trigger code blocks directly.

## Test plan
- [x] \`pnpm lint\` clean
- [ ] CI passes
- [ ] Manual UI check: only one code-block button visible in the editor toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)