### PR TITLE
chore(deps): bump react-day-picker 9.14 → 10.0.1 (PR #546)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "radix-ui": "^1.5.0",
     "react": "19.2.7",
     "react-colorful": "^5.7.0",
-    "react-day-picker": "^9.14.0",
+    "react-day-picker": "^10.0.1",
     "react-dom": "19.2.7",
     "react-easy-crop": "^5.5.7",
     "recharts": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ importers:
         specifier: ^5.7.0
         version: 5.7.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-day-picker:
-        specifier: ^9.14.0
-        version: 9.14.0(react@19.2.7)
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@19.2.17)(react@19.2.7)
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
@@ -2788,10 +2788,6 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@tabby_ai/hijri-converter@1.0.5':
-    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
-    engines: {node: '>=16.0.0'}
-
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -3636,9 +3632,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  date-fns-jalali@4.1.0-0:
-    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
@@ -4796,11 +4789,15 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  react-day-picker@9.14.0:
-    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
     engines: {node: '>=18'}
     peerDependencies:
+      '@types/react': '>=16.8.0'
       react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -8061,8 +8058,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tabby_ai/hijri-converter@1.0.5': {}
-
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -8934,8 +8929,6 @@ snapshots:
       whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.4.0: {}
 
@@ -10364,13 +10357,13 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  react-day-picker@9.14.0(react@19.2.7):
+  react-day-picker@10.0.1(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       '@date-fns/tz': 1.4.1
-      '@tabby_ai/hijri-converter': 1.0.5
       date-fns: 4.4.0
-      date-fns-jalali: 4.1.0-0
       react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:

--- a/src/components/backlog/backlog-filters.tsx
+++ b/src/components/backlog/backlog-filters.tsx
@@ -994,11 +994,11 @@ export function BacklogFilters({
                 }}
                 disabled={filterByDueDate.includeNone}
                 defaultMonth={new Date()}
-                initialFocus
+                autoFocus
                 numberOfMonths={2}
                 captionLayout="dropdown"
-                fromYear={calendarStartYear}
-                toYear={new Date().getFullYear() + 1}
+                startMonth={new Date(calendarStartYear, 0)}
+                endMonth={new Date(new Date().getFullYear() + 1, 11)}
                 className={`rounded-md border-zinc-800 bg-zinc-950 text-zinc-300 ${
                   filterByDueDate.includeNone ? 'opacity-50 pointer-events-none' : ''
                 }`}

--- a/src/components/tickets/date-picker.tsx
+++ b/src/components/tickets/date-picker.tsx
@@ -110,10 +110,10 @@ export function DatePicker({
           selected={value || undefined}
           onSelect={(date) => onChange(date || null)}
           numberOfMonths={1}
-          initialFocus
+          autoFocus
           captionLayout="dropdown"
-          fromYear={calendarStartYear}
-          toYear={calendarMaxYear}
+          startMonth={new Date(calendarStartYear, 0)}
+          endMonth={new Date(calendarMaxYear, 11)}
           className="bg-zinc-900"
           classNames={
             value

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -72,7 +72,7 @@ function Calendar({
             : 'rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5',
           defaultClassNames.caption_label,
         ),
-        table: 'w-full border-collapse',
+        month_grid: 'w-full border-collapse',
         weekdays: cn('flex', defaultClassNames.weekdays),
         weekday: cn(
           'text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none',


### PR DESCRIPTION
## Summary
Bumps \`react-day-picker\` from 9.14.0 to 10.0.1.

v10 removes APIs that were deprecated in v9 and renames one classname slot. Migrated all three usages in the codebase.

### Prop renames (all required since the v9 names are deleted in v10)
- \`initialFocus\` → \`autoFocus\`
- \`fromYear={Y}\` → \`startMonth={new Date(Y, 0)}\`
- \`toYear={Y}\` → \`endMonth={new Date(Y, 11)}\`

### Classname slot rename
- \`table\` → \`month_grid\` in the calendar's \`classNames\` map

### Files touched
- \`src/components/ui/calendar.tsx\` (slot rename)
- \`src/components/tickets/date-picker.tsx\` (date picker popover used in ticket forms)
- \`src/components/backlog/backlog-filters.tsx\` (range picker for due-date filter)

## Test plan
- [x] \`pnpm install\` succeeds
- [x] \`pnpm lint\` clean (no new errors)
- [x] \`pnpm test\` — 1527 / 1527 pass
- [x] \`tsc --noEmit\` reports no day-picker-related errors
- [ ] CI passes
- [ ] Manual UI smoke (recommended post-merge):
  - Open a ticket, change the due date — single-date picker works, keyboard focus lands on the popover
  - Open backlog due-date filter — range picker shows two months, autofocuses, dropdown navigation still respects start/end bounds

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)