### PR TITLE
test(lib): cover totp, logger, presets, ticket-format (slice 7)

### DIFF
--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { logger } from '../logger'
+
+let debugSpy: ReturnType<typeof vi.spyOn>
+let infoSpy: ReturnType<typeof vi.spyOn>
+let warnSpy: ReturnType<typeof vi.spyOn>
+let errorSpy: ReturnType<typeof vi.spyOn>
+let logSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+  infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+})
+
+describe('logging gates', () => {
+  it('routes each level to the matching console method when enabled', () => {
+    vi.stubEnv('NEXT_PUBLIC_DEBUG', 'true')
+    logger.debug('d')
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e', new Error('boom'))
+    expect(debugSpy).toHaveBeenCalled()
+    expect(infoSpy).toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  it('is silent in production', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('NEXT_PUBLIC_DEBUG', 'true')
+    logger.info('nope')
+    expect(infoSpy).not.toHaveBeenCalled()
+  })
+
+  it('is silent when NEXT_PUBLIC_DEBUG is explicitly false', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('NEXT_PUBLIC_DEBUG', 'false')
+    logger.info('nope')
+    expect(infoSpy).not.toHaveBeenCalled()
+  })
+
+  it('includes the error message in the formatted output', () => {
+    vi.stubEnv('NEXT_PUBLIC_DEBUG', 'true')
+    logger.error('failed', new Error('the cause'))
+    expect(errorSpy.mock.calls[0][0]).toContain('the cause')
+  })
+})
+
+describe('measure helpers', () => {
+  beforeEach(() => vi.stubEnv('NEXT_PUBLIC_DEBUG', 'true'))
+
+  it('measure returns the result and logs a performance line', () => {
+    const result = logger.measure('work', () => 42)
+    expect(result).toBe(42)
+    expect(logSpy).toHaveBeenCalled()
+  })
+
+  it('measure rethrows and still logs', () => {
+    expect(() =>
+      logger.measure('boom', () => {
+        throw new Error('x')
+      }),
+    ).toThrow('x')
+    expect(logSpy).toHaveBeenCalled()
+  })
+
+  it('measureAsync returns the resolved value', async () => {
+    const result = await logger.measureAsync('async', async () => 'ok')
+    expect(result).toBe('ok')
+  })
+
+  it('measureAsync rethrows on rejection', async () => {
+    await expect(
+      logger.measureAsync('async-boom', async () => {
+        throw new Error('y')
+      }),
+    ).rejects.toThrow('y')
+  })
+})

--- a/src/lib/__tests__/ticket-format.test.ts
+++ b/src/lib/__tests__/ticket-format.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createMockTicket } from '@/__tests__/utils/mocks'
+import { useProjectsStore } from '@/stores/projects-store'
+import type { ColumnWithTickets } from '@/types'
+import { formatTicketId, formatTicketIds } from '../ticket-format'
+
+beforeEach(() => {
+  useProjectsStore.setState({
+    projects: [{ id: 'p1', key: 'PUNT', name: 'Punt', color: '#000', role: 'owner' }],
+  })
+})
+
+describe('formatTicketId', () => {
+  it('formats as PROJECTKEY-NUMBER when the project is known', () => {
+    const ticket = createMockTicket({ id: 't1', projectId: 'p1', number: 42 })
+    expect(formatTicketId(ticket)).toBe('PUNT-42')
+  })
+
+  it('falls back to TICKET when the project is unknown', () => {
+    const ticket = createMockTicket({ id: 't1', projectId: 'unknown', number: 7 })
+    expect(formatTicketId(ticket)).toBe('TICKET-7')
+  })
+})
+
+describe('formatTicketIds', () => {
+  it('maps known ids to formatted keys and leaves unknown ids as-is', () => {
+    const t1 = createMockTicket({ id: 't1', projectId: 'p1', number: 1 })
+    const t2 = createMockTicket({ id: 't2', projectId: 'p1', number: 2 })
+    const columns: ColumnWithTickets[] = [
+      { id: 'c1', name: 'To Do', order: 0, projectId: 'p1', tickets: [t1, t2] },
+    ]
+    expect(formatTicketIds(columns, ['t1', 't2', 'missing'])).toEqual([
+      'PUNT-1',
+      'PUNT-2',
+      'missing',
+    ])
+  })
+})

