### PR TITLE
test(api): cover ticket list/detail routes (slice 11)

### DIFF
--- a/src/app/api/projects/[projectId]/tickets/[ticketId]/__tests__/route.test.ts
+++ b/src/app/api/projects/[projectId]/tickets/[ticketId]/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { requireMembership, requireTicketPermission } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { DELETE, GET } from '../route'
+
+vi.mock('@/lib/auth-helpers', () => ({
+  requireAuth: vi.fn().mockResolvedValue({ id: 'u1' }),
+  requireProjectByKey: vi.fn(async (k: string) => k),
+  requireMembership: vi.fn().mockResolvedValue(undefined),
+  requirePermission: vi.fn().mockResolvedValue(undefined),
+  requireTicketPermission: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('@/lib/db', () => ({
+  db: {
+    ticket: { findFirst: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    ticketLink: { findMany: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}))
+vi.mock('@/lib/events', () => ({ projectEvents: { emitTicketEvent: vi.fn() } }))
+vi.mock('@/lib/audit', () => ({
+  logTicketActivity: vi.fn(),
+  logBatchChanges: vi.fn().mockResolvedValue({ activityIds: [] }),
+  createActivityGroupId: vi.fn(() => 'g1'),
+  computeTicketChanges: vi.fn(() => []),
+}))
+vi.mock('@/lib/prisma-selects', () => ({
+  TICKET_SELECT_FULL: {},
+  transformTicket: (t: unknown) => t,
+}))
+
+const mMembership = vi.mocked(requireMembership)
+const mTicketPerm = vi.mocked(requireTicketPermission)
+const mFindFirst = vi.mocked(db.ticket.findFirst)
+const mLinkFindMany = vi.mocked(db.ticketLink.findMany)
+const mDelete = vi.mocked(db.ticket.delete)
+const params = Promise.resolve({ projectId: 'PUNT', ticketId: 't1' })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mMembership.mockResolvedValue(undefined as never)
+  mTicketPerm.mockResolvedValue(undefined as never)
+  mLinkFindMany.mockResolvedValue([] as never)
+  mDelete.mockResolvedValue({ id: 't1' } as never)
+})
+
+describe('GET /api/projects/[projectId]/tickets/[ticketId]', () => {
+  it('returns the ticket when found', async () => {
+    mFindFirst.mockResolvedValue({ id: 't1', title: 'A' } as never)
+    const res = await GET(new Request('http://localhost/x'), { params })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ id: 't1' })
+  })
+
+  it('returns 404 when the ticket is missing', async () => {
+    mFindFirst.mockResolvedValue(null as never)
+    const res = await GET(new Request('http://localhost/x'), { params })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when membership is forbidden', async () => {
+    mMembership.mockRejectedValue(new Error('Forbidden: nope'))
+    const res = await GET(new Request('http://localhost/x'), { params })
+    expect(res.status).toBe(403)
+  })
+})
+
+function delReq() {
+  return new Request('http://localhost/x', { method: 'DELETE' })
+}
+
+describe('DELETE /api/projects/[projectId]/tickets/[ticketId]', () => {
+  it('returns 404 when the ticket is missing', async () => {
+    mFindFirst.mockResolvedValue(null as never)
+    const res = await DELETE(delReq(), { params })
+    expect(res.status).toBe(404)
+  })
+
+  it('deletes the ticket when found and permitted', async () => {
+    mFindFirst.mockResolvedValue({
+      id: 't1',
+      number: 5,
+      creatorId: 'u1',
+      project: { key: 'PUNT' },
+    } as never)
+    const res = await DELETE(delReq(), { params })
+    expect(res.status).toBe(200)
+    expect(mDelete).toHaveBeenCalledWith({ where: { id: 't1' } })
+  })
+
+  it('returns 403 when the delete permission is denied', async () => {
+    mFindFirst.mockResolvedValue({
+      id: 't1',
+      number: 5,
+      creatorId: 'someone-else',
+      project: { key: 'PUNT' },
+    } as never)
+    mTicketPerm.mockRejectedValue(new Error('Forbidden: cannot delete'))
+    const res = await DELETE(delReq(), { params })
+    expect(res.status).toBe(403)
+    expect(mDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/projects/[projectId]/tickets/__tests__/route.test.ts
+++ b/src/app/api/projects/[projectId]/tickets/__tests__/route.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { requireMembership } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { validateColumnInProject } from '@/lib/ticket-mutations-server'
+import { GET, PATCH } from '../route'
+
+vi.mock('@/lib/auth-helpers', () => ({
+  requireAuth: vi.fn().mockResolvedValue({ id: 'u1' }),
+  requireProjectByKey: vi.fn(async (k: string) => k),
+  requireMembership: vi.fn().mockResolvedValue(undefined),
+  requirePermission: vi.fn().mockResolvedValue(undefined),
+  requireTicketPermission: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('@/lib/db', () => ({
+  db: {
+    ticket: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}))
+vi.mock('@/lib/events', () => ({ projectEvents: { emitTicketEvent: vi.fn() } }))
+vi.mock('@/lib/audit', () => ({
+  logTicketCreated: vi.fn(),
+  logBatchChanges: vi.fn().mockResolvedValue({ activityIds: [] }),
+  createActivityGroupId: vi.fn(() => 'g1'),
+  logTicketActivity: vi.fn(),
+  computeTicketChanges: vi.fn(() => []),
+}))
+vi.mock('@/lib/prisma-selects', () => ({
+  TICKET_SELECT_FULL: {},
+  transformTicket: (t: unknown) => t,
+}))
+vi.mock('@/lib/ticket-mutations-server', () => ({
+  validateColumnInProject: vi.fn(),
+  resolveResolutionColumnCoupling: vi.fn(),
+  validateMemberships: vi.fn(),
+  validateParentForCreate: vi.fn(),
+  validateProjectMembership: vi.fn(),
+  validateSprintNotCompletedUnresolved: vi.fn(),
+}))
+
+const mMembership = vi.mocked(requireMembership)
+const mFindMany = vi.mocked(db.ticket.findMany)
+const mValidateColumn = vi.mocked(validateColumnInProject)
+const params = Promise.resolve({ projectId: 'PUNT' })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mMembership.mockResolvedValue(undefined as never)
+})
+
+describe('GET /api/projects/[projectId]/tickets', () => {
+  it('returns the project tickets', async () => {
+    mFindMany.mockResolvedValue([{ id: 't1' }, { id: 't2' }] as never)
+    const res = await GET(new Request('http://localhost/api/projects/PUNT/tickets'), { params })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toHaveLength(2)
+  })
+
+  it('applies the hasAttachments=true filter', async () => {
+    mFindMany.mockResolvedValue([] as never)
+    await GET(new Request('http://localhost/api/projects/PUNT/tickets?hasAttachments=true'), {
+      params,
+    })
+    expect(mFindMany.mock.calls[0][0].where.attachments).toEqual({ some: {} })
+  })
+
+  it('applies the hasAttachments=false filter', async () => {
+    mFindMany.mockResolvedValue([] as never)
+    await GET(new Request('http://localhost/api/projects/PUNT/tickets?hasAttachments=false'), {
+      params,
+    })
+    expect(mFindMany.mock.calls[0][0].where.attachments).toEqual({ none: {} })
+  })
+
+  it('returns 403 when membership is forbidden', async () => {
+    mMembership.mockRejectedValue(new Error('Forbidden: not a member'))
+    const res = await GET(new Request('http://localhost/api/projects/PUNT/tickets'), { params })
+    expect(res.status).toBe(403)
+  })
+})
+
+function patchReq(body: unknown) {
+  return new Request('http://localhost/api/projects/PUNT/tickets', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('PATCH /api/projects/[projectId]/tickets (batch move)', () => {
+  it('rejects an invalid body', async () => {
+    const res = await PATCH(patchReq({ nonsense: true }), { params })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects when the target column is not in the project', async () => {
+    mValidateColumn.mockResolvedValue(null as never)
+    const res = await PATCH(patchReq({ ticketIds: ['t1'], toColumnId: 'c2', newOrder: 0 }), {
+      params,
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toContain('Target column not found')
+  })
+
+  it('rejects when some tickets do not belong to the project', async () => {
+    mValidateColumn.mockResolvedValue({ id: 'c2', name: 'Done' } as never)
+    mFindMany.mockResolvedValue([] as never) // fewer than requested
+    const res = await PATCH(patchReq({ ticketIds: ['t1', 't2'], toColumnId: 'c2', newOrder: 0 }), {
+      params,
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toContain('not found or do not belong')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,10 +65,10 @@ export default defineConfig({
       // improves — they should only ever go UP, never down.
       // Aspirational target remains 80% global / 90% for stores/API/utils.
       thresholds: {
-        lines: 66,
-        functions: 64,
-        branches: 51,
-        statements: 65,
+        lines: 67,
+        functions: 65,
+        branches: 52,
+        statements: 66,
       },
     },
   },


### PR DESCRIPTION
## Summary
The two highest-traffic ticket endpoints, focused on the **security guard paths** (auth, IDOR, validation).

| Route | Before → After | Tests |
|-------|----------------|-------|
| `tickets/route.ts` | 35% → **51%** | 7 — GET list; hasAttachments true/false filters; 403 forbidden membership; PATCH batch-move guards (invalid body 400, target-column-not-in-project 400, ticket count-mismatch 400) |
| `tickets/[ticketId]/route.ts` | 40% → **56%** | 6 — GET found/404/403; DELETE 404-missing, success-when-permitted, 403 when ticket-delete permission denied |

The full mutation *success* paths (POST create, PATCH update bodies, DELETE blocker-unblocking) remain uncovered — the high-value guard logic (who's allowed, what's valid) is now tested. Same reusable mock pattern as the project route (#599), minus `importOriginal` (which pulls next-auth → `next/server` and fails in the test env).

## Ratchet bump
All four crossed integer boundaries: lines 66→67, statements 65→66, functions 64→65, branches 51→52.

Overall coverage: **lines 67.15%, branches 52.15%.**

## Test plan
- [x] `pnpm test:ci` — 2051/2051 pass, coverage clears the raised floor, exit 0
- [x] `biome check` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)