### PR TITLE
test(lib): cover audit, toast, undo-toast (slice 8)

### DIFF
--- a/src/lib/__tests__/audit.test.ts
+++ b/src/lib/__tests__/audit.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { db } from '@/lib/db'
+import {
+  computeTicketChanges,
+  createActivityGroupId,
+  logBatchChanges,
+  logTicketActivity,
+  logTicketCreated,
+  logTicketDeleted,
+  logTicketFieldChange,
+} from '../audit'
+
+vi.mock('@/lib/db', () => ({
+  db: { ticketActivity: { create: vi.fn(), createMany: vi.fn() } },
+}))
+
+const mockCreate = vi.mocked(db.ticketActivity.create)
+const mockCreateMany = vi.mocked(db.ticketActivity.createMany)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCreate.mockResolvedValue({ id: 'act-1' } as never)
+  mockCreateMany.mockResolvedValue({ count: 0 } as never)
+})
+
+describe('computeTicketChanges', () => {
+  it('detects changed fields and skips unchanged/undefined ones', () => {
+    const changes = computeTicketChanges(
+      { priority: 'low', title: 'A', type: 'task' },
+      { priority: 'high', title: 'A', type: undefined },
+    )
+    expect(changes).toEqual([{ field: 'priority', oldValue: 'low', newValue: 'high' }])
+  })
+
+  it('treats equal dates as unchanged', () => {
+    const d = new Date('2024-01-01')
+    const changes = computeTicketChanges({ dueDate: d }, { dueDate: new Date('2024-01-01') })
+    expect(changes).toEqual([])
+  })
+
+  it('compares objects/arrays structurally', () => {
+    const same = computeTicketChanges({ labels: [{ id: 'l1' }] }, { labels: [{ id: 'l1' }] })
+    expect(same).toEqual([])
+    const diff = computeTicketChanges({ labels: [{ id: 'l1' }] }, { labels: [{ id: 'l2' }] })
+    expect(diff).toHaveLength(1)
+  })
+
+  it('coerces a missing old value to null in the change record', () => {
+    const changes = computeTicketChanges({}, { priority: 'high' })
+    expect(changes).toEqual([{ field: 'priority', oldValue: null, newValue: 'high' }])
+  })
+})
+
+describe('createActivityGroupId', () => {
+  it('returns a grp_-prefixed id', () => {
+    expect(createActivityGroupId()).toMatch(/^grp_/)
+  })
+})
+
+describe('logTicketActivity', () => {
+  it('creates an entry and returns its id', async () => {
+    expect(await logTicketActivity('t1', 'u1', 'created')).toBe('act-1')
+  })
+
+  it('stringifies values and returns null when the DB throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockCreate.mockRejectedValue(new Error('db down'))
+    expect(await logTicketActivity('t1', 'u1', 'updated', { field: 'x', oldValue: 1 })).toBeNull()
+  })
+
+  it('logTicketCreated and logTicketDeleted use the right actions', async () => {
+    await logTicketCreated('t1', 'u1')
+    expect(mockCreate.mock.calls[0][0].data.action).toBe('created')
+    await logTicketDeleted('t1', 'u1')
+    expect(mockCreate.mock.calls[1][0].data.action).toBe('deleted')
+  })
+
+  it('logTicketFieldChange maps the field to an action', async () => {
+    await logTicketFieldChange('t1', 'u1', 'priority', 'low', 'high')
+    expect(mockCreate.mock.calls[0][0].data.action).toBe('priority_changed')
+  })
+})
+
+describe('logBatchChanges', () => {
+  it('returns empty when only internal fields changed', async () => {
+    const result = await logBatchChanges('t1', 'u1', [
+      { field: 'order', oldValue: 0, newValue: 1 },
+      { field: 'updatedAt', oldValue: 'a', newValue: 'b' },
+    ])
+    expect(result).toEqual({ activityIds: [], groupId: null })
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(mockCreateMany).not.toHaveBeenCalled()
+  })
+
+  it('logs a single significant change without a group id', async () => {
+    const result = await logBatchChanges('t1', 'u1', [
+      { field: 'priority', oldValue: 'low', newValue: 'high' },
+      { field: 'order', oldValue: 0, newValue: 1 },
+    ])
+    expect(result).toEqual({ activityIds: ['act-1'], groupId: null })
+    expect(mockCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('createMany with a shared group id for multiple changes', async () => {
+    const result = await logBatchChanges(
+      't1',
+      'u1',
+      [
+        { field: 'priority', oldValue: 'low', newValue: 'high' },
+        { field: 'type', oldValue: 'task', newValue: 'bug' },
+      ],
+      'grp_fixed',
+    )
+    expect(result.groupId).toBe('grp_fixed')
+    expect(mockCreateMany).toHaveBeenCalledTimes(1)
+    const rows = mockCreateMany.mock.calls[0][0].data as Array<{ groupId: string; action: string }>
+    expect(rows.every((r) => r.groupId === 'grp_fixed')).toBe(true)
+  })
+
+  it('returns a null group id when createMany throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockCreateMany.mockRejectedValue(new Error('db down'))
+    const result = await logBatchChanges('t1', 'u1', [
+      { field: 'priority', oldValue: 'low', newValue: 'high' },
+      { field: 'type', oldValue: 'task', newValue: 'bug' },
+    ])
+    expect(result).toEqual({ activityIds: [], groupId: null })
+  })
+})

--- a/src/lib/__tests__/toast.test.ts
+++ b/src/lib/__tests__/toast.test.ts
@@ -1,0 +1,90 @@
+import { toast } from 'sonner'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSettingsStore } from '@/stores/settings-store'
+import { getEffectiveDuration, showToast, TOAST_DURATION } from '../toast'
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(() => 'id-s'),
+    error: vi.fn(() => 'id-e'),
+    info: vi.fn(() => 'id-i'),
+    warning: vi.fn(() => 'id-w'),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}))
+vi.mock('@/stores/settings-store', () => ({ useSettingsStore: { getState: vi.fn() } }))
+
+const mockGetState = vi.mocked(useSettingsStore.getState)
+
+function prefs(overrides: Record<string, unknown> = {}) {
+  return {
+    toastAutoDismiss: true,
+    toastDismissDelay: 4000,
+    errorToastAutoDismiss: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetState.mockReturnValue(prefs() as never)
+})
+
+describe('getEffectiveDuration', () => {
+  it('returns Infinity when auto-dismiss is off', () => {
+    mockGetState.mockReturnValue(prefs({ toastAutoDismiss: false }) as never)
+    expect(getEffectiveDuration(2000)).toBe(TOAST_DURATION.INFINITE)
+  })
+
+  it('uses the error auto-dismiss setting for error toasts', () => {
+    mockGetState.mockReturnValue(prefs({ errorToastAutoDismiss: false }) as never)
+    expect(getEffectiveDuration(2000, true)).toBe(TOAST_DURATION.INFINITE)
+  })
+
+  it('returns the dismiss delay when no duration is requested', () => {
+    expect(getEffectiveDuration(undefined)).toBe(4000)
+  })
+
+  it('treats a requested duration as a minimum (never shortens)', () => {
+    expect(getEffectiveDuration(2000)).toBe(4000) // delay wins
+    expect(getEffectiveDuration(8000)).toBe(8000) // requested wins
+  })
+})
+
+describe('showToast core methods', () => {
+  it('success/error/info/warning delegate to sonner', () => {
+    showToast.success('ok')
+    showToast.error('bad')
+    showToast.info('fyi')
+    showToast.warning('careful')
+    expect(toast.success).toHaveBeenCalledWith('ok', expect.anything())
+    expect(toast.error).toHaveBeenCalledWith('bad', expect.anything())
+    expect(toast.info).toHaveBeenCalledWith('fyi', expect.anything())
+    expect(toast.warning).toHaveBeenCalledWith('careful', expect.anything())
+  })
+
+  it('copied and demoModeNotice produce standardized messages', () => {
+    showToast.copied('API key')
+    expect(toast.success).toHaveBeenCalledWith('API key copied to clipboard', expect.anything())
+    showToast.demoModeNotice('File uploads')
+    expect(toast.info).toHaveBeenCalledWith(
+      'File uploads is disabled in demo mode',
+      expect.anything(),
+    )
+  })
+
+  it('dismiss and dismissAll call sonner dismiss', () => {
+    showToast.dismiss('id-1')
+    expect(toast.dismiss).toHaveBeenCalledWith('id-1')
+    showToast.dismissAll()
+    expect(toast.dismiss).toHaveBeenCalledWith()
+  })
+
+  it('loading wires up a sonner promise toast and returns the promise', async () => {
+    const p = Promise.resolve('done')
+    const returned = showToast.loading(p, { loadingMessage: 'Saving...' })
+    expect(toast.promise).toHaveBeenCalled()
+    await expect(returned).resolves.toBe('done')
+  })
+})