--- a/src/lib/__tests__/totp.test.ts
+++ b/src/lib/__tests__/totp.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  countRemainingRecoveryCodes,
+  decryptTotpSecret,
+  encryptTotpSecret,
+  generateRecoveryCodes,
+  generateTotpKeyUri,
+  generateTotpSecret,
+  hashRecoveryCodes,
+  isTotpReplay,
+  markRecoveryCodeUsed,
+  reencryptTotpSecret,
+  verifyRecoveryCode,
+  verifyTotpToken,
+} from '../totp'
+
+// Deterministic, fast password hashing for the recovery-code tests.
+vi.mock('@/lib/password', () => ({
+  hashPassword: vi.fn(async (s: string) => `hashed:${s}`),
+  verifyPassword: vi.fn(async (plain: string, hash: string) => hash === `hashed:${plain}`),
+}))
+
+beforeEach(() => {
+  vi.stubEnv('AUTH_SECRET', 'test-auth-secret-value')
+})
+afterEach(() => vi.unstubAllEnvs())
+
+describe('TOTP secret encryption', () => {
+  it('round-trips a secret through encrypt/decrypt', () => {
+    const enc = encryptTotpSecret('JBSWY3DPEHPK3PXP')
+    expect(enc.split(':')).toHaveLength(3)
+    expect(decryptTotpSecret(enc)).toBe('JBSWY3DPEHPK3PXP')
+  })
+
+  it('produces a different ciphertext each time (random IV)', () => {
+    expect(encryptTotpSecret('SECRET')).not.toBe(encryptTotpSecret('SECRET'))
+  })
+
+  it('throws without AUTH_SECRET', () => {
+    vi.stubEnv('AUTH_SECRET', '')
+    expect(() => encryptTotpSecret('SECRET')).toThrow(/AUTH_SECRET/)
+  })
+
+  it('rejects a malformed encrypted secret', () => {
+    expect(() => decryptTotpSecret('not-valid')).toThrow(/Invalid encrypted TOTP secret format/)
+  })
+
+  it('reencrypts from an old AUTH_SECRET to the current one', () => {
+    const oldKeyEnc = (() => {
+      vi.stubEnv('AUTH_SECRET', 'old-secret')
+      return encryptTotpSecret('PORTABLE')
+    })()
+    vi.stubEnv('AUTH_SECRET', 'new-secret')
+    const reenc = reencryptTotpSecret(oldKeyEnc, 'old-secret')
+    expect(decryptTotpSecret(reenc)).toBe('PORTABLE')
+  })
+
+  it('reencrypt rejects a malformed secret', () => {
+    expect(() => reencryptTotpSecret('bad', 'old')).toThrow(/Invalid encrypted TOTP secret format/)
+  })
+})
+
+describe('TOTP secret + URI generation', () => {
+  it('generates a non-empty secret', () => {
+    expect(generateTotpSecret().length).toBeGreaterThan(0)
+  })
+
+  it('builds a key URI containing the issuer, label and secret', () => {
+    const uri = generateTotpKeyUri('JBSWY3DPEHPK3PXP', 'alice', 'PUNT')
+    expect(uri).toContain('otpauth://')
+    expect(uri).toContain('PUNT')
+    expect(uri).toContain('alice')
+  })
+
+  it('rejects an obviously-wrong token', () => {
+    expect(verifyTotpToken('000000', generateTotpSecret())).toBe(false)
+  })
+})
+
+describe('isTotpReplay', () => {
+  it('is false when there is no prior use', () => {
+    expect(isTotpReplay(null)).toBe(false)
+    expect(isTotpReplay(undefined)).toBe(false)
+  })
+
+  it('is true within the same 30s window and false outside it', () => {
+    expect(isTotpReplay(new Date())).toBe(true)
+    expect(isTotpReplay(new Date(Date.now() - 60_000))).toBe(false)
+  })
+})
+
+describe('recovery codes', () => {
+  it('generates codes in XXXXX-XXXXX format', () => {
+    const codes = generateRecoveryCodes(3)
+    expect(codes).toHaveLength(3)
+    for (const code of codes) {
+      expect(code).toMatch(/^[0-9A-F]{5}-[0-9A-F]{5}$/)
+    }
+  })
+
+  it('hashes each code', async () => {
+    const hashed = await hashRecoveryCodes(['ABCDE-12345'])
+    expect(hashed).toEqual(['hashed:ABCDE-12345'])
+  })
+
+  it('verifyRecoveryCode returns the matching index, skipping used codes', async () => {
+    const stored = ['', 'hashed:GOOD-CODE0', 'hashed:OTHER-CODE1']
+    expect(await verifyRecoveryCode('GOOD-CODE0', stored)).toBe(1)
+    expect(await verifyRecoveryCode('NOPE', stored)).toBe(-1)
+  })
+
+  it('verifyRecoveryCode coerces a legacy JSON-string array', async () => {
+    const stored = JSON.stringify(['hashed:GOOD-CODE0'])
+    expect(await verifyRecoveryCode('GOOD-CODE0', stored)).toBe(0)
+  })
+
+  it('markRecoveryCodeUsed clears the code at the index', () => {
+    const updated = markRecoveryCodeUsed(['a', 'b', 'c'], 1)
+    expect(updated).toEqual(['a', '', 'c'])
+  })
+
+  it('countRemainingRecoveryCodes counts the unused codes', () => {
+    expect(countRemainingRecoveryCodes(['a', '', 'c'])).toBe(2)
+    expect(countRemainingRecoveryCodes('garbage')).toBe(0)
+  })
+})

