### PR TITLE
fix(meta): set metadataBase from env for absolute og:image URLs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,16 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 })
 
+// Absolute base for og:image and other social metadata. Baked at build
+// time, so it must come from env, not request headers. Falls back to
+// Railway's auto-provided domain, then to Next's localhost default.
+const appUrl =
+  process.env.NEXTAUTH_URL ??
+  process.env.NEXT_PUBLIC_APP_URL ??
+  (process.env.RAILWAY_PUBLIC_DOMAIN ? `https://${process.env.RAILWAY_PUBLIC_DOMAIN}` : undefined)
+
 export const metadata: Metadata = {
+  metadataBase: appUrl ? new URL(appUrl) : undefined,
   title: 'PUNT - Simple Kanban & Ticket Tracker',
   description:
     'A lightweight, self-hosted ticket tracker and kanban board. Jira-like without the bloat.',


### PR DESCRIPTION
## Summary
- The deployed site bakes `http://localhost:3000` into `og:image`/`twitter:image` (confirmed via Facebook Sharing Debugger), so scrapers can't fetch the preview image
- Set `metadataBase` from `NEXTAUTH_URL` → `NEXT_PUBLIC_APP_URL` → `https://$RAILWAY_PUBLIC_DOMAIN` (auto-provided on Railway, so the demo needs no new config)
- Note: this is only observable in production builds — `next dev` always resolves metadata against the local origin

## Test plan
- [x] Production build + start with env set serves `og:image` = `https://punt-demo-production.up.railway.app/opengraph-image.png?...`
- [x] Verified the Railway service exposes `RAILWAY_PUBLIC_DOMAIN` and doesn't set the higher-priority vars
- [ ] After deploy: live HTML serves absolute og:image; re-scrape in Facebook debugger

🤖 Generated with [Claude Code](https://claude.com/claude-code)