### PR TITLE
chore(ci): bump checkout/setup-node to v6 for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -38,7 +38,7 @@ jobs:
           version: 11
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
           version: 11
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` and `actions/setup-node` from v4 to v6 in `ci.yml` and `release.yml`, matching `deploy-docs.yml`
- Resolves the runner deprecation annotation: GitHub forces Node 24 for JS actions starting June 16, 2026, and removes Node 20 from runners September 16, 2026

## Test plan
- [ ] CI (lint-and-test) passes on this PR — exercises both bumped actions in `ci.yml`
- `release.yml` uses the same action versions, so a green CI run validates the same setup path

🤖 Generated with [Claude Code](https://claude.com/claude-code)