### PR TITLE
test(data-provider): cover api + demo providers and factory (slice 2)

### DIFF
--- a/src/lib/data-provider/__tests__/api-provider.test.ts
+++ b/src/lib/data-provider/__tests__/api-provider.test.ts
@@ -1,0 +1,308 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { APIDataProvider } from '../api-provider'
+
+// withBasePath is kept real (NEXT_PUBLIC_BASE_PATH is empty in tests, so it
+// returns the path unchanged). Only the network boundary is mocked.
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  // mockImplementation (not mockResolvedValue) so every call gets a FRESH
+  // Response — a Response body can only be read once.
+  fetchMock = vi.fn().mockImplementation(async () => jsonResponse({}))
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+function lastCall(): [string, RequestInit] {
+  const calls = fetchMock.mock.calls
+  return calls[calls.length - 1] as [string, RequestInit]
+}
+
+describe('APIDataProvider.fetchJson (via getProjects)', () => {
+  it('sends a JSON Content-Type header', async () => {
+    await new APIDataProvider().getProjects()
+    const [, init] = lastCall()
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+  })
+
+  it('includes the X-Tab-Id header when a tabId is set', async () => {
+    await new APIDataProvider('tab-9').getProjects()
+    const [, init] = lastCall()
+    expect((init.headers as Record<string, string>)['X-Tab-Id']).toBe('tab-9')
+  })
+
+  it('omits X-Tab-Id when no tabId is provided', async () => {
+    await new APIDataProvider().getProjects()
+    const [, init] = lastCall()
+    expect((init.headers as Record<string, string>)['X-Tab-Id']).toBeUndefined()
+  })
+
+  it('returns the parsed JSON body on success', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ id: 'p1' }]))
+    const result = await new APIDataProvider().getProjects()
+    expect(result).toEqual([{ id: 'p1' }])
+  })
+
+  it('throws the server-provided error message on a non-ok response', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'Nope' }, 400))
+    await expect(new APIDataProvider().getProjects()).rejects.toThrow('Nope')
+  })
+
+  it('falls back to "Request failed" when the error body is not JSON', async () => {
+    fetchMock.mockImplementation(async () => new Response('boom', { status: 503 }))
+    await expect(new APIDataProvider().getProjects()).rejects.toThrow('Request failed')
+  })
+
+  it('throws an HTTP <status> error when the error body has no error field', async () => {
+    fetchMock.mockImplementation(async () => jsonResponse({}, 503))
+    await expect(new APIDataProvider().getProjects()).rejects.toThrow('HTTP 503')
+  })
+})
+
+describe('APIDataProvider error-swallowing reads', () => {
+  it('getProject returns null when the request fails', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'x' }, 404))
+    expect(await new APIDataProvider().getProject('p1')).toBeNull()
+  })
+
+  it('getTicket returns null when the request fails', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'x' }, 404))
+    expect(await new APIDataProvider().getTicket('p1', 't1')).toBeNull()
+  })
+
+  it('getActiveSprint returns null when the request fails', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'x' }, 404))
+    expect(await new APIDataProvider().getActiveSprint('p1')).toBeNull()
+  })
+})
+
+describe('APIDataProvider special-logic methods', () => {
+  it('searchTickets builds query params with q and limit', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]))
+    await new APIDataProvider().searchTickets('p1', { query: 'bug', limit: 25 })
+    const [url] = lastCall()
+    expect(url).toContain('/api/projects/p1/tickets/search?')
+    expect(url).toContain('q=bug')
+    expect(url).toContain('limit=25')
+  })
+
+  it('searchTickets omits limit when not provided', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]))
+    await new APIDataProvider().searchTickets('p1', { query: 'bug' })
+    const [url] = lastCall()
+    expect(url).toContain('q=bug')
+    expect(url).not.toContain('limit=')
+  })
+
+  it('completeSprint maps the incomplete action and passes the carryover target', async () => {
+    await new APIDataProvider().completeSprint('p1', 's1', {
+      incompleteAction: 'carryover',
+      carryOverToSprintId: 's2',
+    })
+    const [url, init] = lastCall()
+    expect(url).toContain('/api/projects/p1/sprints/s1/complete')
+    expect(JSON.parse(init.body as string)).toEqual({
+      action: 'close_to_next',
+      targetSprintId: 's2',
+    })
+  })
+
+  it('completeSprint falls back to close_to_backlog for an unknown action', async () => {
+    await new APIDataProvider().completeSprint('p1', 's1', {
+      incompleteAction: 'bogus' as never,
+    })
+    const [, init] = lastCall()
+    expect(JSON.parse(init.body as string).action).toBe('close_to_backlog')
+  })
+
+  it('getBurndownData appends ?unit=tickets only for the tickets unit', async () => {
+    const p = new APIDataProvider()
+    await p.getBurndownData('p1', 's1', 'tickets')
+    expect(lastCall()[0]).toContain('?unit=tickets')
+    await p.getBurndownData('p1', 's1', 'points')
+    expect(lastCall()[0]).not.toContain('unit=')
+  })
+
+  it('getProjectMembers unwraps the user from each membership row', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ user: { id: 'u1' } }, { user: { id: 'u2' } }]))
+    const members = await new APIDataProvider().getProjectMembers('p1')
+    expect(members).toEqual([{ id: 'u1' }, { id: 'u2' }])
+  })
+
+  it('deleteProject sends the reauth payload when provided', async () => {
+    await new APIDataProvider().deleteProject('p1', { confirmPassword: 'pw' })
+    const [, init] = lastCall()
+    expect(init.method).toBe('DELETE')
+    expect(JSON.parse(init.body as string)).toEqual({ confirmPassword: 'pw' })
+  })
+
+  it('deleteProject omits a body when no reauth is provided', async () => {
+    await new APIDataProvider().deleteProject('p1')
+    const [, init] = lastCall()
+    expect(init.method).toBe('DELETE')
+    expect(init.body).toBeUndefined()
+  })
+
+  it('moveTicket delegates to updateTicket (PATCH on the ticket)', async () => {
+    await new APIDataProvider().moveTicket('p1', 't1', { columnId: 'c2', order: 3 })
+    const [url, init] = lastCall()
+    expect(url).toContain('/api/projects/p1/tickets/t1')
+    expect(init.method).toBe('PATCH')
+    expect(JSON.parse(init.body as string)).toEqual({ columnId: 'c2', order: 3 })
+  })
+})
+
+describe('APIDataProvider URL/method/body contract', () => {
+  const P = 'p1'
+  type Case = {
+    name: string
+    run: (p: APIDataProvider) => Promise<unknown>
+    url: string
+    method?: string
+    body?: unknown
+  }
+  const cases: Case[] = [
+    { name: 'getProjects', run: (p) => p.getProjects(), url: '/api/projects' },
+    {
+      name: 'createProject',
+      run: (p) => p.createProject({ name: 'X', key: 'X' } as never),
+      url: '/api/projects',
+      method: 'POST',
+      body: { name: 'X', key: 'X' },
+    },
+    {
+      name: 'updateProject',
+      run: (p) => p.updateProject(P, { name: 'Y' } as never),
+      url: '/api/projects/p1',
+      method: 'PATCH',
+      body: { name: 'Y' },
+    },
+    {
+      name: 'getColumnsWithTickets',
+      run: (p) => p.getColumnsWithTickets(P),
+      url: '/api/projects/p1/columns',
+    },
+    { name: 'getTickets', run: (p) => p.getTickets(P), url: '/api/projects/p1/tickets' },
+    {
+      name: 'createTicket',
+      run: (p) => p.createTicket(P, { title: 'T' } as never),
+      url: '/api/projects/p1/tickets',
+      method: 'POST',
+      body: { title: 'T' },
+    },
+    {
+      name: 'updateTicket',
+      run: (p) => p.updateTicket(P, 't1', { title: 'T2' } as never),
+      url: '/api/projects/p1/tickets/t1',
+      method: 'PATCH',
+      body: { title: 'T2' },
+    },
+    {
+      name: 'deleteTicket',
+      run: (p) => p.deleteTicket(P, 't1'),
+      url: '/api/projects/p1/tickets/t1',
+      method: 'DELETE',
+    },
+    {
+      name: 'moveTickets',
+      run: (p) => p.moveTickets(P, ['t1', 't2'], 'c2', 0),
+      url: '/api/projects/p1/tickets',
+      method: 'PATCH',
+      body: { ticketIds: ['t1', 't2'], toColumnId: 'c2', newOrder: 0 },
+    },
+    { name: 'getLabels', run: (p) => p.getLabels(P), url: '/api/projects/p1/labels' },
+    {
+      name: 'createLabel',
+      run: (p) => p.createLabel(P, { name: 'L', color: '#fff' } as never),
+      url: '/api/projects/p1/labels',
+      method: 'POST',
+      body: { name: 'L', color: '#fff' },
+    },
+    {
+      name: 'updateLabel',
+      run: (p) => p.updateLabel(P, 'l1', { name: 'L2' } as never),
+      url: '/api/projects/p1/labels/l1',
+      method: 'PATCH',
+      body: { name: 'L2' },
+    },
+    {
+      name: 'deleteLabel',
+      run: (p) => p.deleteLabel(P, 'l1'),
+      url: '/api/projects/p1/labels/l1',
+      method: 'DELETE',
+    },
+    { name: 'getSprints', run: (p) => p.getSprints(P), url: '/api/projects/p1/sprints' },
+    {
+      name: 'createSprint',
+      run: (p) => p.createSprint(P, { name: 'S' } as never),
+      url: '/api/projects/p1/sprints',
+      method: 'POST',
+      body: { name: 'S' },
+    },
+    {
+      name: 'updateSprint',
+      run: (p) => p.updateSprint(P, 's1', { name: 'S2' } as never),
+      url: '/api/projects/p1/sprints/s1',
+      method: 'PATCH',
+      body: { name: 'S2' },
+    },
+    {
+      name: 'deleteSprint',
+      run: (p) => p.deleteSprint(P, 's1'),
+      url: '/api/projects/p1/sprints/s1',
+      method: 'DELETE',
+    },
+    {
+      name: 'startSprint',
+      run: (p) => p.startSprint(P, 's1', {} as never),
+      url: '/api/projects/p1/sprints/s1/start',
+      method: 'POST',
+    },
+    {
+      name: 'extendSprint',
+      run: (p) => p.extendSprint(P, 's1', { endDate: 'x' } as never),
+      url: '/api/projects/p1/sprints/s1/extend',
+      method: 'POST',
+      body: { endDate: 'x' },
+    },
+    {
+      name: 'reopenSprint',
+      run: (p) => p.reopenSprint(P, 's1'),
+      url: '/api/projects/p1/sprints/s1/reopen',
+      method: 'POST',
+      body: {},
+    },
+    {
+      name: 'getSprintSettings',
+      run: (p) => p.getSprintSettings(P),
+      url: '/api/projects/p1/sprints/settings',
+    },
+    {
+      name: 'updateSprintSettings',
+      run: (p) => p.updateSprintSettings(P, { doneColumnIds: ['c1'] } as never),
+      url: '/api/projects/p1/sprints/settings',
+      method: 'PATCH',
+      body: { doneColumnIds: ['c1'] },
+    },
+    { name: 'getDashboardStats', run: (p) => p.getDashboardStats(), url: '/api/dashboard/stats' },
+    { name: 'getBranding', run: (p) => p.getBranding(), url: '/api/branding' },
+  ]
+
+  it.each(cases)('$name hits the right endpoint', async ({ run, url, method, body }) => {
+    fetchMock.mockResolvedValue(jsonResponse([]))
+    await run(new APIDataProvider())
+    const [calledUrl, init] = lastCall()
+    expect(calledUrl).toBe(url)
+    expect(init.method ?? 'GET').toBe(method ?? 'GET')
+    if (body !== undefined) {
+      expect(JSON.parse(init.body as string)).toEqual(body)
+    }
+  })
+})

