### PR TITLE
test(stores): cover selection/sprint/board gaps (slice 3)

### DIFF
--- a/src/stores/__tests__/board-store-extra.test.ts
+++ b/src/stores/__tests__/board-store-extra.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockTicket } from '@/__tests__/utils/mocks'
+import { useBoardStore } from '../board-store'
+
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+}
+global.localStorage = localStorageMock as unknown as Storage
+
+const PROJECT_ID = 'test-project'
+
+describe('Board Store — sync / collapse / sort / hydration', () => {
+  beforeEach(() => {
+    useBoardStore.setState({
+      projects: {},
+      searchQueries: {},
+      collapsedColumns: {},
+      columnSorts: {},
+      _hasHydrated: true,
+    })
+    vi.clearAllMocks()
+  })
+
+  describe('syncTicketsFromAPI', () => {
+    it('groups tickets into their columns, sorted by order', () => {
+      useBoardStore.setState({
+        projects: {
+          [PROJECT_ID]: [
+            { id: 'col-1', name: 'To Do', order: 0, projectId: PROJECT_ID, tickets: [] },
+            { id: 'col-2', name: 'Done', order: 1, projectId: PROJECT_ID, tickets: [] },
+          ],
+        },
+      })
+
+      useBoardStore
+        .getState()
+        .syncTicketsFromAPI(PROJECT_ID, [
+          createMockTicket({ id: 'a', columnId: 'col-1', order: 1 }),
+          createMockTicket({ id: 'b', columnId: 'col-1', order: 0 }),
+          createMockTicket({ id: 'c', columnId: 'col-2', order: 0 }),
+        ])
+
+      const cols = useBoardStore.getState().getColumns(PROJECT_ID)
+      expect(cols[0].tickets.map((t) => t.id)).toEqual(['b', 'a']) // sorted by order
+      expect(cols[1].tickets.map((t) => t.id)).toEqual(['c'])
+    })
+
+    it('falls back to default columns when the project has none', () => {
+      useBoardStore.getState().syncTicketsFromAPI(PROJECT_ID, [])
+      const cols = useBoardStore.getState().getColumns(PROJECT_ID)
+      expect(cols.length).toBeGreaterThan(0)
+      expect(cols[0].name).toBe('To Do')
+    })
+
+    it('empties columns that have no incoming tickets', () => {
+      useBoardStore.setState({
+        projects: {
+          [PROJECT_ID]: [
+            {
+              id: 'col-1',
+              name: 'To Do',
+              order: 0,
+              projectId: PROJECT_ID,
+              tickets: [createMockTicket({ id: 'stale', columnId: 'col-1' })],
+            },
+          ],
+        },
+      })
+      useBoardStore.getState().syncTicketsFromAPI(PROJECT_ID, [])
+      expect(useBoardStore.getState().getColumns(PROJECT_ID)[0].tickets).toEqual([])
+    })
+  })
+
+  describe('column collapse', () => {
+    it('defaults to not collapsed', () => {
+      expect(useBoardStore.getState().isColumnCollapsed('col-1')).toBe(false)
+    })
+
+    it('toggles collapsed state', () => {
+      useBoardStore.getState().toggleColumnCollapsed('col-1')
+      expect(useBoardStore.getState().isColumnCollapsed('col-1')).toBe(true)
+      useBoardStore.getState().toggleColumnCollapsed('col-1')
+      expect(useBoardStore.getState().isColumnCollapsed('col-1')).toBe(false)
+    })
+
+    it('sets collapsed state explicitly', () => {
+      useBoardStore.getState().setColumnCollapsed('col-1', true)
+      expect(useBoardStore.getState().isColumnCollapsed('col-1')).toBe(true)
+      useBoardStore.getState().setColumnCollapsed('col-1', false)
+      expect(useBoardStore.getState().isColumnCollapsed('col-1')).toBe(false)
+    })
+  })
+
+  describe('column sorts', () => {
+    it('defaults to manual', () => {
+      expect(useBoardStore.getState().getColumnSort('col-1')).toBe('manual')
+    })
+
+    it('sets and reads a column sort', () => {
+      useBoardStore.getState().setColumnSort('col-1', 'priority')
+      expect(useBoardStore.getState().getColumnSort('col-1')).toBe('priority')
+    })
+
+    it('keeps column sorts independent and clears them all', () => {
+      useBoardStore.getState().setColumnSort('col-1', 'priority')
+      useBoardStore.getState().setColumnSort('col-2', 'dueDate')
+      expect(useBoardStore.getState().getColumnSort('col-2')).toBe('dueDate')
+      useBoardStore.getState().clearAllColumnSorts()
+      expect(useBoardStore.getState().getColumnSort('col-1')).toBe('manual')
+      expect(useBoardStore.getState().getColumnSort('col-2')).toBe('manual')
+    })
+  })
+
+  describe('hydration flag', () => {
+    it('setHasHydrated updates the flag', () => {
+      useBoardStore.getState().setHasHydrated(false)
+      expect(useBoardStore.getState()._hasHydrated).toBe(false)
+      useBoardStore.getState().setHasHydrated(true)
+      expect(useBoardStore.getState()._hasHydrated).toBe(true)
+    })
+  })
+
+  describe('getSearchQuery', () => {
+    it('returns the stored query and empty string for unknown projects', () => {
+      useBoardStore.getState().setSearchQuery(PROJECT_ID, 'hello')
+      expect(useBoardStore.getState().getSearchQuery(PROJECT_ID)).toBe('hello')
+      expect(useBoardStore.getState().getSearchQuery('unknown')).toBe('')
+    })
+  })
+})

