### PR TITLE
test(queries): cover remaining hooks (slice 4e — hooks/queries complete)

### DIFF
--- a/src/hooks/queries/__tests__/use-activity.test.tsx
+++ b/src/hooks/queries/__tests__/use-activity.test.tsx
@@ -1,0 +1,51 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTicketActivity } from '../use-activity'
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('useTicketActivity', () => {
+  it('fetches the first page and exposes the next cursor', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          entries: [{ type: 'comment', id: 'e1' }],
+          nextCursor: 'c2',
+          hasMore: true,
+        }),
+        { status: 200 },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useTicketActivity('p1', 't1'), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.pages[0].entries).toHaveLength(1)
+    expect(result.current.hasNextPage).toBe(true)
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/projects/p1/tickets/t1/activity?')
+  })
+
+  it('is disabled without ids', () => {
+    const { result } = renderHook(() => useTicketActivity('p1', ''), { wrapper })
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('surfaces a fetch error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: 'boom' }), { status: 500 })),
+    )
+    const { result } = renderHook(() => useTicketActivity('p1', 't1'), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe('boom')
+  })
+})

--- a/src/hooks/queries/__tests__/use-branding.test.tsx
+++ b/src/hooks/queries/__tests__/use-branding.test.tsx
@@ -1,0 +1,29 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDataProvider } from '@/lib/data-provider'
+import { useBranding } from '../use-branding'
+
+vi.mock('@/lib/data-provider', () => ({ getDataProvider: vi.fn() }))
+
+const mockGetDataProvider = vi.mocked(getDataProvider)
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('useBranding', () => {
+  it('fetches branding through the data provider', async () => {
+    const getBranding = vi.fn().mockResolvedValue({ appName: 'PUNT' })
+    mockGetDataProvider.mockReturnValue({ getBranding } as never)
+    const { result } = renderHook(() => useBranding(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toMatchObject({ appName: 'PUNT' })
+  })
+})

--- a/src/hooks/queries/__tests__/use-burndown.test.tsx
+++ b/src/hooks/queries/__tests__/use-burndown.test.tsx
@@ -1,0 +1,36 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDataProvider } from '@/lib/data-provider'
+import { useBurndownData } from '../use-burndown'
+
+vi.mock('@/lib/data-provider', () => ({ getDataProvider: vi.fn() }))
+vi.mock('@/hooks/use-realtime', () => ({ getTabId: vi.fn(() => 'tab-1') }))
+
+const mockGetDataProvider = vi.mocked(getDataProvider)
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('useBurndownData', () => {
+  it('fetches burndown data for a sprint', async () => {
+    const getBurndownData = vi.fn().mockResolvedValue({ unit: 'points', dataPoints: [] })
+    mockGetDataProvider.mockReturnValue({ getBurndownData } as never)
+    const { result } = renderHook(() => useBurndownData('p1', 's1', 'points'), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(getBurndownData).toHaveBeenCalledWith('p1', 's1', 'points')
+  })
+
+  it('is disabled without a sprintId', () => {
+    mockGetDataProvider.mockReturnValue({ getBurndownData: vi.fn() } as never)
+    const { result } = renderHook(() => useBurndownData('p1', null), { wrapper })
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})

--- a/src/hooks/queries/__tests__/use-chat-sessions.test.tsx
+++ b/src/hooks/queries/__tests__/use-chat-sessions.test.tsx
@@ -1,0 +1,101 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { showToast } from '@/lib/toast'
+import {
+  useChatSession,
+  useChatSessions,
+  useCreateChatSession,
+  useDeleteChatSession,
+  useRenameChatSession,
+} from '../use-chat-sessions'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/toast', () => ({ showToast: { success: vi.fn(), error: vi.fn() } }))
+
+const mockApiFetch = vi.mocked(apiFetch)
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+function fail(status = 500) {
+  return new Response('x', { status })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockApiFetch.mockResolvedValue(ok([]))
+})
+
+describe('useChatSessions', () => {
+  it('fetches sessions, scoping by project when provided', async () => {
+    mockApiFetch.mockResolvedValue(ok([{ id: 'cs1' }]))
+    const { result } = renderHook(() => useChatSessions('p1'), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/chat/sessions?projectId=p1')
+  })
+
+  it('errors when the request fails', async () => {
+    mockApiFetch.mockResolvedValue(fail())
+    const { result } = renderHook(() => useChatSessions(), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useChatSession', () => {
+  it('is disabled without a sessionId', () => {
+    const { result } = renderHook(() => useChatSession(null), { wrapper })
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('fetches a session by id', async () => {
+    mockApiFetch.mockResolvedValue(ok({ id: 'cs1', messages: [] }))
+    const { result } = renderHook(() => useChatSession('cs1'), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toMatchObject({ id: 'cs1' })
+  })
+})
+
+describe('chat session mutations', () => {
+  it('useCreateChatSession POSTs', async () => {
+    mockApiFetch.mockResolvedValue(ok({ id: 'cs2' }))
+    const { result } = renderHook(() => useCreateChatSession(), { wrapper })
+    result.current.mutate({ name: 'Chat', projectId: 'p1' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/api/chat/sessions',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('useRenameChatSession toasts success and error', async () => {
+    mockApiFetch.mockResolvedValue(ok({ id: 'cs1' }))
+    const { result } = renderHook(() => useRenameChatSession(), { wrapper })
+    result.current.mutate({ sessionId: 'cs1', name: 'Renamed' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Conversation renamed')
+
+    mockApiFetch.mockResolvedValue(fail())
+    const { result: r2 } = renderHook(() => useRenameChatSession(), { wrapper })
+    r2.current.mutate({ sessionId: 'cs1', name: 'Renamed' })
+    await waitFor(() => expect(r2.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('Failed to rename conversation')
+  })
+
+  it('useDeleteChatSession toasts success', async () => {
+    mockApiFetch.mockResolvedValue(ok({}))
+    const { result } = renderHook(() => useDeleteChatSession(), { wrapper })
+    result.current.mutate('cs1')
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith('Conversation deleted')
+  })
+})

--- a/src/hooks/queries/__tests__/use-database-backup.test.tsx
+++ b/src/hooks/queries/__tests__/use-database-backup.test.tsx
@@ -1,0 +1,163 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { isDemoMode } from '@/lib/demo'
+import { showToast } from '@/lib/toast'
+import {
+  checkIfExportEncrypted,
+  fileToBase64,
+  isZipContent,
+  useDatabaseStats,
+  useExportDatabase,
+  useExportEstimate,
+  useImportDatabase,
+  usePreviewDatabase,
+  useWipeDatabase,
+  useWipeProjects,
+} from '../use-database-backup'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn(), withBasePath: (p: string) => p }))
+vi.mock('@/lib/demo', () => ({ isDemoMode: vi.fn(() => false) }))
+vi.mock('@/lib/toast', () => ({ showToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }))
+vi.mock('next-auth/react', () => ({ signOut: vi.fn().mockResolvedValue(undefined) }))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+function fail(message: string, status = 400) {
+  return new Response(JSON.stringify({ error: message }), { status })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsDemoMode.mockReturnValue(false)
+  mockApiFetch.mockResolvedValue(ok({}))
+})
+
+describe('pure helpers', () => {
+  it('checkIfExportEncrypted detects the encrypted flag', () => {
+    expect(checkIfExportEncrypted(JSON.stringify({ encrypted: true }))).toBe(true)
+    expect(checkIfExportEncrypted(JSON.stringify({ encrypted: false }))).toBe(false)
+    expect(checkIfExportEncrypted('not json')).toBe(false)
+  })
+
+  it('isZipContent detects the ZIP magic prefix', () => {
+    expect(isZipContent('UEsDsomethingbase64')).toBe(true)
+    expect(isZipContent('eyJmb28iOiJiYXI')).toBe(false)
+  })
+
+  it('fileToBase64 extracts the base64 payload', async () => {
+    const file = new File(['hello'], 'f.txt', { type: 'text/plain' })
+    const base64 = await fileToBase64(file)
+    expect(atob(base64)).toBe('hello')
+  })
+})
+
+describe('stats / estimate queries', () => {
+  it('useDatabaseStats returns demo stats in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useDatabaseStats(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.projects).toBe(2)
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('useDatabaseStats fetches in production', async () => {
+    mockApiFetch.mockResolvedValue(ok({ projects: 9 }))
+    const { result } = renderHook(() => useDatabaseStats(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.projects).toBe(9)
+  })
+
+  it('useExportEstimate returns demo estimate in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useExportEstimate(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.totals.totalBytes).toBeGreaterThan(0)
+  })
+})
+
+describe('demo-mode info toasts', () => {
+  const reauth = { confirmPassword: 'pw', confirmText: 'WIPE' }
+
+  it('useExportDatabase returns null with an info toast', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useExportDatabase(), { wrapper })
+    result.current.mutate({ confirmPassword: 'pw' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toBeNull()
+    expect(showToast.info).toHaveBeenCalledWith('Database export is disabled in demo mode')
+  })
+
+  it.each([
+    ['usePreviewDatabase', () => usePreviewDatabase(), { content: 'x' }],
+    ['useImportDatabase', () => useImportDatabase(), { content: 'x', ...reauth }],
+    ['useWipeProjects', () => useWipeProjects(), reauth],
+  ])('%s throws a Demo mode error', async (_name, hook, params) => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(hook as never, { wrapper })
+    ;(result.current as { mutate: (p: unknown) => void }).mutate(params)
+    await waitFor(() => expect((result.current as { isError: boolean }).isError).toBe(true))
+    expect(showToast.info).toHaveBeenCalled()
+  })
+})
+
+describe('production mutations', () => {
+  it('useImportDatabase builds a record-count success message', async () => {
+    mockApiFetch.mockResolvedValue(
+      ok({
+        counts: { projects: 2, tickets: 5 },
+        files: { attachmentsRestored: 1, avatarsRestored: 1 },
+      }),
+    )
+    const { result } = renderHook(() => useImportDatabase(), { wrapper })
+    result.current.mutate({ content: 'x', confirmPassword: 'pw', confirmText: 'IMPORT' })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith(
+      'Database imported successfully (7 records, 2 files)',
+    )
+  })
+
+  it('useImportDatabase toasts on a real error', async () => {
+    mockApiFetch.mockResolvedValue(fail('corrupt backup'))
+    const { result } = renderHook(() => useImportDatabase(), { wrapper })
+    result.current.mutate({ content: 'x', confirmPassword: 'pw', confirmText: 'IMPORT' })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('corrupt backup')
+  })
+
+  it('useWipeDatabase toasts success and triggers sign-out', async () => {
+    mockApiFetch.mockResolvedValue(ok({ success: true }))
+    const { result } = renderHook(() => useWipeDatabase(), { wrapper })
+    result.current.mutate({
+      currentPassword: 'pw',
+      username: 'admin',
+      password: 'NewPassw0rd!!',
+      confirmText: 'WIPE',
+    })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(showToast.success).toHaveBeenCalledWith(
+      'Database wiped successfully. Redirecting to login...',
+    )
+  })
+
+  it('useWipeProjects toasts on error', async () => {
+    mockApiFetch.mockResolvedValue(fail('cannot wipe'))
+    const { result } = renderHook(() => useWipeProjects(), { wrapper })
+    result.current.mutate({ confirmPassword: 'pw', confirmText: 'WIPE' })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(showToast.error).toHaveBeenCalledWith('cannot wipe')
+  })
+})

--- a/src/hooks/queries/__tests__/use-email-verification.test.tsx
+++ b/src/hooks/queries/__tests__/use-email-verification.test.tsx
@@ -1,0 +1,35 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { useEmailVerificationStatus } from '../use-email-verification'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+const mockApiFetch = vi.mocked(apiFetch)
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('useEmailVerificationStatus', () => {
+  it('fetches the verification status', async () => {
+    mockApiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ email: 'a@b.com', emailVerified: true }), { status: 200 }),
+    )
+    const { result } = renderHook(() => useEmailVerificationStatus(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.emailVerified).toBe(true)
+  })
+
+  it('throws when the request fails', async () => {
+    mockApiFetch.mockResolvedValue(new Response('x', { status: 500 }))
+    const { result } = renderHook(() => useEmailVerificationStatus(), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})

--- a/src/hooks/queries/__tests__/use-version.test.tsx
+++ b/src/hooks/queries/__tests__/use-version.test.tsx
@@ -1,0 +1,78 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiFetch } from '@/lib/base-path'
+import { isDemoMode } from '@/lib/demo'
+import { useCheckForUpdates, useLastUpdateCheck, useLocalVersion } from '../use-version'
+
+vi.mock('@/lib/base-path', () => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/demo', () => ({ isDemoMode: vi.fn(() => false) }))
+
+const mockApiFetch = vi.mocked(apiFetch)
+const mockIsDemoMode = vi.mocked(isDemoMode)
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsDemoMode.mockReturnValue(false)
+})
+
+describe('useLocalVersion', () => {
+  it('fetches the version in production', async () => {
+    mockApiFetch.mockResolvedValue(ok({ version: '1.2.3' }))
+    const { result } = renderHook(() => useLocalVersion(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.version).toBe('1.2.3')
+  })
+
+  it('returns the demo version in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useLocalVersion(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.version).toBe('0.0.0-demo')
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('errors when the request fails', async () => {
+    mockApiFetch.mockResolvedValue(new Response('x', { status: 500 }))
+    const { result } = renderHook(() => useLocalVersion(), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useCheckForUpdates', () => {
+  it('checks the API and caches the result', async () => {
+    mockApiFetch.mockResolvedValue(ok({ updateAvailable: true }))
+    const { result } = renderHook(() => useCheckForUpdates(), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toMatchObject({ updateAvailable: true })
+  })
+
+  it('returns a disabled result in demo mode without hitting the API', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useCheckForUpdates(), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.error).toContain('disabled in demo mode')
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('useLastUpdateCheck', () => {
+  it('does not auto-fetch (cache-only)', () => {
+    const { result } = renderHook(() => useLastUpdateCheck(), { wrapper })
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
       // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
         lines: 58,
-        functions: 55,
+        functions: 56,
         branches: 45,
         statements: 57,
       },


### PR DESCRIPTION
## Summary
Final batch of the hooks/queries slice (follows #592). **Every query-hook file now has a test** — `hooks/queries` went from 7.7% (before slice 4) to ~83%.

| Hook file | Tests | Focus |
|-----------|-------|-------|
| `use-branding` | 1 | provider fetch |
| `use-burndown` | 2 | provider fetch + disabled |
| `use-email-verification` | 2 | fetch + error |
| `use-activity` | 3 | infinite query — first page + nextCursor, disabled, error |
| `use-version` | 6 | local version (demo vs API + error); check-for-updates (demo-disabled vs API + cache); last-update-check (cache-only) |
| `use-chat-sessions` | 8 | list (project scoping) + error; detail + disabled; create/rename/delete + toasts |
| `use-database-backup` | 14 | pure helpers (`checkIfExportEncrypted`, `isZipContent`, `fileToBase64`); stats/estimate demo vs API; export demo info toast; preview/import/wipe-projects demo "Demo mode" throws; import record-count message; wipe-database success + signOut; errors |

## Ratchet bump
- functions 55→56 (lines 58 / statements 57 / branches 45 unchanged — already at the new actuals)

Overall coverage: **lines 58.66%, branches 45.63%.**

## Slice 4 complete
With this PR, the entire `hooks/queries` directory is covered. That closes out the coverage backfill the ratchet PR (#585) flagged:

| Slice | Area | PRs |
|-------|------|-----|
| 1 | lib/actions 0→85% | #586 |
| 2 | data-provider 0–11→90% | #587 |
| 3 | stores | #588 |
| 4a–4e | hooks/queries 7.7→83% | #589/#590/#591/#592/this |

**Overall journey: lines 42.1% → 58.7%, branches 33.3% → 45.6%**, with the enforced ratchet floor climbing 41→58 (lines) in lockstep.

## Test plan
- [x] `pnpm test:ci` — 1872/1872 pass, coverage clears the raised floor, exit 0
- [x] `biome check` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)