### PR TITLE
test(actions): cover lib/actions (slice 1 of coverage backfill)

### DIFF
--- a/src/lib/actions/__tests__/activity-utils.test.ts
+++ b/src/lib/actions/__tests__/activity-utils.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { isDemoMode } from '@/lib/demo'
+import { deleteActivityEntries, extractActivityMeta } from '../activity-utils'
+
+vi.mock('@/lib/base-path', () => ({
+  apiFetch: vi.fn(),
+}))
+vi.mock('@/lib/demo', () => ({
+  isDemoMode: vi.fn(() => false),
+}))
+vi.mock('@/hooks/use-realtime', () => ({
+  getTabId: vi.fn(() => 'test-tab-id'),
+}))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+
+describe('extractActivityMeta', () => {
+  it('returns undefined when the response has no _activity field', () => {
+    expect(extractActivityMeta({}, 'ticket-1')).toBeUndefined()
+  })
+
+  it('returns undefined when _activity has neither activityIds nor groupId', () => {
+    expect(extractActivityMeta({ _activity: {} }, 'ticket-1')).toBeUndefined()
+    expect(
+      extractActivityMeta({ _activity: { activityIds: [], groupId: null } }, 'ticket-1'),
+    ).toBeUndefined()
+  })
+
+  it('returns meta with both activityIds and groupId when present', () => {
+    const meta = extractActivityMeta(
+      { _activity: { activityIds: ['a1', 'a2'], groupId: 'group-1' } },
+      'ticket-1',
+    )
+    expect(meta).toEqual({
+      ticketId: 'ticket-1',
+      activityIds: ['a1', 'a2'],
+      groupId: 'group-1',
+    })
+  })
+
+  it('defaults activityIds to an empty array when only groupId is present', () => {
+    const meta = extractActivityMeta({ _activity: { groupId: 'group-1' } }, 'ticket-1')
+    expect(meta).toEqual({ ticketId: 'ticket-1', activityIds: [], groupId: 'group-1' })
+  })
+
+  it('normalizes a null groupId to undefined when activityIds carry the signal', () => {
+    const meta = extractActivityMeta(
+      { _activity: { activityIds: ['a1'], groupId: null } },
+      'ticket-1',
+    )
+    expect(meta).toEqual({ ticketId: 'ticket-1', activityIds: ['a1'], groupId: undefined })
+  })
+})
+
+describe('deleteActivityEntries', () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset()
+    mockApiFetch.mockResolvedValue(new Response(null, { status: 200 }))
+    mockIsDemoMode.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does nothing when ticketId is missing', async () => {
+    await deleteActivityEntries('PUNT', { ticketId: '', groupId: 'g1', activityIds: ['a1'] })
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when there is no groupId and no activityIds', async () => {
+    await deleteActivityEntries('PUNT', { ticketId: 'ticket-1', activityIds: [] })
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('does nothing in demo mode even with valid metadata', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    await deleteActivityEntries('PUNT', { ticketId: 'ticket-1', groupId: 'g1' })
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('posts to the batch-delete endpoint with groupId and activityIds', async () => {
+    await deleteActivityEntries('PUNT', {
+      ticketId: 'ticket-1',
+      groupId: 'g1',
+      activityIds: ['a1', 'a2'],
+    })
+
+    expect(mockApiFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockApiFetch.mock.calls[0]
+    expect(url).toBe('/api/projects/PUNT/tickets/ticket-1/activity/batch-delete')
+    expect(init?.method).toBe('POST')
+    expect((init?.headers as Record<string, string>)['X-Tab-Id']).toBe('test-tab-id')
+    expect(JSON.parse(init?.body as string)).toEqual({ groupId: 'g1', activityIds: ['a1', 'a2'] })
+  })
+
+  it('proceeds when only activityIds are provided (no groupId)', async () => {
+    await deleteActivityEntries('PUNT', { ticketId: 'ticket-1', activityIds: ['a1'] })
+    expect(mockApiFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows API errors so undo is never blocked', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockApiFetch.mockRejectedValue(new Error('network down'))
+
+    await expect(
+      deleteActivityEntries('PUNT', { ticketId: 'ticket-1', groupId: 'g1' }),
+    ).resolves.toBeUndefined()
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to delete activity entries:', expect.any(Error))
+  })
+})

--- a/src/lib/actions/__tests__/delete-tickets.test.ts
+++ b/src/lib/actions/__tests__/delete-tickets.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockTicket } from '@/__tests__/utils/mocks'
+import { apiFetch } from '@/lib/base-path'
+import { isDemoMode } from '@/lib/demo'
+import { demoStorage } from '@/lib/demo/demo-storage'
+import { showToast } from '@/lib/toast'
+import { showUndoRedoToast } from '@/lib/undo-toast'
+import { useBoardStore } from '@/stores/board-store'
+import { useProjectsStore } from '@/stores/projects-store'
+import { useSelectionStore } from '@/stores/selection-store'
+import { useUndoStore } from '@/stores/undo-store'
+import type { ColumnWithTickets, TicketWithRelations } from '@/types'
+import {
+  deleteTickets,
+  prepareTicketsForDelete,
+  restoreAttachments,
+  restoreCommentsAndLinks,
+} from '../delete-tickets'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/demo', () => ({ isDemoMode: vi.fn(() => false) }))
+vi.mock('@/lib/demo/demo-storage', () => ({ demoStorage: { deleteTicket: vi.fn() } }))
+vi.mock('@/lib/toast', () => ({ showToast: { error: vi.fn() } }))
+vi.mock('@/lib/undo-toast', () => ({ showUndoRedoToast: vi.fn() }))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+const PROJECT_ID = 'project-1'
+
+function okJson(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+
+function seedColumns(tickets: TicketWithRelations[]): ColumnWithTickets[] {
+  return [{ id: 'col-1', name: 'To Do', order: 0, projectId: PROJECT_ID, tickets }]
+}
+
+describe('prepareTicketsForDelete', () => {
+  it('finds selected tickets across columns, attaching their column id', () => {
+    const t1 = createMockTicket({ id: 't1', columnId: 'col-1' })
+    const t2 = createMockTicket({ id: 't2', columnId: 'col-2' })
+    const columns: ColumnWithTickets[] = [
+      { id: 'col-1', name: 'A', order: 0, projectId: PROJECT_ID, tickets: [t1] },
+      { id: 'col-2', name: 'B', order: 1, projectId: PROJECT_ID, tickets: [t2] },
+    ]
+    const result = prepareTicketsForDelete(['t1', 't2'], columns)
+    expect(result).toEqual([
+      { ticket: t1, columnId: 'col-1' },
+      { ticket: t2, columnId: 'col-2' },
+    ])
+  })
+
+  it('returns an empty array when no ids match', () => {
+    const columns = seedColumns([createMockTicket({ id: 't1' })])
+    expect(prepareTicketsForDelete(['nope'], columns)).toEqual([])
+  })
+})
+
+describe('deleteTickets', () => {
+  let ticket: TicketWithRelations
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    // Restore-data fetches (comments/links via apiFetch) + DELETE all succeed.
+    mockApiFetch.mockResolvedValue(okJson([]))
+    // Activity fetches use the global fetch.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okJson({ entries: [] })))
+
+    ticket = createMockTicket({ id: 't1', number: 1, columnId: 'col-1' })
+    useBoardStore.setState({
+      projects: { [PROJECT_ID]: seedColumns([ticket]) },
+      _hasHydrated: true,
+    })
+    useSelectionStore.setState({ selectedTicketIds: new Set(['t1']), copiedTicketIds: [] })
+    useUndoStore.setState({ undoStack: [], redoStack: [] })
+    useProjectsStore.setState({
+      projects: [{ id: PROJECT_ID, key: 'PUNT', name: 'Punt', ticketCount: 1 }],
+    })
+  })
+
+  it('fails when given no tickets', async () => {
+    const result = await deleteTickets({ projectId: PROJECT_ID, tickets: [] })
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('No tickets to delete')
+  })
+
+  it('optimistically removes the ticket, clears selection, and pushes an undo entry', async () => {
+    const result = await deleteTickets({
+      projectId: PROJECT_ID,
+      tickets: [{ ticket, columnId: 'col-1' }],
+    })
+
+    expect(result.success).toBe(true)
+    const ids = useBoardStore
+      .getState()
+      .getColumns(PROJECT_ID)
+      .flatMap((c) => c.tickets.map((t) => t.id))
+    expect(ids).not.toContain('t1')
+    expect(useSelectionStore.getState().selectedTicketIds.size).toBe(0)
+    expect(useUndoStore.getState().undoStack).toHaveLength(1)
+  })
+
+  it('issues a DELETE request per ticket', async () => {
+    await deleteTickets({ projectId: PROJECT_ID, tickets: [{ ticket, columnId: 'col-1' }] })
+    const deleteCalls = mockApiFetch.mock.calls.filter(([, init]) => init?.method === 'DELETE')
+    expect(deleteCalls).toHaveLength(1)
+    expect(deleteCalls[0][0]).toBe(`/api/projects/${PROJECT_ID}/tickets/t1`)
+  })
+
+  it('rolls back the optimistic removal and reports failure when the API errors', async () => {
+    mockApiFetch.mockImplementation(async (_url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return new Response(null, { status: 500 })
+      return okJson([])
+    })
+
+    const result = await deleteTickets({
+      projectId: PROJECT_ID,
+      tickets: [{ ticket, columnId: 'col-1' }],
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('API error')
+    expect(showToast.error).toHaveBeenCalledWith('Failed to delete ticket(s)')
+    // Ticket restored to the board
+    const ids = useBoardStore
+      .getState()
+      .getColumns(PROJECT_ID)
+      .flatMap((c) => c.tickets.map((t) => t.id))
+    expect(ids).toContain('t1')
+  })
+
+  it('in demo mode skips the API and deletes from demoStorage', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const result = await deleteTickets({
+      projectId: PROJECT_ID,
+      tickets: [{ ticket, columnId: 'col-1' }],
+    })
+
+    expect(result.success).toBe(true)
+    expect(demoStorage.deleteTicket).toHaveBeenCalledWith(PROJECT_ID, 't1')
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('shows a singular toast for one ticket and a plural toast for many', async () => {
+    await deleteTickets({ projectId: PROJECT_ID, tickets: [{ ticket, columnId: 'col-1' }] })
+    expect(showUndoRedoToast).toHaveBeenLastCalledWith(
+      'error',
+      expect.objectContaining({ title: 'Ticket deleted' }),
+    )
+
+    const t2 = createMockTicket({ id: 't2', number: 2, columnId: 'col-1' })
+    useBoardStore.setState({
+      projects: { [PROJECT_ID]: seedColumns([ticket, t2]) },
+      _hasHydrated: true,
+    })
+    await deleteTickets({
+      projectId: PROJECT_ID,
+      tickets: [
+        { ticket, columnId: 'col-1' },
+        { ticket: t2, columnId: 'col-1' },
+      ],
+    })
+    expect(showUndoRedoToast).toHaveBeenLastCalledWith(
+      'error',
+      expect.objectContaining({ title: '2 tickets deleted' }),
+    )
+  })
+
+  it('invokes onComplete on both success and failure', async () => {
+    const onComplete = vi.fn()
+    await deleteTickets({
+      projectId: PROJECT_ID,
+      tickets: [{ ticket, columnId: 'col-1' }],
+      onComplete,
+    })
+    expect(onComplete).toHaveBeenCalledTimes(1)
+
+    mockApiFetch.mockImplementation(async (_url: string, init?: RequestInit) =>
+      init?.method === 'DELETE' ? new Response(null, { status: 500 }) : okJson([]),
+    )
+    await deleteTickets({
+      projectId: PROJECT_ID,
+      tickets: [{ ticket, columnId: 'col-1' }],
+      onComplete,
+    })
+    expect(onComplete).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('restoreAttachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    mockApiFetch.mockResolvedValue(new Response(null, { status: 200 }))
+  })
+
+  it('does nothing for empty or undefined attachments', async () => {
+    await restoreAttachments(PROJECT_ID, 'srv-1', undefined)
+    await restoreAttachments(PROJECT_ID, 'srv-1', [])
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('does nothing in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    await restoreAttachments(PROJECT_ID, 'srv-1', [
+      { filename: 'a.png', mimeType: 'image/png', size: 1, url: '/u/a' },
+    ])
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('POSTs the attachments to the restore endpoint', async () => {
+    await restoreAttachments(PROJECT_ID, 'srv-1', [
+      { filename: 'a.png', mimeType: 'image/png', size: 1, url: '/u/a' },
+    ])
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      `/api/projects/${PROJECT_ID}/tickets/srv-1/attachments`,
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('swallows errors', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockApiFetch.mockRejectedValue(new Error('boom'))
+    await expect(
+      restoreAttachments(PROJECT_ID, 'srv-1', [
+        { filename: 'a.png', mimeType: 'image/png', size: 1, url: '/u/a' },
+      ]),
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('restoreCommentsAndLinks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    mockApiFetch.mockResolvedValue(new Response(null, { status: 200 }))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
+  })
+
+  it('does nothing when restoreData is undefined', async () => {
+    await restoreCommentsAndLinks(PROJECT_ID, 'srv-1', undefined)
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('does nothing in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    await restoreCommentsAndLinks(PROJECT_ID, 'srv-1', {
+      comments: [
+        {
+          content: 'hi',
+          authorId: 'u1',
+          isSystemGenerated: false,
+          source: null,
+          createdAt: '2024-01-01',
+        },
+      ],
+      links: [],
+      activities: [],
+    })
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('restores comments, links, and activities via their endpoints', async () => {
+    await restoreCommentsAndLinks(
+      PROJECT_ID,
+      'srv-1',
+      {
+        comments: [
+          {
+            content: 'hi',
+            authorId: 'u1',
+            isSystemGenerated: false,
+            source: null,
+            createdAt: '2024-01-01',
+          },
+        ],
+        links: [{ linkType: 'blocks', linkedTicketId: 't2', direction: 'outward' }],
+        activities: [
+          {
+            action: 'created',
+            field: null,
+            oldValue: null,
+            newValue: null,
+            groupId: null,
+            userId: 'u1',
+            createdAt: '2024-01-01',
+          },
+        ],
+      },
+      ['auto-activity-1'],
+    )
+
+    const calledUrls = mockApiFetch.mock.calls.map(([url]) => url)
+    expect(calledUrls).toContain(`/api/projects/${PROJECT_ID}/tickets/srv-1/comments/restore`)
+    expect(calledUrls).toContain(`/api/projects/${PROJECT_ID}/tickets/srv-1/links/restore`)
+    // Activities + auto-delete go through the global fetch
+    const fetchUrls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.map(([u]) => u)
+    expect(fetchUrls).toContain(`/api/projects/${PROJECT_ID}/tickets/srv-1/activity/batch-delete`)
+    expect(fetchUrls).toContain(`/api/projects/${PROJECT_ID}/tickets/srv-1/activity/restore`)
+  })
+
+  it('skips empty sections (no comments, links, or activities)', async () => {
+    await restoreCommentsAndLinks(PROJECT_ID, 'srv-1', {
+      comments: [],
+      links: [],
+      activities: [],
+    })
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/actions/__tests__/paste-tickets.test.ts
+++ b/src/lib/actions/__tests__/paste-tickets.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockTicket } from '@/__tests__/utils/mocks'
+import { batchCreateTicketsAPI } from '@/hooks/queries/use-tickets'
+import { showToast } from '@/lib/toast'
+import { showUndoRedoToast } from '@/lib/undo-toast'
+import { useBoardStore } from '@/stores/board-store'
+import { useProjectsStore } from '@/stores/projects-store'
+import { useSelectionStore } from '@/stores/selection-store'
+import { useUIStore } from '@/stores/ui-store'
+import { useUndoStore } from '@/stores/undo-store'
+import type { ColumnWithTickets, TicketWithRelations } from '@/types'
+import { pasteTickets } from '../paste-tickets'
+
+vi.mock('@/hooks/queries/use-tickets', () => ({
+  batchCreateTicketsAPI: vi.fn(),
+}))
+vi.mock('@/lib/toast', () => ({
+  showToast: { error: vi.fn(), success: vi.fn() },
+}))
+vi.mock('@/lib/undo-toast', () => ({
+  showUndoRedoToast: vi.fn(),
+}))
+
+const mockBatchCreate = vi.mocked(batchCreateTicketsAPI)
+const PROJECT_ID = 'project-1'
+
+function seedColumns(tickets: TicketWithRelations[]): ColumnWithTickets[] {
+  return [
+    { id: 'col-1', name: 'To Do', order: 0, projectId: PROJECT_ID, tickets },
+    { id: 'col-2', name: 'Done', order: 1, projectId: PROJECT_ID, tickets: [] },
+  ]
+}
+
+describe('pasteTickets', () => {
+  let columns: ColumnWithTickets[]
+  let original: TicketWithRelations
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    original = createMockTicket({ id: 'ticket-1', number: 1, columnId: 'col-1', title: 'Original' })
+    columns = seedColumns([original])
+
+    useBoardStore.setState({ projects: { [PROJECT_ID]: columns }, _hasHydrated: true })
+    useSelectionStore.setState({ selectedTicketIds: new Set(), copiedTicketIds: [] })
+    useUndoStore.setState({ undoStack: [], redoStack: [] })
+    useUIStore.setState({ activeTicketId: null })
+    useProjectsStore.setState({
+      projects: [{ id: PROJECT_ID, key: 'PUNT', name: 'Punt', ticketCount: 1 }],
+    })
+    // Default: API echoes back a server ticket per temp id
+    mockBatchCreate.mockResolvedValue(new Map())
+  })
+
+  describe('validation', () => {
+    it('fails when there are no copied IDs', () => {
+      const result = pasteTickets({ projectId: PROJECT_ID, columns })
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No tickets to paste')
+    })
+
+    it('fails when copied IDs match no ticket in the columns', () => {
+      const result = pasteTickets({
+        projectId: PROJECT_ID,
+        columns,
+        copiedIds: ['does-not-exist'],
+      })
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Could not find copied tickets')
+    })
+
+    it('falls back to the selection store copied IDs when none are passed', () => {
+      useSelectionStore.setState({ copiedTicketIds: ['ticket-1'] })
+      const result = pasteTickets({ projectId: PROJECT_ID, columns })
+      expect(result.success).toBe(true)
+      expect(result.newTickets).toHaveLength(1)
+    })
+  })
+
+  describe('optimistic update (synchronous)', () => {
+    it('adds a copy with an incremented number and "(copy)" suffix', () => {
+      const result = pasteTickets({ projectId: PROJECT_ID, columns, copiedIds: ['ticket-1'] })
+
+      expect(result.success).toBe(true)
+      const pasted = result.newTickets[0].ticket
+      expect(pasted.title).toBe('Original (copy)')
+      expect(pasted.number).toBe(2) // max existing (1) + 1
+      expect(pasted.id).not.toBe('ticket-1') // fresh temp id
+
+      // Board reflects the optimistic add in the same column
+      const col1 = useBoardStore.getState().getColumns(PROJECT_ID)[0]
+      expect(col1.tickets.map((t) => t.id)).toContain(pasted.id)
+    })
+
+    it('registers an undo entry for the paste', () => {
+      pasteTickets({ projectId: PROJECT_ID, columns, copiedIds: ['ticket-1'] })
+      const stack = useUndoStore.getState().undoStack
+      expect(stack).toHaveLength(1)
+      expect(stack[0].action.type).toBe('paste')
+    })
+
+    it('selects only the newly pasted tickets, clearing prior selection', () => {
+      useSelectionStore.setState({ selectedTicketIds: new Set(['some-old-id']) })
+      const result = pasteTickets({ projectId: PROJECT_ID, columns, copiedIds: ['ticket-1'] })
+
+      const selected = useSelectionStore.getState().selectedTicketIds
+      expect(selected.has('some-old-id')).toBe(false)
+      expect(selected.has(result.newTickets[0].ticket.id)).toBe(true)
+    })
+
+    it('shows an undo/redo toast', () => {
+      pasteTickets({ projectId: PROJECT_ID, columns, copiedIds: ['ticket-1'] })
+      expect(showUndoRedoToast).toHaveBeenCalledWith(
+        'success',
+        expect.objectContaining({
+          title: 'Ticket pasted',
+        }),
+      )
+    })
+
+    it('pluralizes the toast title for multiple tickets', () => {
+      const second = createMockTicket({ id: 'ticket-2', number: 2, columnId: 'col-1' })
+      columns = seedColumns([original, second])
+      useBoardStore.setState({ projects: { [PROJECT_ID]: columns }, _hasHydrated: true })
+
+      pasteTickets({ projectId: PROJECT_ID, columns, copiedIds: ['ticket-1', 'ticket-2'] })
+      expect(showUndoRedoToast).toHaveBeenCalledWith(
+        'success',
+        expect.objectContaining({
+          title: '2 tickets pasted',
+        }),
+      )
+    })
+
+    it('opens the drawer for a single paste when enabled', () => {
+      const result = pasteTickets({
+        projectId: PROJECT_ID,
+        columns,
+        copiedIds: ['ticket-1'],
+        openSinglePastedTicket: true,
+      })
+      expect(useUIStore.getState().activeTicketId).toBe(result.newTickets[0].ticket.id)
+    })
+
+    it('does not open the drawer when openSinglePastedTicket is false', () => {
+      pasteTickets({
+        projectId: PROJECT_ID,
+        columns,
+        copiedIds: ['ticket-1'],
+        openSinglePastedTicket: false,
+      })
+      expect(useUIStore.getState().activeTicketId).toBeNull()
+    })
+
+    it('invokes the onComplete callback', () => {
+      const onComplete = vi.fn()
+      pasteTickets({ projectId: PROJECT_ID, columns, copiedIds: ['ticket-1'], onComplete })
+      expect(onComplete).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('persistence (asynchronous)', () => {
+    it('replaces the optimistic temp ticket with the server ticket', async () => {
+      // Build the server response dynamically from the temp ids the action generated.
+      mockBatchCreate.mockImplementation(async (_projectId, toCreate) => {
+        const map = new Map<string, TicketWithRelations>()
+        for (const { tempId, columnId } of toCreate) {
+          map.set(tempId, createMockTicket({ id: `server-${tempId}`, number: 2, columnId }))
+        }
+        return map
+      })
+
+      const result = pasteTickets({ projectId: PROJECT_ID, columns, copiedIds: ['ticket-1'] })
+      const tempId = result.newTickets[0].ticket.id
+
+      await vi.waitFor(() => {
+        const ids = useBoardStore
+          .getState()
+          .getColumns(PROJECT_ID)
+          .flatMap((c) => c.tickets.map((t) => t.id))
+        expect(ids).toContain(`server-${tempId}`)
+        expect(ids).not.toContain(tempId)
+      })
+    })
+
+    it('rolls back the optimistic ticket and shows an error when persistence fails', async () => {
+      mockBatchCreate.mockRejectedValue(new Error('boom'))
+      const result = pasteTickets({ projectId: PROJECT_ID, columns, copiedIds: ['ticket-1'] })
+      const tempId = result.newTickets[0].ticket.id
+
+      await vi.waitFor(() => {
+        expect(showToast.error).toHaveBeenCalledWith('Failed to paste tickets')
+      })
+      const ids = useBoardStore
+        .getState()
+        .getColumns(PROJECT_ID)
+        .flatMap((c) => c.tickets.map((t) => t.id))
+      expect(ids).not.toContain(tempId)
+    })
+  })
+})

--- a/src/lib/actions/__tests__/ticket-actions.test.ts
+++ b/src/lib/actions/__tests__/ticket-actions.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockTicket } from '@/__tests__/utils/mocks'
+import { apiFetch } from '@/lib/base-path'
+import { isDemoMode } from '@/lib/demo'
+import { demoStorage } from '@/lib/demo/demo-storage'
+import { showToast } from '@/lib/toast'
+import { showUndoRedoToast } from '@/lib/undo-toast'
+import { useBoardStore } from '@/stores/board-store'
+import { useUndoStore } from '@/stores/undo-store'
+import type { ColumnWithTickets, TicketWithRelations } from '@/types'
+import { moveTickets, reorderTickets, updateTickets } from '../ticket-actions'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/demo', () => ({ isDemoMode: vi.fn(() => false) }))
+vi.mock('@/lib/demo/demo-storage', () => ({ demoStorage: { updateTicket: vi.fn() } }))
+vi.mock('@/lib/toast', () => ({ showToast: { error: vi.fn() } }))
+vi.mock('@/lib/undo-toast', () => ({ showUndoRedoToast: vi.fn() }))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+const PROJECT_ID = 'project-1'
+const TAB = 'tab-1'
+
+const ok = () => new Response(null, { status: 200 })
+const fail = () => new Response(null, { status: 500 })
+
+function getCol(id: string): ColumnWithTickets | undefined {
+  return useBoardStore
+    .getState()
+    .getColumns(PROJECT_ID)
+    .find((c) => c.id === id)
+}
+function colTicketIds(id: string): string[] {
+  return getCol(id)?.tickets.map((t) => t.id) ?? []
+}
+
+function seed(todo: TicketWithRelations[], done: TicketWithRelations[] = []) {
+  const columns: ColumnWithTickets[] = [
+    { id: 'col-todo', name: 'To Do', order: 0, projectId: PROJECT_ID, tickets: todo },
+    { id: 'col-done', name: 'Done', order: 1, projectId: PROJECT_ID, tickets: done },
+  ]
+  useBoardStore.setState({ projects: { [PROJECT_ID]: columns }, _hasHydrated: true })
+}
+
+describe('moveTickets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    mockApiFetch.mockResolvedValue(ok())
+    useUndoStore.setState({ undoStack: [], redoStack: [] })
+  })
+
+  it('is a no-op when the target column does not exist', async () => {
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo' })])
+    await moveTickets({ projectId: PROJECT_ID, ticketIds: ['t1'], toColumnId: 'nope', tabId: TAB })
+    expect(colTicketIds('col-todo')).toEqual(['t1'])
+    expect(useUndoStore.getState().undoStack).toHaveLength(0)
+  })
+
+  it('is a no-op when the ticket is already in the target column', async () => {
+    seed([], [createMockTicket({ id: 't1', columnId: 'col-done' })])
+    await moveTickets({
+      projectId: PROJECT_ID,
+      ticketIds: ['t1'],
+      toColumnId: 'col-done',
+      tabId: TAB,
+    })
+    expect(useUndoStore.getState().undoStack).toHaveLength(0)
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('moves a ticket optimistically, registers undo, and shows a toast', async () => {
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo', resolution: null })])
+    await moveTickets({
+      projectId: PROJECT_ID,
+      ticketIds: ['t1'],
+      toColumnId: 'col-done',
+      tabId: TAB,
+    })
+
+    expect(colTicketIds('col-todo')).not.toContain('t1')
+    expect(colTicketIds('col-done')).toContain('t1')
+    expect(useUndoStore.getState().undoStack).toHaveLength(1)
+    expect(showUndoRedoToast).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Moved ticket to Done' }),
+    )
+  })
+
+  it('auto-sets resolution to Done when moving into a completed column', async () => {
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo', resolution: null })])
+    await moveTickets({
+      projectId: PROJECT_ID,
+      ticketIds: ['t1'],
+      toColumnId: 'col-done',
+      tabId: TAB,
+    })
+    const moved = getCol('col-done')?.tickets.find((t) => t.id === 't1')
+    expect(moved?.resolution).toBe('Done')
+    expect(moved?.resolvedAt).toBeInstanceOf(Date)
+  })
+
+  it('auto-clears resolution when moving out of a completed column', async () => {
+    seed([], [createMockTicket({ id: 't1', columnId: 'col-done', resolution: 'Done' })])
+    await moveTickets({
+      projectId: PROJECT_ID,
+      ticketIds: ['t1'],
+      toColumnId: 'col-todo',
+      tabId: TAB,
+    })
+    const moved = getCol('col-todo')?.tickets.find((t) => t.id === 't1')
+    expect(moved?.resolution).toBeNull()
+    expect(moved?.resolvedAt).toBeNull()
+  })
+
+  it('PATCHes the API for a real ticket id', async () => {
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo' })])
+    await moveTickets({
+      projectId: PROJECT_ID,
+      ticketIds: ['t1'],
+      toColumnId: 'col-done',
+      tabId: TAB,
+    })
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      `/api/projects/${PROJECT_ID}/tickets/t1`,
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+  })
+
+  it('skips the API for an unsaved temp ticket id', async () => {
+    seed([createMockTicket({ id: 'ticket-temp-1', columnId: 'col-todo' })])
+    await moveTickets({
+      projectId: PROJECT_ID,
+      ticketIds: ['ticket-temp-1'],
+      toColumnId: 'col-done',
+      tabId: TAB,
+    })
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('rolls back the board and shows an error when the API fails', async () => {
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo' })])
+    mockApiFetch.mockResolvedValue(fail())
+
+    await moveTickets({
+      projectId: PROJECT_ID,
+      ticketIds: ['t1'],
+      toColumnId: 'col-done',
+      tabId: TAB,
+    })
+
+    expect(colTicketIds('col-todo')).toContain('t1') // restored
+    expect(colTicketIds('col-done')).not.toContain('t1')
+    expect(showToast.error).toHaveBeenCalledWith('Failed to move ticket')
+  })
+
+  it('persists to demoStorage in demo mode instead of the API', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo' })])
+    await moveTickets({
+      projectId: PROJECT_ID,
+      ticketIds: ['t1'],
+      toColumnId: 'col-done',
+      tabId: TAB,
+    })
+    expect(demoStorage.updateTicket).toHaveBeenCalled()
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('updateTickets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    mockApiFetch.mockResolvedValue(ok())
+    useUndoStore.setState({ undoStack: [], redoStack: [] })
+  })
+
+  it('returns early without an undo entry when no ticket ids match', async () => {
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo' })])
+    await updateTickets({
+      projectId: PROJECT_ID,
+      updates: [{ ticketId: 'missing', changes: { priority: 'high' } }],
+      tabId: TAB,
+    })
+    expect(useUndoStore.getState().undoStack).toHaveLength(0)
+  })
+
+  it('applies a field change optimistically and registers undo', async () => {
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo', priority: 'low' })])
+    await updateTickets({
+      projectId: PROJECT_ID,
+      updates: [{ ticketId: 't1', changes: { priority: 'high' } }],
+      tabId: TAB,
+    })
+    const t = getCol('col-todo')?.tickets.find((t) => t.id === 't1')
+    expect(t?.priority).toBe('high')
+    expect(useUndoStore.getState().undoStack).toHaveLength(1)
+  })
+
+  it('auto-moves a ticket to the done column when a resolution is set', async () => {
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo', resolution: null })])
+    await updateTickets({
+      projectId: PROJECT_ID,
+      updates: [{ ticketId: 't1', changes: { resolution: "Won't Fix" } }],
+      tabId: TAB,
+    })
+    expect(colTicketIds('col-done')).toContain('t1')
+    expect(colTicketIds('col-todo')).not.toContain('t1')
+  })
+
+  it('rolls back and shows an error when the API fails', async () => {
+    seed([createMockTicket({ id: 't1', columnId: 'col-todo', priority: 'low' })])
+    mockApiFetch.mockResolvedValue(fail())
+
+    await updateTickets({
+      projectId: PROJECT_ID,
+      updates: [{ ticketId: 't1', changes: { priority: 'high' } }],
+      tabId: TAB,
+    })
+
+    const t = getCol('col-todo')?.tickets.find((t) => t.id === 't1')
+    expect(t?.priority).toBe('low') // restored
+    expect(showToast.error).toHaveBeenCalledWith('Failed to update ticket')
+  })
+})
+
+describe('reorderTickets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDemoMode.mockReturnValue(false)
+    mockApiFetch.mockResolvedValue(ok())
+    useUndoStore.setState({ undoStack: [], redoStack: [] })
+  })
+
+  it('reorders within a column and registers an undo entry', async () => {
+    seed([
+      createMockTicket({ id: 'a', columnId: 'col-todo', order: 0 }),
+      createMockTicket({ id: 'b', columnId: 'col-todo', order: 1 }),
+      createMockTicket({ id: 'c', columnId: 'col-todo', order: 2 }),
+    ])
+    await reorderTickets({
+      projectId: PROJECT_ID,
+      columnId: 'col-todo',
+      ticketIds: ['c'],
+      targetIndex: 0,
+      tabId: TAB,
+    })
+    expect(colTicketIds('col-todo')[0]).toBe('c')
+    expect(useUndoStore.getState().undoStack).toHaveLength(1)
+  })
+
+  it('rolls back and shows an error when the API fails', async () => {
+    seed([
+      createMockTicket({ id: 'a', columnId: 'col-todo', order: 0 }),
+      createMockTicket({ id: 'b', columnId: 'col-todo', order: 1 }),
+    ])
+    mockApiFetch.mockResolvedValue(fail())
+
+    await reorderTickets({
+      projectId: PROJECT_ID,
+      columnId: 'col-todo',
+      ticketIds: ['b'],
+      targetIndex: 0,
+      tabId: TAB,
+    })
+
+    expect(colTicketIds('col-todo')).toEqual(['a', 'b']) // restored to original order
+    expect(showToast.error).toHaveBeenCalledWith('Failed to reorder ticket')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,10 +65,10 @@ export default defineConfig({
       // improves — they should only ever go UP, never down.
       // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
-        lines: 41,
-        functions: 36,
-        branches: 32,
-        statements: 40,
+        lines: 46,
+        functions: 39,
+        branches: 37,
+        statements: 45,
       },
     },
   },


### PR DESCRIPTION
## Summary
First slice of the coverage backfill flagged in #585. `lib/actions` — the unified optimistic-update + undo + API-rollback layer behind **every** ticket mutation — had **0% coverage**. A silent bug there corrupts board state or the undo stack, so it's the highest-risk place to be untested.

This brings `lib/actions` from **0% → ~85% lines / 86% functions** with 56 tests.

## What's covered
| File | Tests | Key behaviors |
|------|-------|---------------|
| `activity-utils` | 11 | `extractActivityMeta` normalization; `deleteActivityEntries` guards (missing ticketId, demo mode, error swallowing) |
| `paste-tickets` | 13 | validation; optimistic add with `(copy)` + number increment; undo push; selection; drawer open; async server-ticket swap; rollback on persistence failure |
| `delete-tickets` | 17 | `prepareTicketsForDelete`; optimistic remove + undo; per-ticket DELETE; rollback on API error; demo-mode `demoStorage` path; `restoreAttachments` / `restoreCommentsAndLinks` endpoints + guards |
| `ticket-actions` | 15 | `moveTickets` (no-ops, resolution auto-coupling both directions, API PATCH, temp-id skip, rollback, demo); `updateTickets` (resolution→done auto-move, rollback); `reorderTickets` (+ rollback) |

Tests exercise the **real zustand stores** (genuine integration of the store mutations) with only the API/toast layer mocked — these are behavioral tests, not coverage padding.

## Ratchet bump
Per the ratchet established in #585, the floor moves up to lock in the gain:
- lines 41→46, statements 40→45, functions 36→39, branches 32→37

Overall coverage: **lines 42.1% → 46.7%, branches 33.3% → 37.8%.**

## Remaining slices (separate PRs)
- data-provider layer (api-provider 11%, demo-provider 0%)
- hooks/queries (7.7%)
- under-covered stores (selection 23%, board 54%, sprint 62%)

## Test plan
- [x] `pnpm test:ci` — 1583/1583 pass, coverage clears the raised floor, exit 0
- [x] `biome check` clean on new files
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)