--- a/src/lib/permissions/__tests__/presets.test.ts
+++ b/src/lib/permissions/__tests__/presets.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_PERMISSIONS } from '../constants'
+import {
+  DEFAULT_ROLE_NAMES,
+  getDefaultRoleConfigs,
+  getDefaultRolePermissions,
+  isDefaultRoleName,
+  mapLegacyRoleToDefaultName,
+  ROLE_PRESETS,
+} from '../presets'
+
+describe('getDefaultRoleConfigs', () => {
+  it('returns the three default roles with full config', () => {
+    const configs = getDefaultRoleConfigs()
+    expect(configs.map((c) => c.name)).toEqual(['Owner', 'Admin', 'Member'])
+    for (const c of configs) {
+      expect(c.isDefault).toBe(true)
+      expect(typeof c.color).toBe('string')
+      expect(typeof c.position).toBe('number')
+    }
+  })
+
+  it('gives the Owner every permission and the Member only basic ones', () => {
+    const configs = getDefaultRoleConfigs()
+    const owner = configs.find((c) => c.name === 'Owner')!
+    const member = configs.find((c) => c.name === 'Member')!
+    expect(owner.permissions).toEqual([...ALL_PERMISSIONS])
+    expect(member.permissions).toEqual(ROLE_PRESETS[DEFAULT_ROLE_NAMES.MEMBER])
+    expect(member.permissions.length).toBeLessThan(owner.permissions.length)
+  })
+})
+
+describe('getDefaultRolePermissions', () => {
+  it('returns the preset for a known role and [] for an unknown one', () => {
+    expect(getDefaultRolePermissions('Owner')).toEqual(ROLE_PRESETS.Owner)
+    expect(getDefaultRolePermissions('Nonexistent')).toEqual([])
+  })
+})
+
+describe('isDefaultRoleName', () => {
+  it('recognizes default role names only', () => {
+    expect(isDefaultRoleName('Admin')).toBe(true)
+    expect(isDefaultRoleName('Custom')).toBe(false)
+  })
+})
+
+describe('mapLegacyRoleToDefaultName', () => {
+  it('maps legacy role strings (case-insensitive) with a Member fallback', () => {
+    expect(mapLegacyRoleToDefaultName('owner')).toBe('Owner')
+    expect(mapLegacyRoleToDefaultName('ADMIN')).toBe('Admin')
+    expect(mapLegacyRoleToDefaultName('whatever')).toBe('Member')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,10 +65,10 @@ export default defineConfig({
       // improves — they should only ever go UP, never down.
       // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
-        lines: 63,
-        functions: 62,
-        branches: 49,
-        statements: 62,
+        lines: 65,
+        functions: 63,
+        branches: 50,
+        statements: 64,
       },
     },
   },


### PR DESCRIPTION
## Summary
Core lib utilities, several security-relevant.

| File | Tests | Coverage | Focus |
|------|-------|----------|-------|
| `totp` | 17 | **99%** | AES-256-GCM encrypt/decrypt round-trip + random IV + missing-AUTH_SECRET + malformed-format throws; reencrypt across AUTH_SECRETs; secret/URI generation; `isTotpReplay` window logic; recovery codes (format, hashing, verify w/ used-code skipping + legacy JSON-string coercion, mark-used, count-remaining) |
| `logger` | 8 | **97%** | level routing; production + `DEBUG=false` gates; error formatting; `measure`/`measureAsync` return/rethrow/log |
| `permissions/presets` | 5 | — | default role configs; owner-all vs member-basic perms; known/unknown lookups; legacy role mapping |
| `ticket-format` | 3 | **100%** | `PROJECTKEY-N` formatting, `TICKET` fallback, bulk mapping w/ unknown-id passthrough |

`@/lib/password` is mocked in the totp test for fast deterministic hashing; the crypto (AES-GCM, HKDF) runs for real.

## Ratchet bump
- lines 63→65, statements 62→64, functions 62→63, branches 49→50

Overall coverage: **lines 65.18%, branches 50.31%** (up from 63.7% / 49.5%).

## Test plan
- [x] `pnpm test:ci` — 1974/1974 pass, coverage clears the raised floor, exit 0
- [x] `biome check` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)