### PR TITLE
test(queries): cover comment/attachment/repo/settings hooks (slice 4d)

### DIFF
--- a/src/hooks/queries/__tests__/use-attachments.test.tsx
+++ b/src/hooks/queries/__tests__/use-attachments.test.tsx
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
+import {
+  useAddAttachments,
+  useRemoveAttachment,
+  useTicketAttachments,
+  useUploadConfig,
+} from '../use-attachments'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+vi.mock('@/hooks/use-realtime', () => ({ getTabId: vi.fn(() => 'tab-1') }))
+vi.mock('@/lib/toast', () => ({ showToast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/demo', () => ({ isDemoMode: vi.fn(() => false) }))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+const P = 'p1'
+const T = 't1'
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+function fail(message: string, status = 400) {
+  return new Response(JSON.stringify({ error: message }), { status })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+const attachment = {
+  filename: 'f.png',
+  originalName: 'f.png',
+  mimeType: 'image/png',
+  size: 10,
+  url: '/u/f',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsDemoMode.mockReturnValue(false)
+  mockApiFetch.mockResolvedValue(ok([]))
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ok({})))
+})
+
+describe('useUploadConfig', () => {
+  it('fetches the upload config', async () => {
+    mockApiFetch.mockResolvedValue(ok({ allowedTypes: ['image/png'] }))
+    const { result } = renderHook(() => useUploadConfig(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.allowedTypes).toContain('image/png')
+  })
+
+  it('errors when the request fails', async () => {
+    mockApiFetch.mockResolvedValue(new Response('x', { status: 500 }))
+    const { result } = renderHook(() => useUploadConfig(), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useTicketAttachments', () => {
+  it('fetches attachments and is disabled without ids', async () => {
+    mockApiFetch.mockResolvedValue(ok([{ id: 'a1' }]))
+    const { result } = renderHook(() => useTicketAttachments(P, T), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toHaveLength(1)
+
+    const { result: idle } = renderHook(() => useTicketAttachments(P, ''), { wrapper })
+    expect(idle.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useAddAttachments', () => {
+  it('POSTs in production', async () => {
+    mockApiFetch.mockResolvedValue(ok([{ id: 'a1' }]))
+    const { result } = renderHook(() => useAddAttachments(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, attachments: [attachment] })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      `/api/projects/${P}/tickets/${T}/attachments`,
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('returns mock attachments in demo mode without hitting the API', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useAddAttachments(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, attachments: [attachment] })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toHaveLength(1)
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('toasts on error', async () => {
+    mockApiFetch.mockResolvedValue(fail('too big'))
+    const { result } = renderHook(() => useAddAttachments(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, attachments: [attachment] })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('too big')
+  })
+})
+
+describe('useRemoveAttachment', () => {
+  it('DELETEs via global fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok({}))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useRemoveAttachment(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, attachmentId: 'a1' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/projects/${P}/tickets/${T}/attachments/a1`,
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+  })
+
+  it('is a no-op in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useRemoveAttachment(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, attachmentId: 'a1' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('toasts on error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fail('forbidden')))
+    const { result } = renderHook(() => useRemoveAttachment(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, attachmentId: 'a1' })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('forbidden')
+  })
+})

--- a/src/hooks/queries/__tests__/use-comments.test.tsx
+++ b/src/hooks/queries/__tests__/use-comments.test.tsx
@@ -1,0 +1,172 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { demoStorage, isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
+import {
+  useAddComment,
+  useDeleteComment,
+  useTicketComments,
+  useUpdateComment,
+} from '../use-comments'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+vi.mock('@/hooks/use-realtime', () => ({ getTabId: vi.fn(() => 'tab-1') }))
+vi.mock('@/lib/toast', () => ({ showToast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/demo', () => ({
+  isDemoMode: vi.fn(() => false),
+  demoStorage: {
+    getComments: vi.fn(() => []),
+    createComment: vi.fn(),
+    updateComment: vi.fn(),
+    deleteComment: vi.fn(),
+  },
+}))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+const P = 'p1'
+const T = 't1'
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+function fail(message: string, status = 400) {
+  return new Response(JSON.stringify({ error: message }), { status })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsDemoMode.mockReturnValue(false)
+  mockApiFetch.mockResolvedValue(ok([]))
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ok({})))
+})
+
+describe('useTicketComments', () => {
+  it('fetches comments via the API', async () => {
+    mockApiFetch.mockResolvedValue(ok([{ id: 'c1', content: 'hi' }]))
+    const { result } = renderHook(() => useTicketComments(P, T), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toHaveLength(1)
+  })
+
+  it('maps demo comments to ISO strings', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    vi.mocked(demoStorage.getComments).mockReturnValue([
+      {
+        id: 'c1',
+        content: 'hi',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ] as never)
+    const { result } = renderHook(() => useTicketComments(P, T), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(typeof result.current.data?.[0].createdAt).toBe('string')
+  })
+
+  it('is disabled without ids', () => {
+    const { result } = renderHook(() => useTicketComments(P, ''), { wrapper })
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useAddComment', () => {
+  it('POSTs and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({ id: 'c1', content: 'hi' }))
+    const { result } = renderHook(() => useAddComment(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, ticketKey: 'PUNT-1', content: 'hi' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Comment added to PUNT-1')
+  })
+
+  it('creates via demoStorage in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    vi.mocked(demoStorage.createComment).mockReturnValue({
+      id: 'c1',
+      content: 'hi',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never)
+    const { result } = renderHook(() => useAddComment(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, ticketKey: 'PUNT-1', content: 'hi' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(demoStorage.createComment).toHaveBeenCalled()
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('toasts on error', async () => {
+    mockApiFetch.mockResolvedValue(fail('too long'))
+    const { result } = renderHook(() => useAddComment(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, ticketKey: 'PUNT-1', content: 'hi' })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('too long')
+  })
+})
+
+describe('useUpdateComment', () => {
+  it('PATCHes via global fetch and toasts success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok({ id: 'c1', content: 'edited' }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useUpdateComment(), { wrapper })
+    result.current.mutate({
+      projectId: P,
+      ticketId: T,
+      ticketKey: 'PUNT-1',
+      commentId: 'c1',
+      content: 'edited',
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/projects/${P}/tickets/${T}/comments/c1`,
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+    expect(showToast.success).toHaveBeenCalledWith('Comment updated on PUNT-1')
+  })
+
+  it('toasts on error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fail('forbidden')))
+    const { result } = renderHook(() => useUpdateComment(), { wrapper })
+    result.current.mutate({
+      projectId: P,
+      ticketId: T,
+      ticketKey: 'PUNT-1',
+      commentId: 'c1',
+      content: 'edited',
+    })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('forbidden')
+  })
+})
+
+describe('useDeleteComment', () => {
+  it('DELETEs via global fetch and toasts success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok({}))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useDeleteComment(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, ticketKey: 'PUNT-1', commentId: 'c1' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/projects/${P}/tickets/${T}/comments/c1`,
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+    expect(showToast.success).toHaveBeenCalledWith('Comment deleted from PUNT-1')
+  })
+
+  it('deletes via demoStorage in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useDeleteComment(), { wrapper })
+    result.current.mutate({ projectId: P, ticketId: T, ticketKey: 'PUNT-1', commentId: 'c1' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(demoStorage.deleteComment).toHaveBeenCalledWith(P, T, 'c1')
+  })
+})

--- a/src/hooks/queries/__tests__/use-repository.test.tsx
+++ b/src/hooks/queries/__tests__/use-repository.test.tsx
@@ -1,0 +1,143 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { demoStorage, isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
+import {
+  useCommitPatterns,
+  useRepositoryConfig,
+  useUpdateRepository,
+  useWebhookSecret,
+} from '../use-repository'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+vi.mock('@/hooks/use-realtime', () => ({ getTabId: vi.fn(() => 'tab-1') }))
+vi.mock('@/lib/toast', () => ({ showToast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/demo', () => ({
+  isDemoMode: vi.fn(() => false),
+  demoStorage: { getProjects: vi.fn(() => []) },
+}))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+const KEY = 'PUNT'
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+function fail(message: string, status = 400) {
+  return new Response(JSON.stringify({ error: message }), { status })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsDemoMode.mockReturnValue(false)
+  mockApiFetch.mockResolvedValue(ok({ projectKey: KEY }))
+})
+
+describe('useRepositoryConfig', () => {
+  it('fetches config via the API', async () => {
+    mockApiFetch.mockResolvedValue(ok({ projectKey: KEY, repositoryUrl: 'https://x' }))
+    const { result } = renderHook(() => useRepositoryConfig(KEY), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.repositoryUrl).toBe('https://x')
+  })
+
+  it('returns demo defaults in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    vi.mocked(demoStorage.getProjects).mockReturnValue([
+      { id: 'p1', key: KEY, name: 'Punt' },
+    ] as never)
+    const { result } = renderHook(() => useRepositoryConfig(KEY), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toMatchObject({
+      projectKey: KEY,
+      effectiveBranchTemplate: '{type}/{key}-{slug}',
+    })
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a server error', async () => {
+    mockApiFetch.mockResolvedValue(fail('forbidden', 403))
+    const { result } = renderHook(() => useRepositoryConfig(KEY), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe('forbidden')
+  })
+})
+
+describe('useUpdateRepository', () => {
+  it('PATCHes and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({ projectKey: KEY }))
+    const { result } = renderHook(() => useUpdateRepository(KEY), { wrapper })
+    result.current.mutate({ repositoryUrl: 'https://y' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      `/api/projects/${KEY}/repository`,
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+    expect(showToast.success).toHaveBeenCalledWith('Repository settings updated')
+  })
+
+  it('toasts on error', async () => {
+    mockApiFetch.mockResolvedValue(fail('bad url'))
+    const { result } = renderHook(() => useUpdateRepository(KEY), { wrapper })
+    result.current.mutate({ repositoryUrl: 'nope' })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('bad url')
+  })
+
+  it('merges into the cache in demo mode without hitting the API', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useUpdateRepository(KEY), { wrapper })
+    result.current.mutate({ branchTemplate: '{key}' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiFetch).not.toHaveBeenCalled()
+    expect(result.current.data?.effectiveBranchTemplate).toBe('{key}')
+  })
+})
+
+describe('useCommitPatterns', () => {
+  it('PATCHes patterns and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({ projectKey: KEY }))
+    const { result } = renderHook(() => useCommitPatterns(KEY), { wrapper })
+    result.current.mutate([{ id: '1', pattern: 'closes', action: 'close' }])
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Commit patterns updated')
+  })
+})
+
+describe('useWebhookSecret', () => {
+  it('generates a secret and toasts', async () => {
+    mockApiFetch.mockResolvedValue(ok({ projectKey: KEY, hasWebhookSecret: true }))
+    const { result } = renderHook(() => useWebhookSecret(KEY), { wrapper })
+    result.current.mutate('generate')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Webhook secret generated')
+  })
+
+  it('clears a secret and toasts', async () => {
+    mockApiFetch.mockResolvedValue(ok({ projectKey: KEY, hasWebhookSecret: false }))
+    const { result } = renderHook(() => useWebhookSecret(KEY), { wrapper })
+    result.current.mutate('clear')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Webhook secret removed')
+  })
+
+  it('generates a demo secret without hitting the API', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useWebhookSecret(KEY), { wrapper })
+    result.current.mutate('generate')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.webhookSecret).toContain('demo-whsec-')
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/queries/__tests__/use-system-settings.test.tsx
+++ b/src/hooks/queries/__tests__/use-system-settings.test.tsx
@@ -1,0 +1,143 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
+import {
+  useDeleteLogo,
+  useSendTestEmail,
+  useSystemSettings,
+  useUpdateSystemSettings,
+  useUploadLogo,
+} from '../use-system-settings'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/toast', () => ({ showToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }))
+vi.mock('@/lib/demo', () => ({ isDemoMode: vi.fn(() => false) }))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+function fail(message: string, status = 400) {
+  return new Response(JSON.stringify({ error: message }), { status })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsDemoMode.mockReturnValue(false)
+  mockApiFetch.mockResolvedValue(ok({}))
+})
+
+describe('useSystemSettings', () => {
+  it('fetches settings via the API', async () => {
+    mockApiFetch.mockResolvedValue(ok({ id: 's', appName: 'PUNT' }))
+    const { result } = renderHook(() => useSystemSettings(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.appName).toBe('PUNT')
+  })
+
+  it('returns demo settings in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useSystemSettings(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.id).toBe('demo-settings')
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a server error', async () => {
+    mockApiFetch.mockResolvedValue(fail('forbidden', 403))
+    const { result } = renderHook(() => useSystemSettings(), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useUpdateSystemSettings', () => {
+  it('PATCHes and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({ id: 's' }))
+    const { result } = renderHook(() => useUpdateSystemSettings(), { wrapper })
+    result.current.mutate({ appName: 'New' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Settings updated')
+  })
+
+  it('shows a read-only info toast in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useUpdateSystemSettings(), { wrapper })
+    result.current.mutate({ appName: 'New' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.info).toHaveBeenCalledWith('Settings are read-only in demo mode')
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('toasts on error', async () => {
+    mockApiFetch.mockResolvedValue(fail('invalid'))
+    const { result } = renderHook(() => useUpdateSystemSettings(), { wrapper })
+    result.current.mutate({ appName: 'New' })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('invalid')
+  })
+})
+
+describe('logo mutations', () => {
+  it('useUploadLogo POSTs and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({ success: true, logoUrl: '/logo.png' }))
+    const { result } = renderHook(() => useUploadLogo(), { wrapper })
+    result.current.mutate(new File(['x'], 'logo.png', { type: 'image/png' }))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Logo uploaded')
+  })
+
+  it('useUploadLogo shows an info toast in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useUploadLogo(), { wrapper })
+    result.current.mutate(new File(['x'], 'logo.png', { type: 'image/png' }))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.info).toHaveBeenCalledWith('Logo upload is disabled in demo mode')
+  })
+
+  it('useDeleteLogo DELETEs and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({ success: true }))
+    const { result } = renderHook(() => useDeleteLogo(), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Logo removed')
+  })
+})
+
+describe('useSendTestEmail', () => {
+  it('POSTs and toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({ success: true }))
+    const { result } = renderHook(() => useSendTestEmail(), { wrapper })
+    result.current.mutate('test@example.com')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Test email sent successfully')
+  })
+
+  it('shows an info toast in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useSendTestEmail(), { wrapper })
+    result.current.mutate('test@example.com')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.info).toHaveBeenCalledWith('Test email is disabled in demo mode')
+  })
+
+  it('toasts on error', async () => {
+    mockApiFetch.mockResolvedValue(fail('smtp down'))
+    const { result } = renderHook(() => useSendTestEmail(), { wrapper })
+    result.current.mutate('test@example.com')
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('smtp down')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,10 +65,10 @@ export default defineConfig({
       // improves — they should only ever go UP, never down.
       // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
-        lines: 56,
-        functions: 53,
-        branches: 44,
-        statements: 55,
+        lines: 58,
+        functions: 55,
+        branches: 45,
+        statements: 57,
       },
     },
   },


### PR DESCRIPTION
## Summary
Fourth batch of the hooks/queries slice (follows #591) — the mid-size files.

| Hook file | Tests | Focus |
|-----------|-------|-------|
| `use-comments` | 10 | fetch (demo ISO mapping vs API) + disabled; add (demo vs POST + toasts); update/delete via **global fetch** + demo paths |
| `use-attachments` | 9 | upload config; ticket attachments + disabled; add (demo mock vs POST + error); remove via global fetch + demo no-op + error |
| `use-repository` | 10 | config (demo defaults vs API + error); update (PATCH + toast, error, demo cache merge); commit patterns; webhook secret generate/clear/demo |
| `use-system-settings` | 12 | settings (demo defaults vs API + error); update (PATCH + toast, demo read-only info, error); logo upload/delete (+ demo info); send-test-email (+ demo info + error) |

`hooks/queries` directory is now ~84% (was 7.7% before slice 4).

## Ratchet bump
- lines 56→58, statements 55→57, functions 53→55, branches 44→45

Overall coverage: **lines 58.12%, branches 45.37%.**

## Remaining (slice 4e — the last, smallest files)
database-backup, chat-sessions, activity, version, burndown, branding, email-verification.

## Test plan
- [x] `pnpm test:ci` — 1837/1837 pass, coverage clears the raised floor, exit 0
- [x] `biome check` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)