### PR TITLE
fix(deploy): switch Railway builder to Railpack

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,14 +1,11 @@
 # Railway configuration for demo mode deployment
 # Deploys PUNT in demo mode (client-side only, no database required)
 
+# Railpack (not Nixpacks): reads the packageManager field for pnpm 11.
+# Nixpacks ships corepack 0.24.1, which cannot load pnpm >= 10.
 [build]
-builder = "NIXPACKS"
+builder = "RAILPACK"
 buildCommand = "pnpm install && pnpm db:generate && pnpm build"
-
-# Nixpacks pins corepack 0.24.1, which crashes loading pnpm >= 10
-# (ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING); 0.35+ handles it.
-[build.nixpacksPlan.phases.install]
-cmds = ["npm install -g corepack@0.35.0 && corepack enable", "pnpm i --frozen-lockfile"]
 
 [deploy]
 startCommand = "pnpm start"


### PR DESCRIPTION
## Summary
- PR #573's `nixpacksPlan` install override is ignored by Railway, so builds still ran corepack 0.24.1 → same `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` crash loading pnpm 11
- The service instance's own builder setting is already `RAILPACK` — `railway.toml` was overriding it back to `NIXPACKS`
- Railpack reads `packageManager` and installs pnpm 11.5.2 directly (via mise, no corepack), keeping the same build/start commands

## Test plan
- [ ] Railway deploy of the merge commit builds and passes healthcheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)