### PR TITLE
fix(deploy): override Nixpacks corepack to 0.35.0 for pnpm 11

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -5,6 +5,11 @@
 builder = "NIXPACKS"
 buildCommand = "pnpm install && pnpm db:generate && pnpm build"
 
+# Nixpacks pins corepack 0.24.1, which crashes loading pnpm >= 10
+# (ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING); 0.35+ handles it.
+[build.nixpacksPlan.phases.install]
+cmds = ["npm install -g corepack@0.35.0 && corepack enable", "pnpm i --frozen-lockfile"]
+
 [deploy]
 startCommand = "pnpm start"
 healthcheckPath = "/"


### PR DESCRIPTION
## Summary
- Railway build of `7682cfd` failed: Nixpacks hardcodes `corepack@0.24.1`, which crashes with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` loading any pnpm >= 10 (reproduced locally on both Node 22 and Node 24 — it is corepack's bug, not the Node version)
- Override the Nixpacks install phase via `railway.toml` to install `corepack@0.35.0`, verified locally to load pnpm 11.5.2

## Test plan
- [x] Local repro: `corepack@0.24.1` + `pnpm@11.5.2` crashes; `corepack@0.35.0` + `pnpm@11.5.2` prints version, exit 0
- [ ] Railway deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)