--- a/src/lib/__tests__/undo-toast.test.ts
+++ b/src/lib/__tests__/undo-toast.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getEffectiveDuration, rawToast } from '@/lib/toast'
+import { showUndoRedoToast } from '../undo-toast'
+
+vi.mock('@/lib/toast', () => ({
+  rawToast: { success: vi.fn(() => 'id-s'), error: vi.fn(() => 'id-e') },
+  getEffectiveDuration: vi.fn(() => 5000),
+}))
+
+const mockSuccess = vi.mocked(rawToast.success)
+const mockError = vi.mocked(rawToast.error)
+const mockDuration = vi.mocked(getEffectiveDuration)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockDuration.mockReturnValue(5000)
+})
+
+describe('showUndoRedoToast', () => {
+  it('shows a success toast with the resolved duration', () => {
+    showUndoRedoToast('success', { title: 'Pasted', description: 'PUNT-1' })
+    expect(mockSuccess).toHaveBeenCalledWith(
+      'Pasted',
+      expect.objectContaining({ description: 'PUNT-1', duration: 5000, closeButton: false }),
+    )
+  })
+
+  it('shows an error toast', () => {
+    showUndoRedoToast('error', { title: 'Deleted', description: 'PUNT-2' })
+    expect(mockError).toHaveBeenCalledWith('Deleted', expect.objectContaining({ duration: 5000 }))
+  })
+
+  it('makes an error toast persistent (close button + copy) when the duration is infinite', () => {
+    mockDuration.mockReturnValue(Number.POSITIVE_INFINITY)
+    showUndoRedoToast('error', { title: 'Deleted', description: 'PUNT-3' })
+    const opts = mockError.mock.calls[0][1] as { closeButton: boolean; cancel?: { label: string } }
+    expect(opts.closeButton).toBe(true)
+    expect(opts.cancel?.label).toBe('Copy')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,8 +66,8 @@ export default defineConfig({
       // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
         lines: 65,
-        functions: 63,
-        branches: 50,
+        functions: 64,
+        branches: 51,
         statements: 64,
       },
     },


### PR DESCRIPTION
## Summary
More core lib utilities.

| File | Tests | Coverage | Focus |
|------|-------|----------|-------|
| `audit` | 13 | **87%** | `computeTicketChanges` (changed/unchanged/undefined, date equality, structural object compare, null coercion); `createActivityGroupId`; `logTicketActivity` success + DB-throw→null; created/deleted/field-change action mapping; `logBatchChanges` (internal-field filtering, single-no-group, createMany-with-group, error path) |
| `toast` | 8 | 61% | `getEffectiveDuration` all branches (auto-dismiss off, error setting, default delay, requested-as-minimum); core methods delegate to sonner; copied/demoModeNotice messages; dismiss/dismissAll; loading promise |
| `undo-toast` | 3 | 67% | success/error toasts; persistent error path (close button + copy) when duration is infinite |

`@/lib/db`, `sonner`, and the settings store are mocked.

## Ratchet bump
- functions 63→64, branches 50→51 (lines 65 / statements 64 unchanged)

Overall coverage: **lines 65.89%, branches 51.2%.**

## Test plan
- [x] `pnpm test:ci` — 1998/1998 pass, coverage clears the raised floor, exit 0
- [x] `biome check` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)