--- a/src/lib/data-provider/__tests__/demo-provider.test.ts
+++ b/src/lib/data-provider/__tests__/demo-provider.test.ts
@@ -1,0 +1,397 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockTicket } from '@/__tests__/utils/mocks'
+import { DEMO_USER_SUMMARY } from '@/lib/demo/demo-data'
+import { demoStorage } from '@/lib/demo/demo-storage'
+import { DemoDataProvider } from '../demo-provider'
+
+vi.mock('@/lib/demo/demo-storage', () => ({
+  demoStorage: {
+    initialize: vi.fn(),
+    getProjects: vi.fn(() => []),
+    getProject: vi.fn(),
+    createProject: vi.fn(),
+    updateProject: vi.fn(),
+    deleteProject: vi.fn(),
+    getColumnsWithTickets: vi.fn(() => []),
+    getColumns: vi.fn(() => []),
+    getTickets: vi.fn(() => []),
+    getTicket: vi.fn(),
+    createTicket: vi.fn((_pid, _col, data) => data),
+    updateTicket: vi.fn(),
+    deleteTicket: vi.fn(),
+    getLabels: vi.fn(() => []),
+    createLabel: vi.fn(),
+    updateLabel: vi.fn(),
+    deleteLabel: vi.fn(),
+    getSprints: vi.fn(() => []),
+    getActiveSprint: vi.fn(),
+    createSprint: vi.fn(),
+    updateSprint: vi.fn(),
+    deleteSprint: vi.fn(),
+  },
+}))
+
+const store = vi.mocked(demoStorage)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // re-apply default return values cleared by clearAllMocks
+  store.getProjects.mockReturnValue([])
+  store.getColumns.mockReturnValue([])
+  store.getColumnsWithTickets.mockReturnValue([])
+  store.getTickets.mockReturnValue([])
+  store.getLabels.mockReturnValue([])
+  store.getSprints.mockReturnValue([])
+  store.createTicket.mockImplementation((_pid, _col, data) => data as never)
+})
+
+describe('DemoDataProvider construction', () => {
+  it('initializes demo storage', () => {
+    new DemoDataProvider()
+    expect(store.initialize).toHaveBeenCalled()
+  })
+})
+
+describe('getProject', () => {
+  it('returns the project with an owner role when found', async () => {
+    store.getProject.mockReturnValue({ id: 'p1', name: 'P' } as never)
+    const result = await new DemoDataProvider().getProject('p1')
+    expect(result).toMatchObject({ id: 'p1', role: 'owner' })
+  })
+
+  it('returns null when the project is missing', async () => {
+    store.getProject.mockReturnValue(undefined as never)
+    expect(await new DemoDataProvider().getProject('p1')).toBeNull()
+  })
+})
+
+describe('not-found errors', () => {
+  it('updateProject throws when storage returns nothing', async () => {
+    store.updateProject.mockReturnValue(undefined as never)
+    await expect(new DemoDataProvider().updateProject('p1', {} as never)).rejects.toThrow(
+      'Project not found',
+    )
+  })
+
+  it('updateTicket throws when storage returns nothing', async () => {
+    store.updateTicket.mockReturnValue(undefined as never)
+    await expect(new DemoDataProvider().updateTicket('p1', 't1', {} as never)).rejects.toThrow(
+      'Ticket not found',
+    )
+  })
+
+  it('updateLabel throws when storage returns nothing', async () => {
+    store.updateLabel.mockReturnValue(undefined as never)
+    await expect(new DemoDataProvider().updateLabel('p1', 'l1', {} as never)).rejects.toThrow(
+      'Label not found',
+    )
+  })
+
+  it('updateSprint throws when storage returns nothing', async () => {
+    store.updateSprint.mockReturnValue(undefined as never)
+    await expect(new DemoDataProvider().updateSprint('p1', 's1', {} as never)).rejects.toThrow(
+      'Sprint not found',
+    )
+  })
+})
+
+describe('searchTickets', () => {
+  const provider = () => new DemoDataProvider()
+
+  it('returns an empty array for a blank query', async () => {
+    expect(await provider().searchTickets('p1', { query: '   ' })).toEqual([])
+  })
+
+  it('matches by title (case-insensitive)', async () => {
+    store.getTickets.mockReturnValue([
+      createMockTicket({ id: 't1', title: 'Fix the Login bug', number: 1 }),
+      createMockTicket({ id: 't2', title: 'Unrelated', number: 2 }),
+    ])
+    const result = await provider().searchTickets('p1', { query: 'login' })
+    expect(result.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('matches by description', async () => {
+    store.getTickets.mockReturnValue([
+      createMockTicket({ id: 't1', title: 'A', description: 'mentions widget', number: 1 }),
+    ])
+    const result = await provider().searchTickets('p1', { query: 'widget' })
+    expect(result.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('matches a bare ticket number (requires the project to resolve the key)', async () => {
+    store.getProjects.mockReturnValue([{ id: 'p1', key: 'PUNT' }] as never)
+    store.getTickets.mockReturnValue([
+      createMockTicket({ id: 't1', title: 'A', number: 42 }),
+      createMockTicket({ id: 't2', title: 'B', number: 7 }),
+    ])
+    const result = await provider().searchTickets('p1', { query: '42' })
+    expect(result.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('matches a PROJECT-N key pattern', async () => {
+    store.getProjects.mockReturnValue([{ id: 'p1', key: 'PUNT' }] as never)
+    store.getTickets.mockReturnValue([createMockTicket({ id: 't1', title: 'A', number: 99 })])
+    const result = await provider().searchTickets('p1', { query: 'PUNT-99' })
+    expect(result.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('respects the limit', async () => {
+    store.getTickets.mockReturnValue(
+      Array.from({ length: 5 }, (_, i) =>
+        createMockTicket({ id: `t${i}`, title: `match ${i}`, number: i }),
+      ),
+    )
+    const result = await provider().searchTickets('p1', { query: 'match', limit: 2 })
+    expect(result).toHaveLength(2)
+  })
+})
+
+describe('createTicket resolves relations', () => {
+  it('resolves labels, sprint, and assignee from ids and defaults the creator', async () => {
+    store.getLabels.mockReturnValue([
+      { id: 'l1', name: 'bug', color: '#f00' },
+      { id: 'l2', name: 'ui', color: '#0f0' },
+    ] as never)
+    store.getSprints.mockReturnValue([{ id: 's1', name: 'S1' }] as never)
+
+    await new DemoDataProvider().createTicket('p1', {
+      columnId: 'c1',
+      title: 'T',
+      labelIds: ['l1'],
+      sprintId: 's1',
+      assigneeId: DEMO_USER_SUMMARY.id,
+    } as never)
+
+    const passed = store.createTicket.mock.calls[0][2] as Record<string, unknown>
+    expect((passed.labels as Array<{ id: string }>).map((l) => l.id)).toEqual(['l1'])
+    expect((passed.sprint as { id: string }).id).toBe('s1')
+    expect((passed.assignee as { id: string }).id).toBe(DEMO_USER_SUMMARY.id)
+    expect((passed.creator as { id: string }).id).toBe(DEMO_USER_SUMMARY.id)
+  })
+})
+
+describe('updateTicket maps inputs', () => {
+  beforeEach(() => {
+    store.updateTicket.mockImplementation(
+      (_p, _t, updates) => ({ ...createMockTicket({ id: 't1' }), ...updates }) as never,
+    )
+  })
+
+  it('converts resolvedAt strings to Date and clears with null', async () => {
+    await new DemoDataProvider().updateTicket('p1', 't1', { resolvedAt: '2024-05-01' } as never)
+    expect((store.updateTicket.mock.calls[0][2] as { resolvedAt: Date }).resolvedAt).toBeInstanceOf(
+      Date,
+    )
+
+    store.updateTicket.mockClear()
+    await new DemoDataProvider().updateTicket('p1', 't1', { resolvedAt: null } as never)
+    expect((store.updateTicket.mock.calls[0][2] as { resolvedAt: null }).resolvedAt).toBeNull()
+  })
+
+  it('clears sprint when sprintId is null', async () => {
+    await new DemoDataProvider().updateTicket('p1', 't1', { sprintId: null } as never)
+    expect((store.updateTicket.mock.calls[0][2] as { sprint: null }).sprint).toBeNull()
+  })
+})
+
+describe('moveTickets', () => {
+  it('updates each ticket order and collects the successful results', async () => {
+    store.updateTicket.mockImplementation((_p, id) =>
+      id === 'missing' ? (undefined as never) : (createMockTicket({ id }) as never),
+    )
+    const result = await new DemoDataProvider().moveTickets('p1', ['a', 'missing', 'b'], 'c2', 0)
+    expect(result.map((t) => t.id)).toEqual(['a', 'b'])
+    expect(store.updateTicket).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('completeSprint', () => {
+  beforeEach(() => {
+    store.getSprints.mockReturnValue([{ id: 's1', name: 'S1', status: 'active' }] as never)
+    store.updateSprint.mockReturnValue({ id: 's1', status: 'completed' } as never)
+  })
+
+  it('throws when the sprint does not exist', async () => {
+    store.getSprints.mockReturnValue([])
+    await expect(
+      new DemoDataProvider().completeSprint('p1', 's1', { incompleteAction: 'keep' }),
+    ).rejects.toThrow('Sprint not found')
+  })
+
+  it('moves incomplete tickets to the backlog and reports disposition', async () => {
+    store.getColumns.mockReturnValue([{ id: 'c1', name: 'To Do' }] as never)
+    store.getTickets.mockReturnValue([
+      createMockTicket({ id: 't1', sprintId: 's1', columnId: 'c1' }),
+    ])
+
+    const result = (await new DemoDataProvider().completeSprint('p1', 's1', {
+      incompleteAction: 'backlog',
+    })) as unknown as { ticketDisposition: { movedToBacklog: string[] } }
+
+    expect(result.ticketDisposition.movedToBacklog).toEqual(['t1'])
+    expect(store.updateTicket).toHaveBeenCalledWith(
+      'p1',
+      't1',
+      expect.objectContaining({ sprintId: null }),
+    )
+  })
+
+  it('counts tickets in a Done column as completed', async () => {
+    store.getColumns.mockReturnValue([{ id: 'c-done', name: 'Done' }] as never)
+    store.getTickets.mockReturnValue([
+      createMockTicket({ id: 't1', sprintId: 's1', columnId: 'c-done' }),
+    ])
+
+    const result = (await new DemoDataProvider().completeSprint('p1', 's1', {
+      incompleteAction: 'backlog',
+    })) as unknown as { ticketDisposition: { completed: string[] } }
+
+    expect(result.ticketDisposition.completed).toEqual(['t1'])
+  })
+
+  it('carries incomplete tickets over to the target sprint', async () => {
+    store.getSprints.mockReturnValue([
+      { id: 's1', name: 'S1', status: 'active' },
+      { id: 's2', name: 'S2', status: 'planning' },
+    ] as never)
+    store.getColumns.mockReturnValue([{ id: 'c1', name: 'In Progress' }] as never)
+    store.getTickets.mockReturnValue([
+      createMockTicket({ id: 't1', sprintId: 's1', columnId: 'c1', carriedOverCount: 0 }),
+    ])
+
+    const result = (await new DemoDataProvider().completeSprint('p1', 's1', {
+      incompleteAction: 'carryover',
+      carryOverToSprintId: 's2',
+    })) as unknown as { ticketDisposition: { carriedOver: string[] } }
+
+    expect(result.ticketDisposition.carriedOver).toEqual(['t1'])
+    expect(store.updateTicket).toHaveBeenCalledWith(
+      'p1',
+      't1',
+      expect.objectContaining({ sprintId: 's2', isCarriedOver: true, carriedFromSprintId: 's1' }),
+    )
+  })
+})
+
+describe('reopenSprint', () => {
+  it('throws when the sprint is not completed', async () => {
+    store.getSprints.mockReturnValue([{ id: 's1', status: 'active' }] as never)
+    await expect(new DemoDataProvider().reopenSprint('p1', 's1')).rejects.toThrow(
+      'Can only reopen a completed sprint',
+    )
+  })
+
+  it('throws when another sprint is already active', async () => {
+    store.getSprints.mockReturnValue([{ id: 's1', status: 'completed' }] as never)
+    store.getActiveSprint.mockReturnValue({ id: 's2', name: 'Other' } as never)
+    await expect(new DemoDataProvider().reopenSprint('p1', 's1')).rejects.toThrow(/already active/)
+  })
+
+  it('reactivates a completed sprint when nothing else is active', async () => {
+    store.getSprints.mockReturnValue([{ id: 's1', status: 'completed' }] as never)
+    store.getActiveSprint.mockReturnValue(undefined as never)
+    store.updateSprint.mockReturnValue({ id: 's1', status: 'active' } as never)
+    const result = await new DemoDataProvider().reopenSprint('p1', 's1')
+    expect(result.status).toBe('active')
+  })
+})
+
+describe('startSprint', () => {
+  it('defaults the end date to two weeks after the start', async () => {
+    store.getSprints.mockReturnValue([{ id: 's1', status: 'planning' }] as never)
+    store.updateSprint.mockImplementation((_p, _s, data) => ({ id: 's1', ...data }) as never)
+
+    const start = new Date('2024-01-01T00:00:00Z')
+    await new DemoDataProvider().startSprint('p1', 's1', { startDate: start } as never)
+    const passed = store.updateSprint.mock.calls[0][2] as { startDate: Date; endDate: Date }
+    const days = (passed.endDate.getTime() - passed.startDate.getTime()) / (24 * 60 * 60 * 1000)
+    expect(days).toBe(14)
+  })
+
+  it('throws when the sprint does not exist', async () => {
+    store.getSprints.mockReturnValue([])
+    await expect(new DemoDataProvider().startSprint('p1', 's1', {} as never)).rejects.toThrow(
+      'Sprint not found',
+    )
+  })
+})
+
+describe('getDashboardStats', () => {
+  it('categorizes tickets by column name', async () => {
+    store.getProjects.mockReturnValue([{ id: 'p1' }] as never)
+    store.getColumns.mockReturnValue([
+      { id: 'c1', name: 'To Do' },
+      { id: 'c2', name: 'In Progress' },
+      { id: 'c3', name: 'Done' },
+    ] as never)
+    store.getTickets.mockReturnValue([
+      createMockTicket({ id: 't1', columnId: 'c1' }),
+      createMockTicket({ id: 't2', columnId: 'c2' }),
+      createMockTicket({ id: 't3', columnId: 'c3' }),
+      createMockTicket({ id: 't4', columnId: 'c3' }),
+    ])
+
+    const stats = await new DemoDataProvider().getDashboardStats()
+    expect(stats).toEqual({ openTickets: 1, inProgress: 1, completed: 2 })
+  })
+})
+
+describe('static demo-mode responses', () => {
+  it('getSprintSettings returns demo defaults', async () => {
+    const s = await new DemoDataProvider().getSprintSettings('p1')
+    expect(s.defaultSprintDuration).toBe(14)
+  })
+
+  it('updateSprintSettings merges provided values', async () => {
+    const s = await new DemoDataProvider().updateSprintSettings('p1', {
+      defaultSprintDuration: 7,
+      doneColumnIds: ['c1'],
+    })
+    expect(s.defaultSprintDuration).toBe(7)
+    expect(s.doneColumnIds).toEqual(['c1'])
+  })
+
+  it('getProjectMembers includes the demo user', async () => {
+    const members = await new DemoDataProvider().getProjectMembers('p1')
+    expect(members.some((m) => m.id === DEMO_USER_SUMMARY.id)).toBe(true)
+  })
+
+  it('getBranding returns the PUNT defaults', async () => {
+    expect((await new DemoDataProvider().getBranding()).appName).toBe('PUNT')
+  })
+
+  it('getBurndownData returns an empty points series', async () => {
+    const d = await new DemoDataProvider().getBurndownData('p1', 's1')
+    expect(d.unit).toBe('points')
+    expect(d.dataPoints).toEqual([])
+  })
+})
+
+describe('delegations to demoStorage', () => {
+  it('passes through simple reads and writes', async () => {
+    const p = new DemoDataProvider()
+    await p.getProjects()
+    await p.createProject({ name: 'X' } as never)
+    await p.deleteProject('p1')
+    await p.getColumnsWithTickets('p1')
+    await p.getTickets('p1')
+    await p.getTicket('p1', 't1')
+    await p.deleteTicket('p1', 't1')
+    await p.getLabels('p1')
+    await p.createLabel('p1', { name: 'L', color: '#fff' } as never)
+    await p.deleteLabel('p1', 'l1')
+    await p.getSprints('p1')
+    await p.getActiveSprint('p1')
+    await p.createSprint('p1', { name: 'S' } as never)
+    await p.deleteSprint('p1', 's1')
+
+    expect(store.getProjects).toHaveBeenCalled()
+    expect(store.createProject).toHaveBeenCalledWith({ name: 'X' })
+    expect(store.deleteProject).toHaveBeenCalledWith('p1')
+    expect(store.getColumnsWithTickets).toHaveBeenCalledWith('p1')
+    expect(store.deleteTicket).toHaveBeenCalledWith('p1', 't1')
+    expect(store.createLabel).toHaveBeenCalledWith('p1', { name: 'L', color: '#fff' })
+    expect(store.deleteSprint).toHaveBeenCalledWith('p1', 's1')
+  })
+})

--- a/src/lib/data-provider/__tests__/index.test.ts
+++ b/src/lib/data-provider/__tests__/index.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Replace the concrete providers with lightweight fakes so we test only the
+// factory's selection + singleton logic, not provider internals.
+vi.mock('../api-provider', () => ({
+  APIDataProvider: class {
+    tabId: string
+    constructor(tabId = '') {
+      this.tabId = tabId
+    }
+  },
+}))
+vi.mock('../demo-provider', () => ({
+  DemoDataProvider: class {
+    kind = 'demo'
+  },
+}))
+vi.mock('@/lib/demo/demo-config', () => ({ isDemoMode: vi.fn() }))
+
+import { isDemoMode } from '@/lib/demo/demo-config'
+
+const mockIsDemoMode = vi.mocked(isDemoMode)
+
+async function loadFactory() {
+  // Fresh module each test so the module-level singletons reset.
+  vi.resetModules()
+  return import('../index')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getDataProvider', () => {
+  it('returns a DemoDataProvider in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { getDataProvider } = await loadFactory()
+    expect((getDataProvider() as { kind?: string }).kind).toBe('demo')
+  })
+
+  it('reuses the same demo provider instance (singleton)', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { getDataProvider } = await loadFactory()
+    expect(getDataProvider()).toBe(getDataProvider())
+  })
+
+  it('returns an APIDataProvider in production mode', async () => {
+    mockIsDemoMode.mockReturnValue(false)
+    const { getDataProvider } = await loadFactory()
+    expect((getDataProvider() as { tabId?: string }).tabId).toBe('')
+  })
+
+  it('reuses the API provider when the tabId is unchanged', async () => {
+    mockIsDemoMode.mockReturnValue(false)
+    const { getDataProvider } = await loadFactory()
+    expect(getDataProvider('tab-1')).toBe(getDataProvider('tab-1'))
+  })
+
+  it('creates a new API provider when the tabId changes', async () => {
+    mockIsDemoMode.mockReturnValue(false)
+    const { getDataProvider } = await loadFactory()
+    const first = getDataProvider('tab-1')
+    const second = getDataProvider('tab-2')
+    expect(first).not.toBe(second)
+    expect((second as { tabId: string }).tabId).toBe('tab-2')
+  })
+})
+
+describe('createDataProvider', () => {
+  it('returns a fresh (non-singleton) instance each call', async () => {
+    mockIsDemoMode.mockReturnValue(false)
+    const { createDataProvider } = await loadFactory()
+    expect(createDataProvider('t')).not.toBe(createDataProvider('t'))
+  })
+
+  it('returns a demo provider in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { createDataProvider } = await loadFactory()
+    expect((createDataProvider() as { kind?: string }).kind).toBe('demo')
+  })
+})
+
+describe('useDataProvider', () => {
+  it('delegates to getDataProvider', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { useDataProvider, getDataProvider } = await loadFactory()
+    expect(useDataProvider()).toBe(getDataProvider())
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,10 +65,10 @@ export default defineConfig({
       // improves — they should only ever go UP, never down.
       // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
-        lines: 46,
-        functions: 39,
-        branches: 37,
-        statements: 45,
+        lines: 49,
+        functions: 43,
+        branches: 39,
+        statements: 48,
       },
     },
   },


### PR DESCRIPTION
## Summary
Slice 2 of the coverage backfill (follows #586). The **data-provider layer** — the abstraction every component goes through for data access — was at **api-provider 11% / demo-provider 0%**. Both implementations were effectively untested. This brings the layer to **~90% statements / 93% lines** with 84 tests.

## What's covered
| File | Tests | Focus |
|------|-------|-------|
| `api-provider` | 43 | `fetchJson` contract (headers, `X-Tab-Id`, JSON parse; error-message vs `HTTP <status>` vs `Request failed` branches); error-swallowing reads (→ null); `searchTickets` query building; `completeSprint` action mapping; `getBurndownData` unit param; `getProjectMembers` unwrap; `deleteProject` reauth body; **table-driven URL/method/body contract** across the uniform REST methods |
| `demo-provider` | 33 | `demoStorage` delegation; `getProject` role mapping; not-found throws; `searchTickets` matching (title/description/bare-number/`PROJECT-N` key/limit); `createTicket` relation resolution; `updateTicket` input mapping; `moveTickets` result collection; `completeSprint` dispositions (backlog/carryover/completed); `reopenSprint` guards; `startSprint` default end date; `getDashboardStats` categorization; static demo responses |
| `index` | 8 | factory selection (demo vs API), singleton reuse, tabId rotation, `createDataProvider` non-singleton, `useDataProvider` |

api-provider tests mock only the network boundary (`fetch`); demo-provider tests mock `demoStorage`; the factory test mocks both provider classes to test selection/singleton logic in isolation.

## Ratchet bump
- lines 46→49, statements 45→48, functions 39→43, branches 37→39

Overall coverage: **lines 46.7% → 49.4%, branches 37.8% → 40.1%.**

## Remaining slices (separate PRs)
- hooks/queries (7.7%)
- under-covered stores (selection 23%, board 54%, sprint 62%)

## Test plan
- [x] `pnpm test:ci` — 1667/1667 pass, coverage clears the raised floor, exit 0
- [x] `biome check` clean on new files
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)