--- a/src/stores/__tests__/selection-store.test.ts
+++ b/src/stores/__tests__/selection-store.test.ts
@@ -6,6 +6,8 @@ describe('Selection Store', () => {
     useSelectionStore.setState({
       selectedTicketIds: new Set(),
       lastSelectedId: null,
+      ticketOrigins: new Map(),
+      copiedTicketIds: [],
     })
   })
 
@@ -130,6 +132,67 @@ describe('Selection Store', () => {
       expect(ids).toContain('ticket-1')
       expect(ids).toContain('ticket-2')
       expect(ids).toHaveLength(2)
+    })
+  })
+
+  describe('selectRange edge cases', () => {
+    it('selects only the current ticket when the last or current id is not in the list', () => {
+      useSelectionStore.getState().selectTicket('anchor')
+      // 'anchor' is not present in the provided list -> lastIndex === -1 branch
+      useSelectionStore.getState().selectRange('ticket-2', ['ticket-1', 'ticket-2', 'ticket-3'])
+      expect(useSelectionStore.getState().getSelectedIds()).toEqual(['ticket-2'])
+      expect(useSelectionStore.getState().lastSelectedId).toBe('ticket-2')
+    })
+  })
+
+  describe('ticket origins', () => {
+    it('stores and retrieves a ticket origin', () => {
+      useSelectionStore.getState().setTicketOrigin('ticket-1', { columnId: 'col-1', position: 3 })
+      expect(useSelectionStore.getState().getTicketOrigin('ticket-1')).toEqual({
+        columnId: 'col-1',
+        position: 3,
+      })
+    })
+
+    it('returns undefined for an unknown origin', () => {
+      expect(useSelectionStore.getState().getTicketOrigin('nope')).toBeUndefined()
+    })
+
+    it('clears origins when selecting a single ticket', () => {
+      useSelectionStore.getState().setTicketOrigin('ticket-1', { columnId: 'col-1', position: 0 })
+      useSelectionStore.getState().selectTicket('ticket-2')
+      expect(useSelectionStore.getState().getTicketOrigin('ticket-1')).toBeUndefined()
+    })
+
+    it('clears origins on clearSelection', () => {
+      useSelectionStore.getState().setTicketOrigin('ticket-1', { columnId: 'col-1', position: 0 })
+      useSelectionStore.getState().clearSelection()
+      expect(useSelectionStore.getState().getTicketOrigin('ticket-1')).toBeUndefined()
+    })
+  })
+
+  describe('clipboard', () => {
+    it('copies the current selection to the clipboard', () => {
+      useSelectionStore.getState().selectTicket('ticket-1')
+      useSelectionStore.getState().toggleTicket('ticket-2')
+      useSelectionStore.getState().copySelected()
+      const copied = useSelectionStore.getState().getCopiedIds()
+      expect(copied).toContain('ticket-1')
+      expect(copied).toContain('ticket-2')
+      expect(copied).toHaveLength(2)
+    })
+
+    it('copying does not change the live selection', () => {
+      useSelectionStore.getState().selectTicket('ticket-1')
+      useSelectionStore.getState().copySelected()
+      expect(useSelectionStore.getState().getSelectedIds()).toEqual(['ticket-1'])
+    })
+
+    it('clears the clipboard', () => {
+      useSelectionStore.getState().selectTicket('ticket-1')
+      useSelectionStore.getState().copySelected()
+      useSelectionStore.getState().clearClipboard()
+      expect(useSelectionStore.getState().getCopiedIds()).toEqual([])
     })
   })
 })

