### PR TITLE
fix(deps): pin pnpm 11 via packageManager (fixes Railway deploy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/docs-site/pnpm-workspace.yaml
+++ b/docs-site/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 packages: []
+allowBuilds:
+  # postinstall only prints a funding banner; not needed for builds
+  core-js: false

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=22.22.1"
   },
+  "packageManager": "pnpm@11.5.2",
   "scripts": {
     "predev": "node scripts/check-deps.mjs",
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- Railway's Nixpacks builder failed deploying main (`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`): it runs `pnpm i --frozen-lockfile` with an older pnpm that doesn't read `overrides` from `pnpm-workspace.yaml`
- Add `"packageManager": "pnpm@11.5.2"` so Nixpacks/corepack/action-setup all use the same pnpm
- Remove `version:` pins from `pnpm/action-setup` in all workflows — it errors when the pin and `packageManager` disagree, and `packageManager` is now the single source of truth
- `docs-site`: explicitly deny the `core-js` build script (funding banner only) — pnpm 11 hard-errors on unconfigured build scripts

## Test plan
- [x] `pnpm install --frozen-lockfile` exits 0 at repo root (the command Railway runs)
- [x] `pnpm install --frozen-lockfile` exits 0 in `docs-site`
- [ ] CI green on this PR (validates action-setup reading `packageManager`)
- [ ] Railway deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)