### PR TITLE
test(queries): cover sprint + role hooks (slice 4c)

### DIFF
--- a/src/hooks/queries/__tests__/use-roles.test.tsx
+++ b/src/hooks/queries/__tests__/use-roles.test.tsx
@@ -1,0 +1,174 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { demoStorage, isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
+import {
+  useCreateRole,
+  useDeleteRole,
+  useProjectRoles,
+  useReorderRoles,
+  useResetRolesToDefaults,
+  useRole,
+  useRoleDefaults,
+  useUpdateRole,
+} from '../use-roles'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+vi.mock('@/hooks/use-realtime', () => ({ getTabId: vi.fn(() => 'tab-1') }))
+vi.mock('@/lib/toast', () => ({ showToast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/demo', () => ({
+  isDemoMode: vi.fn(() => false),
+  demoStorage: { getRoles: vi.fn(() => []) },
+}))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+const P = 'p1'
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+function fail(message: string, status = 400) {
+  return new Response(JSON.stringify({ error: message }), { status })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsDemoMode.mockReturnValue(false)
+  mockApiFetch.mockResolvedValue(ok([]))
+})
+
+describe('useProjectRoles', () => {
+  it('fetches roles via the API', async () => {
+    mockApiFetch.mockResolvedValue(ok([{ id: 'r1', name: 'Owner' }]))
+    const { result } = renderHook(() => useProjectRoles(P), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toHaveLength(1)
+  })
+
+  it('returns demo roles with full permissions in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    vi.mocked(demoStorage.getRoles).mockReturnValue([{ id: 'r1', name: 'Owner' }] as never)
+    const { result } = renderHook(() => useProjectRoles(P), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.[0].permissions.length).toBeGreaterThan(0)
+  })
+
+  it('is disabled without a projectId', () => {
+    const { result } = renderHook(() => useProjectRoles(''), { wrapper })
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('surfaces a server error', async () => {
+    mockApiFetch.mockResolvedValue(fail('forbidden', 403))
+    const { result } = renderHook(() => useProjectRoles(P), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe('forbidden')
+  })
+})
+
+describe('useRole / useRoleDefaults', () => {
+  it('useRole fetches a single role', async () => {
+    mockApiFetch.mockResolvedValue(ok({ id: 'r1' }))
+    const { result } = renderHook(() => useRole(P, 'r1'), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toMatchObject({ id: 'r1' })
+  })
+
+  it('useRoleDefaults fetches in production and is disabled in demo mode', async () => {
+    mockApiFetch.mockResolvedValue(ok({ defaults: true }))
+    const { result } = renderHook(() => useRoleDefaults(P), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    mockIsDemoMode.mockReturnValue(true)
+    const { result: demo } = renderHook(() => useRoleDefaults(P), { wrapper })
+    expect(demo.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('role mutations (production)', () => {
+  it('useCreateRole POSTs and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({ id: 'r2' }))
+    const { result } = renderHook(() => useCreateRole(P), { wrapper })
+    result.current.mutate({ name: 'New', color: '#fff', permissions: [] })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      `/api/projects/${P}/roles`,
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(showToast.success).toHaveBeenCalledWith('Role created')
+  })
+
+  it('useUpdateRole PATCHes and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({ id: 'r1' }))
+    const { result } = renderHook(() => useUpdateRole(P), { wrapper })
+    result.current.mutate({ roleId: 'r1', name: 'Renamed' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Role updated')
+  })
+
+  it('useDeleteRole DELETEs and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({}))
+    const { result } = renderHook(() => useDeleteRole(P), { wrapper })
+    result.current.mutate('r1')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Role deleted')
+  })
+
+  it('useResetRolesToDefaults POSTs and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok([{ id: 'r1' }]))
+    const { result } = renderHook(() => useResetRolesToDefaults(P), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Roles reset to system defaults')
+  })
+
+  it('useCreateRole toasts on error', async () => {
+    mockApiFetch.mockResolvedValue(fail('dup name'))
+    const { result } = renderHook(() => useCreateRole(P), { wrapper })
+    result.current.mutate({ name: 'New', color: '#fff', permissions: [] })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('dup name')
+  })
+
+  it('useReorderRoles POSTs the new order', async () => {
+    mockApiFetch.mockResolvedValue(ok([{ id: 'r2' }, { id: 'r1' }]))
+    const { result } = renderHook(() => useReorderRoles(P), { wrapper })
+    result.current.mutate(['r2', 'r1'])
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      `/api/projects/${P}/roles/reorder`,
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+})
+
+describe('role mutations (demo mode operate on the query cache)', () => {
+  beforeEach(() => mockIsDemoMode.mockReturnValue(true))
+
+  it('useCreateRole adds the role without hitting the API', async () => {
+    const { result } = renderHook(() => useCreateRole(P), { wrapper })
+    result.current.mutate({ name: 'Demo Role', color: '#fff', permissions: [] })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiFetch).not.toHaveBeenCalled()
+    expect(showToast.success).toHaveBeenCalledWith('Role created')
+  })
+
+  it('useDeleteRole removes from the cache without hitting the API', async () => {
+    const { result } = renderHook(() => useDeleteRole(P), { wrapper })
+    result.current.mutate('r1')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiFetch).not.toHaveBeenCalled()
+    expect(showToast.success).toHaveBeenCalledWith('Role deleted')
+  })
+})

--- a/src/hooks/queries/__tests__/use-sprints.test.tsx
+++ b/src/hooks/queries/__tests__/use-sprints.test.tsx
@@ -1,0 +1,206 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDataProvider } from '@/lib/data-provider'
+import { showToast } from '@/lib/toast'
+import {
+  useActiveSprint,
+  useCompleteSprint,
+  useCreateSprint,
+  useDeleteSprint,
+  useExtendSprint,
+  useProjectSprints,
+  useReopenSprint,
+  useSprintDetail,
+  useSprintSettings,
+  useStartSprint,
+  useUpdateSprint,
+  useUpdateSprintSettings,
+  useUpdateTicketSprint,
+} from '../use-sprints'
+
+vi.mock('@/lib/data-provider', () => ({ getDataProvider: vi.fn() }))
+vi.mock('@/hooks/use-realtime', () => ({ getTabId: vi.fn(() => 'tab-1') }))
+vi.mock('@/lib/toast', () => ({ showToast: { success: vi.fn(), error: vi.fn() } }))
+
+const mockGetDataProvider = vi.mocked(getDataProvider)
+const P = 'p1'
+let provider: Record<string, ReturnType<typeof vi.fn>>
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  provider = {
+    getSprints: vi.fn().mockResolvedValue([]),
+    getActiveSprint: vi.fn().mockResolvedValue(null),
+    getSprintSettings: vi.fn().mockResolvedValue({ defaultSprintDuration: 14 }),
+    createSprint: vi.fn().mockResolvedValue({ id: 's1' }),
+    updateSprint: vi.fn().mockResolvedValue({ id: 's1' }),
+    deleteSprint: vi.fn().mockResolvedValue(undefined),
+    startSprint: vi.fn().mockResolvedValue({ id: 's1' }),
+    completeSprint: vi.fn(),
+    reopenSprint: vi.fn().mockResolvedValue({ id: 's1' }),
+    extendSprint: vi.fn(),
+    updateTicket: vi.fn().mockResolvedValue({ id: 't1' }),
+    updateSprintSettings: vi.fn().mockResolvedValue({ defaultSprintDuration: 7 }),
+  }
+  mockGetDataProvider.mockReturnValue(provider as never)
+})
+
+describe('sprint queries', () => {
+  it('useProjectSprints fetches and is disabled without a projectId', async () => {
+    provider.getSprints.mockResolvedValue([{ id: 's1' }])
+    const { result } = renderHook(() => useProjectSprints(P), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toHaveLength(1)
+
+    const { result: idle } = renderHook(() => useProjectSprints(''), { wrapper })
+    expect(idle.current.fetchStatus).toBe('idle')
+  })
+
+  it('useActiveSprint fetches the active sprint', async () => {
+    provider.getActiveSprint.mockResolvedValue({ id: 's1' })
+    const { result } = renderHook(() => useActiveSprint(P), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toMatchObject({ id: 's1' })
+  })
+
+  it('useSprintDetail finds the sprint or throws not-found', async () => {
+    provider.getSprints.mockResolvedValue([{ id: 's1', name: 'S' }])
+    const { result } = renderHook(() => useSprintDetail(P, 's1'), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toMatchObject({ id: 's1' })
+
+    const { result: missing } = renderHook(() => useSprintDetail(P, 'nope'), { wrapper })
+    await waitFor(() => expect(missing.current.isError).toBe(true))
+    expect(missing.current.error?.message).toBe('Sprint not found')
+  })
+
+  it('useSprintSettings fetches settings', async () => {
+    const { result } = renderHook(() => useSprintSettings(P), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toMatchObject({ defaultSprintDuration: 14 })
+  })
+})
+
+describe('sprint mutations', () => {
+  it('useCreateSprint toasts success and error', async () => {
+    const { result } = renderHook(() => useCreateSprint(P), { wrapper })
+    result.current.mutate({ name: 'S1' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Sprint created')
+
+    provider.createSprint.mockRejectedValue(new Error('dup'))
+    const { result: r2 } = renderHook(() => useCreateSprint(P), { wrapper })
+    r2.current.mutate({ name: 'S1' })
+    await waitFor(() => expect(r2.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('dup')
+  })
+
+  it('useUpdateSprint toasts success', async () => {
+    const { result } = renderHook(() => useUpdateSprint(P), { wrapper })
+    result.current.mutate({ sprintId: 's1', name: 'New' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Sprint updated')
+  })
+
+  it('useDeleteSprint toasts success', async () => {
+    const { result } = renderHook(() => useDeleteSprint(P), { wrapper })
+    result.current.mutate('s1')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Sprint deleted')
+  })
+
+  it('useStartSprint toasts success', async () => {
+    const { result } = renderHook(() => useStartSprint(P), { wrapper })
+    result.current.mutate({ sprintId: 's1' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Sprint started')
+  })
+
+  it('useReopenSprint toasts success', async () => {
+    const { result } = renderHook(() => useReopenSprint(P), { wrapper })
+    result.current.mutate('s1')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Sprint reopened')
+  })
+
+  it('useUpdateTicketSprint calls updateTicket without a toast', async () => {
+    const { result } = renderHook(() => useUpdateTicketSprint(P), { wrapper })
+    result.current.mutate({ ticketId: 't1', sprintId: 's2', order: 3 })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(provider.updateTicket).toHaveBeenCalledWith(P, 't1', { sprintId: 's2', order: 3 })
+    expect(showToast.success).not.toHaveBeenCalled()
+  })
+
+  it('useUpdateSprintSettings toasts success', async () => {
+    const { result } = renderHook(() => useUpdateSprintSettings(P), { wrapper })
+    result.current.mutate({ defaultSprintDuration: 7 })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Sprint settings updated')
+  })
+})
+
+describe('useCompleteSprint message building', () => {
+  it('builds a summary from the ticket disposition', async () => {
+    provider.completeSprint.mockResolvedValue({
+      id: 's1',
+      ticketDisposition: {
+        carriedOver: ['a', 'b'],
+        movedToBacklog: ['c'],
+        completed: ['d', 'e', 'f'],
+      },
+    })
+    const { result } = renderHook(() => useCompleteSprint(P), { wrapper })
+    result.current.mutate({ sprintId: 's1', options: { action: 'close_to_next' } as never })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith(
+      'Sprint completed! 2 tickets carried over. 1 ticket moved to backlog. 3 completed.',
+    )
+  })
+
+  it('toasts on error', async () => {
+    provider.completeSprint.mockRejectedValue(new Error('still active'))
+    const { result } = renderHook(() => useCompleteSprint(P), { wrapper })
+    result.current.mutate({ sprintId: 's1', options: { action: 'close_keep' } as never })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('still active')
+  })
+})
+
+describe('useExtendSprint end-date calculation', () => {
+  it('uses the provided newEndDate directly', async () => {
+    provider.extendSprint.mockResolvedValue({ id: 's1', endDate: new Date('2024-06-01') })
+    const newEndDate = new Date('2024-06-01')
+    const { result } = renderHook(() => useExtendSprint(P), { wrapper })
+    result.current.mutate({ sprintId: 's1', days: 7, newEndDate })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(provider.extendSprint).toHaveBeenCalledWith(P, 's1', { newEndDate })
+  })
+
+  it('calculates the new end date from the current sprint when not provided', async () => {
+    provider.getSprints.mockResolvedValue([{ id: 's1', endDate: new Date('2024-01-01') }])
+    provider.extendSprint.mockResolvedValue({ id: 's1', endDate: new Date('2024-01-08') })
+    const { result } = renderHook(() => useExtendSprint(P), { wrapper })
+    result.current.mutate({ sprintId: 's1', days: 7 })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const passed = provider.extendSprint.mock.calls[0][2] as { newEndDate: Date }
+    // 2024-01-01 + 7 days = 2024-01-08
+    expect(passed.newEndDate.toISOString().slice(0, 10)).toBe('2024-01-08')
+  })
+
+  it('throws when the sprint to extend is not found', async () => {
+    provider.getSprints.mockResolvedValue([])
+    const { result } = renderHook(() => useExtendSprint(P), { wrapper })
+    result.current.mutate({ sprintId: 'nope', days: 7 })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('Sprint not found')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,10 +65,10 @@ export default defineConfig({
       // improves — they should only ever go UP, never down.
       // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
-        lines: 54,
-        functions: 50,
-        branches: 42,
-        statements: 53,
+        lines: 56,
+        functions: 53,
+        branches: 44,
+        statements: 55,
       },
     },
   },


### PR DESCRIPTION
## Summary
Third batch of the hooks/queries slice (follows #590).

| Hook file | Tests | Coverage | Focus |
|-----------|-------|----------|-------|
| `use-sprints` | 16 | **96%** | list/active/detail (not-found throw)/settings; create/update/delete/start/reopen + toasts; `useUpdateTicketSprint` (no toast); `useCompleteSprint` disposition-message building; `useExtendSprint` end-date calc (provided vs computed, not-found throw) |
| `use-roles` | 14 | 68% | demo full-permission mapping vs API + error + disabled; `useRole`/`useRoleDefaults` demo-disabled gate; create/update/delete/reset/reorder in production; demo-mode cache mutations skip the API |

`hooks/queries` directory is now ~76% (was 7.7% before slice 4).

## Ratchet bump
- lines 54→56, statements 53→55, functions 50→53, branches 42→44

Overall coverage: **lines 56.55%, branches 44.25%.**

## Remaining (slice 4d — the smaller files)
comments, attachments, repository, system-settings, database-backup, chat-sessions, activity, version, burndown, branding, email-verification.

## Test plan
- [x] `pnpm test:ci` — 1796/1796 pass, coverage clears the raised floor, exit 0
- [x] `biome check` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)