--- a/src/stores/__tests__/sprint-store.test.ts
+++ b/src/stores/__tests__/sprint-store.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useSprintStore } from '../sprint-store'
+
+describe('Sprint Store', () => {
+  beforeEach(() => {
+    useSprintStore.setState({
+      dismissedPrompts: {},
+      sprintSorts: {},
+      planningViewOpen: false,
+    })
+  })
+
+  describe('dismissed completion prompts', () => {
+    it('shouldShowPrompt is true for a sprint that was never dismissed', () => {
+      expect(useSprintStore.getState().shouldShowPrompt('s1')).toBe(true)
+    })
+
+    it('still shows the prompt after dismissing with "later" (remind-me-later semantics)', () => {
+      useSprintStore.getState().dismissSprintPrompt('s1', 'later')
+      // "later" records the dismissal but keeps the prompt eligible to reappear
+      expect(useSprintStore.getState().shouldShowPrompt('s1')).toBe(true)
+      expect(useSprintStore.getState().dismissedPrompts.s1.action).toBe('later')
+    })
+
+    it('suppresses the prompt after dismissing with "extend"', () => {
+      useSprintStore.getState().dismissSprintPrompt('s1', 'extend')
+      expect(useSprintStore.getState().shouldShowPrompt('s1')).toBe(false)
+    })
+
+    it('records a dismissedAt timestamp', () => {
+      useSprintStore.getState().dismissSprintPrompt('s1', 'later')
+      expect(typeof useSprintStore.getState().dismissedPrompts.s1.dismissedAt).toBe('number')
+    })
+
+    it('tracks dismissals per sprint independently', () => {
+      useSprintStore.getState().dismissSprintPrompt('s1', 'extend')
+      expect(useSprintStore.getState().shouldShowPrompt('s1')).toBe(false)
+      expect(useSprintStore.getState().shouldShowPrompt('s2')).toBe(true)
+    })
+
+    it('clears a single dismissed prompt, re-enabling its prompt', () => {
+      useSprintStore.getState().dismissSprintPrompt('s1', 'extend')
+      useSprintStore.getState().dismissSprintPrompt('s2', 'extend')
+      useSprintStore.getState().clearDismissedPrompt('s1')
+      expect(useSprintStore.getState().shouldShowPrompt('s1')).toBe(true)
+      expect(useSprintStore.getState().shouldShowPrompt('s2')).toBe(false)
+    })
+
+    it('clears all dismissed prompts', () => {
+      useSprintStore.getState().dismissSprintPrompt('s1', 'later')
+      useSprintStore.getState().dismissSprintPrompt('s2', 'extend')
+      useSprintStore.getState().clearAllDismissedPrompts()
+      expect(useSprintStore.getState().dismissedPrompts).toEqual({})
+    })
+  })
+
+  describe('per-section sort configuration', () => {
+    it('returns null for an unset section', () => {
+      expect(useSprintStore.getState().getSprintSort('backlog')).toBeNull()
+    })
+
+    it('sets and retrieves a section sort', () => {
+      const sort = { field: 'priority', direction: 'desc' as const }
+      useSprintStore.getState().setSprintSort('s1', sort)
+      expect(useSprintStore.getState().getSprintSort('s1')).toEqual(sort)
+    })
+
+    it('keeps section sorts independent', () => {
+      useSprintStore
+        .getState()
+        .setSprintSort('s1', { field: 'priority', direction: 'asc' as const })
+      expect(useSprintStore.getState().getSprintSort('s2')).toBeNull()
+    })
+
+    it('allows resetting a section sort to null', () => {
+      useSprintStore
+        .getState()
+        .setSprintSort('s1', { field: 'priority', direction: 'asc' as const })
+      useSprintStore.getState().setSprintSort('s1', null)
+      expect(useSprintStore.getState().getSprintSort('s1')).toBeNull()
+    })
+
+    it('clears all section sorts', () => {
+      useSprintStore
+        .getState()
+        .setSprintSort('s1', { field: 'priority', direction: 'asc' as const })
+      useSprintStore.getState().setSprintSort('s2', { field: 'type', direction: 'desc' as const })
+      useSprintStore.getState().clearAllSprintSorts()
+      expect(useSprintStore.getState().sprintSorts).toEqual({})
+    })
+  })
+
+  describe('planning view', () => {
+    it('toggles the planning view open state', () => {
+      expect(useSprintStore.getState().planningViewOpen).toBe(false)
+      useSprintStore.getState().setPlanningViewOpen(true)
+      expect(useSprintStore.getState().planningViewOpen).toBe(true)
+      useSprintStore.getState().setPlanningViewOpen(false)
+      expect(useSprintStore.getState().planningViewOpen).toBe(false)
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,9 +66,9 @@ export default defineConfig({
       // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
         lines: 49,
-        functions: 43,
-        branches: 39,
-        statements: 48,
+        functions: 44,
+        branches: 40,
+        statements: 49,
       },
     },
   },


### PR DESCRIPTION
## Summary
Slice 3 of the coverage backfill (follows #587) — the under-covered zustand stores.

| Store | Before | After | Added |
|-------|--------|-------|-------|
| selection-store | 23% | high | `setTicketOrigin`/`getTicketOrigin`, `copySelected`/`getCopiedIds`/`clearClipboard`, the `selectRange` "id not in list" edge branch (extends the existing test) |
| sprint-store | 62% (no dedicated test) | ~77% | dismissed-prompt semantics, per-section sort config, planning-view toggle |
| board-store | 54% | 70% | `syncTicketsFromAPI` (grouping, order sort, default-column fallback, emptying stale columns), column collapse, column sorts, hydration flag, `getSearchQuery` |

A nice catch while writing the sprint tests: the dismissed-prompt logic is **"later" keeps the prompt eligible to reappear, only "extend" suppresses it** (`action !== 'extend'`). My first draft asserted the opposite — the tests now document the real remind-me-later semantics.

## Ratchet bump
- statements 48→49, functions 43→44, branches 39→40 (lines stays 49)

Overall coverage: **lines 49.78%, branches 40.39%.**

## Remaining slice
- hooks/queries (7.7%) — the last and largest; React Query hooks need `renderHook` + a `QueryClient` wrapper, so it's the most infra-heavy. Saved for last deliberately.

## Test plan
- [x] `pnpm test:ci` — 1699/1699 pass, coverage clears the raised floor, exit 0
- [x] `biome check` clean on new/changed files
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)