### PR TITLE
test(ci): enforce coverage with a ratchet floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Run tests
-        run: pnpm test
+      - name: Run tests (with coverage thresholds)
+        run: pnpm test:ci
 
       - name: Build
         run: pnpm build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ src/
 
 Vitest + React Testing Library + MSW. Tests in `__tests__/` subdirectories. See `docs/TESTING.md` for detailed guide.
 
-Coverage target: 80% minimum, 90% for stores/API/utils. Database tests run in separate vitest project to prevent race conditions. Tests require a PostgreSQL test database (see `.env.test`).
+Coverage is enforced in CI via `pnpm test:ci` against a **ratchet floor** in `vitest.config.ts` (currently lines 41 / statements 40 / functions 36 / branches 32). The floor sits just below actual coverage and should only ever be raised, never lowered — bumping it up as coverage improves prevents backsliding. The aspirational target remains 80% global / 90% for stores/API/utils; the gap is tracked for follow-up work. Database tests run in a separate vitest project to prevent race conditions. Tests require a PostgreSQL test database (see `.env.test`).
 
 ### Security
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -60,11 +60,15 @@ export default defineConfig({
         'vitest.config.ts',
         'prisma.config.ts',
       ],
+      // Ratchet floor: set ~1 point below current coverage so it passes today
+      // but fails CI on any meaningful regression. Raise these as coverage
+      // improves — they should only ever go UP, never down.
+      // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
-        lines: 80,
-        functions: 80,
-        branches: 80,
-        statements: 80,
+        lines: 41,
+        functions: 36,
+        branches: 32,
+        statements: 40,
       },
     },
   },


### PR DESCRIPTION
## Summary
The vitest coverage thresholds were set to 80% but **never enforced** — CI ran `pnpm test` (no `--coverage`), so the gate was dead config while actual coverage sits at ~42% lines. CLAUDE.md also advertised an "80% minimum" that wasn't real.

This makes the gate honest and active, as step 1 of addressing low coverage on core logic.

## Changes
- **CI enforces coverage** — `.github/workflows/ci.yml` now runs `pnpm test:ci` (`vitest run --coverage`) instead of `pnpm test`, so thresholds actually gate PRs.
- **Ratchet floor** — `vitest.config.ts` thresholds lowered from a fictional 80 to a floor ~1 point below current coverage: lines 41 / statements 40 / functions 36 / branches 32. This passes today but fails CI on any meaningful regression. The floor should only ever be raised as coverage improves.
- **Honest docs** — CLAUDE.md now describes the enforced floor vs. the 80/90 aspirational target.

## Why a floor instead of just fixing CI at 80%
Flipping CI to enforce 80% today would make `main` instantly un-mergeable (actual is 42%). The ratchet stops the bleeding now — coverage can't regress — while the real work of raising it on the risky areas happens incrementally.

## Current coverage (the baseline this floor locks in)
```
Statements : 41.19% (3232/7846)
Branches   : 33.28% (1761/5290)
Functions  : 37.07% (733/1977)
Lines      : 42.12% (3004/7132)
```

## Follow-up (not in this PR)
Raising actual coverage on the genuinely under-tested core, in leverage order:
- `lib/actions/*` — **0%** (optimistic-update + undo logic; silent-corruption risk)
- `lib/data-provider/` — api-provider 11%, demo-provider 0%
- `hooks/queries/` — 7.7%
- stores: selection 23%, board 54%, sprint 62%

## Test plan
- [x] `pnpm test:ci` passes locally (1527/1527, coverage clears floor, exit 0)
- [x] CI passes (now exercising the coverage gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)